### PR TITLE
Store installed apps and run builder in clone dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ VisionSuit is a compact installer package for Vision Apps built around Generativ
 ## Directory Layout
 
 - `manifests/` – manifest files describing available apps
-- `temp/` – temporary clone location when installing apps
+- `temp/` – temporary workspace used during installation
+- `storage/` – permanent location where installed app files are kept
 
 ## Usage
 
@@ -33,7 +34,7 @@ Install an app from its manifest:
 python app_manager.py install <AppName>
 ```
 
-The install command clones the app repository into `temp/`, builds a Docker image and runs it. If no `Dockerfile` is present, VisionSuit looks for a `docker_setup/builder.py` script and runs it to create one automatically. The container is then exposed on the port defined in the manifest.
+The install command clones the app repository into `temp/` where the Docker image is built. After the build succeeds, the cloned files are moved to `storage/<AppName>` for persistence. If no `Dockerfile` is present, VisionSuit looks for a `docker_setup/builder.py` script and runs it to create one automatically. The container is then exposed on the port defined in the manifest.
 
 ## Web Interface
 

--- a/app_manager.py
+++ b/app_manager.py
@@ -6,6 +6,7 @@ import yaml
 
 MANIFEST_DIR = Path('manifests')
 TEMP_DIR = Path('temp')
+STORAGE_DIR = Path('storage')
 
 
 def list_apps():
@@ -30,6 +31,8 @@ def install_app(name):
         return
 
     clone_dir = TEMP_DIR / name
+    storage_dir = STORAGE_DIR / name
+
     if clone_dir.exists():
         print(f"{clone_dir} already exists")
     else:
@@ -44,7 +47,7 @@ def install_app(name):
         if not dockerfile.exists():
             builder = clone_dir / 'docker_setup' / 'builder.py'
             if builder.exists():
-                subprocess.run(['python', str(builder), repo], check=True)
+                subprocess.run(['python', str(builder), repo], check=True, cwd=clone_dir)
                 build_dir = clone_dir / 'app'
             else:
                 print('No Dockerfile or builder script found. Cannot build the app.')
@@ -60,6 +63,11 @@ def install_app(name):
             docker_tag,
         ], check=True)
         print(f"App {name} running at /{name} (port {port})")
+        STORAGE_DIR.mkdir(exist_ok=True)
+        if storage_dir.exists():
+            shutil.rmtree(storage_dir)
+        shutil.move(str(clone_dir), storage_dir)
+        print(f"Stored app files in {storage_dir}")
     else:
         print('Docker not found. Cannot build or run the app.')
 


### PR DESCRIPTION
## Summary
- add permanent `storage` directory
- fix builder execution path
- persist installed app files
- document the new storage location

## Testing
- `python -m py_compile app_manager.py webserver.py`


------
https://chatgpt.com/codex/tasks/task_e_6868ef6274548333939b34ba3c75778f