### PR TITLE
Add app management actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The install command clones the app repository into `temp/` where the Docker imag
 
 ## Web Interface
 
-A simple Flask web server is provided for browsing and installing apps.
+A simple Flask web server is provided for browsing and managing apps.
 
 Start the server:
 
@@ -47,4 +47,7 @@ python webserver.py
 ```
 
 By default the server runs on port 5000. Open `http://localhost:5000` in your
-browser to view the app list and install apps.
+browser to view the app list. Each application shows an **Install** button when
+it is not present on the system. Once installed, the Web UI displays **Open**,
+**Update** and **Remove** actions allowing you to access the running app,
+rebuild it from the latest sources or delete it entirely.

--- a/app_manager.py
+++ b/app_manager.py
@@ -9,6 +9,10 @@ MANIFEST_DIR = Path('manifests')
 TEMP_DIR = Path('temp')
 STORAGE_DIR = Path('storage')
 
+def is_installed(name: str) -> bool:
+    """Return True if the app has been installed."""
+    return (STORAGE_DIR / name).exists()
+
 
 def list_apps():
     for manifest in MANIFEST_DIR.glob('*.yaml'):
@@ -74,6 +78,64 @@ def install_app(name):
         print('Docker not found. Cannot build or run the app.')
 
 
+def update_app(name):
+    manifest_path = MANIFEST_DIR / f"{name}.yaml"
+    if not manifest_path.exists():
+        print(f"Manifest for {name} not found")
+        return
+    storage_dir = STORAGE_DIR / name
+    if not storage_dir.exists():
+        print(f"{name} is not installed")
+        return
+    with manifest_path.open() as f:
+        data = yaml.safe_load(f)
+    repo = data.get('repo')
+    port = str(data.get('default_port', 3000))
+    docker_tag = name.lower()
+
+    subprocess.run(['git', '-C', str(storage_dir), 'pull'], check=True)
+
+    if shutil.which('docker'):
+        subprocess.run(['docker', 'rm', '-f', docker_tag], check=False)
+
+        dockerfile = storage_dir / 'Dockerfile'
+        build_dir = storage_dir
+        if not dockerfile.exists() or not os.access(dockerfile, os.R_OK):
+            builder_rel = Path('docker_setup') / 'builder.py'
+            builder = storage_dir / builder_rel
+            if builder.exists() and os.access(builder, os.R_OK):
+                subprocess.run(['python', str(builder_rel), repo], check=True, cwd=storage_dir)
+                build_dir = storage_dir / 'app'
+            else:
+                print('No readable Dockerfile or builder script found. Cannot build the app.')
+                return
+
+        subprocess.run(['docker', 'build', '-t', docker_tag, str(build_dir)], check=True)
+        subprocess.run([
+            'docker',
+            'run',
+            '-d',
+            '--name', docker_tag,
+            '-p', f'{port}:{port}',
+            docker_tag,
+        ], check=True)
+        print(f"Updated {name} running at /{name} (port {port})")
+    else:
+        print('Docker not found. Cannot build or run the app.')
+
+
+def remove_app(name):
+    storage_dir = STORAGE_DIR / name
+    docker_tag = name.lower()
+
+    if shutil.which('docker'):
+        subprocess.run(['docker', 'rm', '-f', docker_tag], check=False)
+
+    if storage_dir.exists():
+        shutil.rmtree(storage_dir)
+        print(f"Removed storage for {name}")
+
+
 def main():
     parser = argparse.ArgumentParser(description='VisionSuit App Manager')
     subparsers = parser.add_subparsers(dest='command')
@@ -83,11 +145,21 @@ def main():
     install_parser = subparsers.add_parser('install', help='Install an app from manifest')
     install_parser.add_argument('name', help='App name as defined in manifest')
 
+    update_parser = subparsers.add_parser('update', help='Update an installed app')
+    update_parser.add_argument('name', help='App name as defined in manifest')
+
+    remove_parser = subparsers.add_parser('remove', help='Remove an installed app')
+    remove_parser.add_argument('name', help='App name as defined in manifest')
+
     args = parser.parse_args()
     if args.command == 'list':
         list_apps()
     elif args.command == 'install':
         install_app(args.name)
+    elif args.command == 'update':
+        update_app(args.name)
+    elif args.command == 'remove':
+        remove_app(args.name)
     else:
         parser.print_help()
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,7 +26,15 @@
                 <div class="card-body">
                     <h5 class="card-title">{{ app.name }}</h5>
                     <p class="card-text">{{ app.description }}</p>
+                    {% if not app.installed %}
                     <a href="{{ url_for('install', name=app.name) }}" class="btn btn-primary">Install</a>
+                    {% else %}
+                    <div class="d-flex gap-2">
+                        <a href="{{ url_for('open_app', name=app.name) }}" class="btn btn-success">Open</a>
+                        <a href="{{ url_for('update', name=app.name) }}" class="btn btn-primary">Update</a>
+                        <a href="{{ url_for('remove', name=app.name) }}" class="btn btn-danger">Remove</a>
+                    </div>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/webserver.py
+++ b/webserver.py
@@ -1,6 +1,6 @@
 # Web server for VisionSuit listing available applications
 
-from flask import Flask, render_template, redirect, url_for, flash
+from flask import Flask, render_template, redirect, url_for, flash, request
 import app_manager
 from pathlib import Path
 import yaml
@@ -16,6 +16,7 @@ def load_manifests():
         with manifest.open() as f:
             data = yaml.safe_load(f)
         data.setdefault('name', manifest.stem)
+        data['installed'] = app_manager.is_installed(data['name'])
         apps.append(data)
     return apps
 
@@ -32,6 +33,37 @@ def install(name):
     except Exception as e:
         flash(f'Error installing {name}: {e}', 'danger')
     return redirect(url_for('index'))
+
+@app.route('/update/<name>')
+def update(name):
+    try:
+        app_manager.update_app(name)
+        flash(f'Updated {name}', 'success')
+    except Exception as e:
+        flash(f'Error updating {name}: {e}', 'danger')
+    return redirect(url_for('index'))
+
+@app.route('/remove/<name>')
+def remove(name):
+    try:
+        app_manager.remove_app(name)
+        flash(f'Removed {name}', 'success')
+    except Exception as e:
+        flash(f'Error removing {name}: {e}', 'danger')
+    return redirect(url_for('index'))
+
+@app.route('/open/<name>')
+def open_app(name):
+    manifest_path = MANIFEST_DIR / f"{name}.yaml"
+    if not manifest_path.exists():
+        flash(f'Manifest for {name} not found', 'danger')
+        return redirect(url_for('index'))
+    with manifest_path.open() as f:
+        data = yaml.safe_load(f)
+    port = data.get('default_port', 3000)
+    host = request.host.split(':')[0]
+    url = f'http://{host}:{port}'
+    return redirect(url)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add `is_installed`, `update_app` and `remove_app` helpers
- expose update/remove/open routes in `webserver.py`
- show management buttons depending on install state in the template
- document web UI actions in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app_manager.py webserver.py`
- `python webserver.py` *(started and terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6868f568eeb483338fd6bdbb41149899