### PR TITLE
Add app anchor file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,30 @@ port `80` in the `midgard` network and forwards requests from
 `http://<server>/<AppName>/` to the matching host port. Routes are stored in
 `bifrost_routes.json` and reloaded automatically whenever apps are installed or
 removed.
+
+## Anchor Files
+
+Apps can define custom install steps by placing a `visionsuit-anchor.yaml` (or
+`visionsuit-anchor.json`) file in the root of their repository. VisionSuit reads
+this file when an app is cloned or updated.
+
+Example `visionsuit-anchor.yaml`:
+
+```yaml
+apt_packages:
+  - ffmpeg
+pip_packages:
+  - somepackage>=1.0
+env:
+  SAMPLE_VAR: "value"
+```
+
+Supported keys:
+
+- `apt_packages` – system packages installed via `apt-get` before building the
+  Docker image.
+- `pip_packages` – additional Python packages installed with `pip`.
+- `env` – environment variables passed to the container at runtime.
+
+Include this file in the app repository to have VisionSuit apply these custom
+steps automatically.


### PR DESCRIPTION
## Summary
- introduce `visionsuit-anchor` format for extra packages and env vars
- allow `app_manager` to read the anchor file and apply packages/env
- document anchor usage in README

## Testing
- `python -m py_compile app_manager.py`
- `python -m py_compile webserver.py bifrost.py`

------
https://chatgpt.com/codex/tasks/task_e_6868fc6473848333a01194aec36824eb