### PR TITLE
Fix Prisma migrate failures by adding bundled SQLite env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ backend/.env
 frontend/.env
 backend/.env.local
 frontend/.env.local
+!backend/prisma/.env
 
 # Prisma
 backend/prisma/dev.db

--- a/ChangeLog/2025-09-18-fa46387.md
+++ b/ChangeLog/2025-09-18-fa46387.md
@@ -1,0 +1,14 @@
+# Änderungsbericht 2025-09-18 – Commit fa46387
+
+## Kontext
+Die lokalen Prisma-Kommandos schlugen fehl, weil `DATABASE_URL` nicht gesetzt war und die CLI auf die veraltete `package.json#prisma`-Konfiguration zurückgriff.
+
+## Änderungen
+- Standardisierte SQLite-URL über `backend/prisma/.env`, sodass Migrations- und Seed-Kommandos ohne weitere Vorbereitung funktionieren.
+- `.gitignore` angepasst, um die neue Datei im Repository zu behalten.
+- README-Backend-Anleitung ergänzt, damit das Setup der Prisma-Umgebung nachvollziehbar bleibt.
+- Veralteten `prisma`-Block aus `backend/package.json` entfernt, womit der Prisma-Warnhinweis entfällt.
+
+## Tests
+- `npx prisma migrate deploy`
+- `npm run seed`

--- a/README.md
+++ b/README.md
@@ -39,12 +39,15 @@ Standard-Ports:
 
 #### Backend
 1. `cd backend`
-2. Prisma-Schema anwenden und Seed laden (optional, für Demodaten):
+2. Prüfe die Prisma-Umgebung:
+   - Die Datei `prisma/.env` enthält standardmäßig `DATABASE_URL="file:./dev.db"` für die SQLite-Dev-Datenbank.
+   - Passe den Pfad bei Bedarf an (z. B. für persistente Volumes) und kopiere die Datei für weitere Umgebungen.
+3. Prisma-Schema anwenden und Seed laden (optional, für Demodaten):
    ```bash
    npm run prisma:migrate
    npm run seed
    ```
-3. Entwicklungsserver (ebenfalls auf `0.0.0.0`):
+4. Entwicklungsserver (ebenfalls auf `0.0.0.0`):
    ```bash
    HOST=0.0.0.0 PORT=4000 npm run dev
    ```

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,9 +13,6 @@
     "prisma:studio": "prisma studio",
     "seed": "ts-node --transpile-only prisma/seed.ts"
   },
-  "prisma": {
-    "seed": "ts-node --transpile-only prisma/seed.ts"
-  },
   "dependencies": {
     "@prisma/client": "^6.16.2",
     "cors": "^2.8.5",

--- a/backend/prisma/.env
+++ b/backend/prisma/.env
@@ -1,0 +1,2 @@
+# SQLite development database for Prisma CLI and seed scripts
+DATABASE_URL="file:./dev.db"


### PR DESCRIPTION
## Summary
- add a tracked prisma/.env with the default SQLite DATABASE_URL so Prisma CLI and seeds run without manual setup
- document the new environment file in the backend section of the README and allow it via .gitignore
- drop the deprecated package.json Prisma configuration and record the change in the changelog

## Testing
- npx prisma migrate deploy
- npm run seed

------
https://chatgpt.com/codex/tasks/task_e_68cc30563edc8333a5ce2d0f7f083bf9