### PR TITLE
Add dev starter script for backend and frontend

### DIFF
--- a/ChangeLog/2025-09-18-5957426.md
+++ b/ChangeLog/2025-09-18-5957426.md
@@ -1,0 +1,14 @@
+# Änderungsbericht 2025-09-18 – Commit 5957426
+
+## Überblick
+Der kombinierte Entwicklungsstarter wurde implementiert, damit Backend und Frontend parallel auf `0.0.0.0` laufen können. Die Dokumentation beschreibt den neuen Ablauf und die Dev-Server-Konfiguration wurde auf externe Zugriffe vorbereitet.
+
+## Details
+- Neues Skript `dev-start.sh`, das beide Services mit gemeinsamen Signal-Handling startet und Standard-Ports für externe Erreichbarkeit setzt.
+- Vite-Konfiguration ergänzt um einen robusten Port-Parser sowie `server.host = '0.0.0.0'` für das Frontend.
+- README modernisiert: gemeinsamer Dev-Workflow, Hinweis auf konfigurierbare Ports und präzisierte Einzel-Startbefehle.
+- Backend `package-lock.json` synchronisiert, um die Projektmetadaten (`name`, `version`) mit `package.json` in Einklang zu bringen.
+
+## Tests
+- `npm run lint` im Backend (TypeScript-Typprüfung)
+- `npm run lint` im Frontend (ESLint)

--- a/README.md
+++ b/README.md
@@ -6,30 +6,55 @@ den Upload- und Kuration-Workflow.
 
 ## Architekturüberblick
 
-| Bereich     | Stack & Zweck |
-| ----------- | ------------- |
-| **Backend** | Express 5 (TypeScript) + Prisma + SQLite. Stellt REST-Endpunkte für Assets, Galerien und Systemstatistiken bereit. |
-| **Datenbank** | Prisma-Schema für Benutzer, LoRA-Assets, Galerie-Einträge und Tagging inklusive Referenzen & Constraints. |
-| **Frontend** | Vite + React (TypeScript). Liefert einen ersten UI-Entwurf mit Platzhalterkarten und Statusanzeigen. |
+| Bereich       | Stack & Zweck                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| **Backend**   | Express 5 (TypeScript) + Prisma + SQLite. Stellt REST-Endpunkte für Assets, Galerien und Statistiken bereit. |
+| **Datenbank** | Prisma-Schema für Benutzer, LoRA-Assets, Galerie-Einträge und Tagging inklusive Referenzen & Constraints.    |
+| **Frontend**  | Vite + React (TypeScript). Liefert einen ersten UI-Entwurf mit Platzhalterkarten und Statusanzeigen.         |
 
-## Schnellstart
+## Entwicklung starten
 
-### Backend
-1. `cd backend && npm install`
-2. `cp .env.example .env`
-3. Datenbank anwenden und befüllen:
+### Gemeinsamer Dev-Starter
+
+Der Befehl `./dev-start.sh` startet Backend und Frontend gemeinsam im Watch-Modus und bindet beide Services an `0.0.0.0`.
+So können sie von außen erreicht werden, z. B. in Container- oder Cloud-Umgebungen.
+
+1. Abhängigkeiten installieren:
+   ```bash
+   (cd backend && npm install)
+   (cd frontend && npm install)
+   ```
+2. Starter aufrufen:
+   ```bash
+   ./dev-start.sh
+   ```
+
+Standard-Ports:
+- Backend: `4000` (änderbar über `BACKEND_PORT`)
+- Frontend: `5173` (änderbar über `FRONTEND_PORT`)
+
+> Tipp: Mit `HOST=0.0.0.0 ./dev-start.sh` lässt sich der Host explizit überschreiben, falls erforderlich.
+
+### Einzelne Services
+
+#### Backend
+1. `cd backend`
+2. Prisma-Schema anwenden und Seed laden (optional, für Demodaten):
    ```bash
    npm run prisma:migrate
    npm run seed
    ```
-4. Entwicklungsserver starten: `npm run dev` (Standard: http://localhost:4000)
+3. Entwicklungsserver (ebenfalls auf `0.0.0.0`):
+   ```bash
+   HOST=0.0.0.0 PORT=4000 npm run dev
+   ```
 
-### Frontend
-1. `cd frontend && npm install`
-2. API-Basis anpassen (optional): `cp .env.example .env`
-3. Entwicklungsserver starten: `npm run dev` (Standard: http://localhost:5173)
-
-> **Hinweis:** Das Frontend zeigt Placeholder-Karten. Inhalte stammen aus dem Seed des Backends oder einer laufenden Instanz.
+#### Frontend
+1. `cd frontend`
+2. Entwicklungsserver starten:
+   ```bash
+   npm run dev -- --host 0.0.0.0 --port 5173
+   ```
 
 ## API-Schnittstellen (Auszug)
 - `GET /health` – Health-Check des Servers.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,13 +1,12 @@
 {
-  "name": "backend",
-  "version": "1.0.0",
+  "name": "visionsuit-backend",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "backend",
-      "version": "1.0.0",
-      "license": "ISC",
+      "name": "visionsuit-backend",
+      "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.16.2",
         "cors": "^2.8.5",

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+HOST_ADDRESS="${HOST:-0.0.0.0}"
+BACKEND_PORT="${BACKEND_PORT:-4000}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+
+export HOST="$HOST_ADDRESS"
+
+echo "Starting VisionSuit backend on ${HOST_ADDRESS}:${BACKEND_PORT}" >&2
+(
+  cd "$ROOT_DIR/backend"
+  HOST="$HOST_ADDRESS" PORT="$BACKEND_PORT" npm run dev
+) &
+BACKEND_PID=$!
+
+echo "Starting VisionSuit frontend on ${HOST_ADDRESS}:${FRONTEND_PORT}" >&2
+(
+  cd "$ROOT_DIR/frontend"
+  npm run dev -- --host "$HOST_ADDRESS" --port "$FRONTEND_PORT"
+) &
+FRONTEND_PID=$!
+
+cleanup() {
+  trap - INT TERM EXIT
+  for pid in "$BACKEND_PID" "$FRONTEND_PID"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+  wait "$BACKEND_PID" 2>/dev/null || true
+  wait "$FRONTEND_PID" 2>/dev/null || true
+}
+
+trap cleanup INT TERM EXIT
+
+wait "$BACKEND_PID"
+wait "$FRONTEND_PID"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
+const parsePort = (value?: string) => {
+  if (!value) {
+    return 5173
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  return Number.isNaN(parsed) ? 5173 : parsed
+}
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: parsePort(process.env.FRONTEND_PORT),
+  },
 })


### PR DESCRIPTION
## Summary
- add a Bash helper that boots backend and frontend dev servers bound to 0.0.0.0 by default
- expose host/port configuration in the Vite dev server and refresh the README with the combined workflow
- regenerate the backend lockfile metadata and document the change in the project changelog

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cc2dad4460833392b8e9713d26e2a4