### PR TITLE
Fix anchor package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ env:
 
 Supported keys:
 
-- `apt_packages` – system packages installed via `apt-get` before building the
-  Docker image.
-- `pip_packages` – additional Python packages installed with `pip`.
-- `env` – environment variables passed to the container at runtime.
+ - `apt_packages` – Debian packages installed inside the Docker image during the
+  build.
+ - `pip_packages` – additional Python packages installed inside the image with `pip`.
+ - `env` – environment variables passed to the container at runtime.
 
 Include this file in the app repository to have VisionSuit apply these custom
 steps automatically.

--- a/visionsuit-anchor.yaml
+++ b/visionsuit-anchor.yaml
@@ -2,14 +2,13 @@
 # Place this file in the root of your VisionSuit-compatible application
 # to provide extra setup steps during installation.
 
-# apt_packages lists Debian packages installed via apt-get
-# before the Docker image for the app is built.
+# apt_packages lists Debian packages installed inside the Docker image
+# during the build phase.
 apt_packages:
   - ffmpeg
   - git
 
-# pip_packages lists Python packages that will be installed with pip
-# before the Docker image is built.
+# pip_packages lists Python packages installed inside the image with pip.
 pip_packages:
   - somepackage>=1.0
   - anotherpackage==2.0


### PR DESCRIPTION
## Summary
- inject apt and pip packages into Dockerfile instead of running on the host
- document container-based installation for anchor packages
- clarify anchor example comments

## Testing
- `python -m py_compile app_manager.py bifrost.py webserver.py`

------
https://chatgpt.com/codex/tasks/task_e_686907f906dc8333aae1041a4fcd4d37