### PR TITLE
Fix install for repos without Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install an app from its manifest:
 python app_manager.py install <AppName>
 ```
 
-The install command clones the app repository into `temp/`, builds a Docker image and runs it. The container is exposed on the port defined in the manifest.
+The install command clones the app repository into `temp/`, builds a Docker image and runs it. If no `Dockerfile` is present, VisionSuit looks for a `docker_setup/builder.py` script and runs it to create one automatically. The container is then exposed on the port defined in the manifest.
 
 ## Web Interface
 

--- a/app_manager.py
+++ b/app_manager.py
@@ -38,7 +38,19 @@ def install_app(name):
     if shutil.which('docker'):
         port = str(data.get('default_port', 3000))
         docker_tag = name.lower()
-        subprocess.run(['docker', 'build', '-t', docker_tag, str(clone_dir)], check=True)
+
+        dockerfile = clone_dir / 'Dockerfile'
+        build_dir = clone_dir
+        if not dockerfile.exists():
+            builder = clone_dir / 'docker_setup' / 'builder.py'
+            if builder.exists():
+                subprocess.run(['python', str(builder), repo], check=True)
+                build_dir = clone_dir / 'app'
+            else:
+                print('No Dockerfile or builder script found. Cannot build the app.')
+                return
+
+        subprocess.run(['docker', 'build', '-t', docker_tag, str(build_dir)], check=True)
         subprocess.run([
             'docker',
             'run',


### PR DESCRIPTION
## Summary
- run builder.py if no Dockerfile exists
- mention builder script in README

## Testing
- `python -m py_compile app_manager.py webserver.py`

------
https://chatgpt.com/codex/tasks/task_e_6868edfe4160833392b3685b71337eaa