### PR TITLE
Add example visionsuit anchor file

### DIFF
--- a/visionsuit-anchor.yaml
+++ b/visionsuit-anchor.yaml
@@ -1,0 +1,21 @@
+# Example VisionSuit anchor file
+# Place this file in the root of your VisionSuit-compatible application
+# to provide extra setup steps during installation.
+
+# apt_packages lists Debian packages installed via apt-get
+# before the Docker image for the app is built.
+apt_packages:
+  - ffmpeg
+  - git
+
+# pip_packages lists Python packages that will be installed with pip
+# before the Docker image is built.
+pip_packages:
+  - somepackage>=1.0
+  - anotherpackage==2.0
+
+# env specifies environment variables to pass to the container
+# when the app is started.
+env:
+  SAMPLE_VAR: "value"
+  DEBUG: "1"


### PR DESCRIPTION
## Summary
- add a sample `visionsuit-anchor.yaml` showing how to list apt and pip packages and env vars

## Testing
- `python -m py_compile app_manager.py bifrost.py webserver.py`


------
https://chatgpt.com/codex/tasks/task_e_6868ff65fdd88333a43fcedca7d28c45