### PR TITLE
Add Bifrost terminology to ingress blueprint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,12 @@ Workflow:
 1. The user starts the app, which launches a WebUI listing all available apps similar to an Appstore.
 2. Additional apps can be included by placing manifest files in the `manifests/` directory.
 3. When an app is selected, the script clones the repo into `temp/`, builds the Docker image, starts it, and configures an ingress so the app is accessible via `{serverip}/{appname}` instead of a port. For example `{serverip}/VisionVault` routes to `{serverip}:3000`.
+
+## Bifrost Ingress Blueprint
+- All app containers join the `asgard` Docker network.
+- **Bifrost** is the only container exposed to the outside world on the `midgard` network.
+- On server start, build or start this controller automatically.
+- App containers keep their internal port as defined in the manifest but are mapped to a random available host port.
+- Record each `{appname}` to host port mapping in a routing table used by Bifrost.
+- Bifrost listens on port `80` and proxies requests from `{serverip}/{appname}` coming from `midgard` to the matching host port in `asgard`.
+- The routing table allows redirecting to namespaces so multiple apps run simultaneously without fixed host ports.


### PR DESCRIPTION
## Summary
- rename the ingress controller to Bifrost
- describe midgard/asgard networks and routing in AGENTS instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868f75858788333a53749965c33113d