### PR TITLE
Add Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ python app_manager.py install VisionVault
 ```
 
 The install command clones the app repository into `temp/`, builds a Docker image and runs it. The container is exposed on the port defined in the manifest.
+
+## Web Interface
+
+A simple Flask web server is provided for browsing and installing apps.
+
+Start the server:
+
+```bash
+python webserver.py
+```
+
+By default the server runs on port 5000. Open `http://localhost:5000` in your
+browser to view the app list and install apps.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML
+Flask

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VisionSuit Appstore</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css">
+</head>
+<body>
+<div class="container py-5">
+    <h1 class="mb-4">VisionSuit Apps</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="mb-3">
+        {% for category, msg in messages %}
+        <div class="alert alert-{{ category }}" role="alert">{{ msg }}</div>
+        {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+    <div class="row">
+        {% for app in apps %}
+        <div class="col-md-4 mb-4">
+            <div class="card h-100 bg-secondary text-light">
+                <div class="card-body">
+                    <h5 class="card-title">{{ app.name }}</h5>
+                    <p class="card-text">{{ app.description }}</p>
+                    <a href="{{ url_for('install', name=app.name) }}" class="btn btn-primary">Install</a>
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/webserver.py
+++ b/webserver.py
@@ -1,0 +1,37 @@
+# Web server for VisionSuit listing available applications
+
+from flask import Flask, render_template, redirect, url_for, flash
+import app_manager
+from pathlib import Path
+import yaml
+
+app = Flask(__name__)
+app.secret_key = 'visionsuit'
+
+MANIFEST_DIR = Path('manifests')
+
+def load_manifests():
+    apps = []
+    for manifest in MANIFEST_DIR.glob('*.yaml'):
+        with manifest.open() as f:
+            data = yaml.safe_load(f)
+        data.setdefault('name', manifest.stem)
+        apps.append(data)
+    return apps
+
+@app.route('/')
+def index():
+    apps = load_manifests()
+    return render_template('index.html', apps=apps)
+
+@app.route('/install/<name>')
+def install(name):
+    try:
+        app_manager.install_app(name)
+        flash(f'Installed {name}', 'success')
+    except Exception as e:
+        flash(f'Error installing {name}: {e}', 'danger')
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- create a `webserver.py` Flask app for browsing and installing VisionSuit apps
- include dark Bootstrap template `templates/index.html`
- document the web interface in README
- add Flask to requirements

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6868eb50c50c8333a6d86497b5dbd5a3