### PR TITLE
Add new Vision app manifests and fix Docker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,16 @@ List available apps:
 python app_manager.py list
 ```
 
+The repository ships with manifests for three applications:
+
+- **VisionVault** – lightweight image board for AI-generated artwork.
+- **MyLora** – manage and browse LoRA models.
+- **SDUnity** – Stable Diffusion web UI built with Gradio.
+
 Install an app from its manifest:
 
 ```bash
-python app_manager.py install VisionVault
+python app_manager.py install <AppName>
 ```
 
 The install command clones the app repository into `temp/`, builds a Docker image and runs it. The container is exposed on the port defined in the manifest.

--- a/app_manager.py
+++ b/app_manager.py
@@ -37,8 +37,16 @@ def install_app(name):
 
     if shutil.which('docker'):
         port = str(data.get('default_port', 3000))
-        subprocess.run(['docker', 'build', '-t', name, str(clone_dir)], check=True)
-        subprocess.run(['docker', 'run', '-d', '--name', name, '-p', f'{port}:{port}', name], check=True)
+        docker_tag = name.lower()
+        subprocess.run(['docker', 'build', '-t', docker_tag, str(clone_dir)], check=True)
+        subprocess.run([
+            'docker',
+            'run',
+            '-d',
+            '--name', docker_tag,
+            '-p', f'{port}:{port}',
+            docker_tag,
+        ], check=True)
         print(f"App {name} running at /{name} (port {port})")
     else:
         print('Docker not found. Cannot build or run the app.')

--- a/manifests/MyLora.yaml
+++ b/manifests/MyLora.yaml
@@ -1,0 +1,4 @@
+name: MyLora
+repo: https://github.com/AsaTyr2018/MyLora
+description: Manage and view LoRA models in a modern web interface
+default_port: 5000

--- a/manifests/SDUnity.yaml
+++ b/manifests/SDUnity.yaml
@@ -1,0 +1,4 @@
+name: SDUnity
+repo: https://github.com/AsaTyr2018/SDUnity
+description: Stable Diffusion web UI built with Gradio
+default_port: 7860


### PR DESCRIPTION
## Summary
- add manifests for MyLora and SDUnity
- document available applications in README
- sanitize docker tag and container name by converting to lowercase

## Testing
- `pip install -r requirements.txt`
- `python app_manager.py list`
- `python app_manager.py install VisionVault` *(fails: Docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ec5e854883338f38fbd7e9cf0cd4