### PR TITLE
Remove Prisma duplicate env file to fix migrate conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ backend/.env
 frontend/.env
 backend/.env.local
 frontend/.env.local
-!backend/prisma/.env
 
 # Prisma
 backend/prisma/dev.db

--- a/ChangeLog/2025-09-18-b29726e.md
+++ b/ChangeLog/2025-09-18-b29726e.md
@@ -1,0 +1,12 @@
+# Änderungsbericht 2025-09-18 – Commit b29726e
+
+## Kontext
+Beim Ausführen von `prisma migrate dev` trat ein Konflikt zwischen zwei `DATABASE_URL`-Definitionen auf (`.env` und `prisma/.env`). Die Prisma-CLI verweigerte daher den Start der Migration.
+
+## Änderungen
+- Entfernte `backend/prisma/.env`, sodass Prisma nur noch die zentral gepflegte `.env` im Backend-Verzeichnis einliest.
+- Bereinigte `.gitignore` und `rollback.sh`, damit keine Referenzen auf die entfernte Datei verbleiben.
+- Aktualisierte die README-Backend-Anleitung mit dem Hinweis auf das neue `.env`-Setup und den Wegfall der separaten Prisma-Umgebung.
+
+## Tests
+- `npm run lint`

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Standard-Ports:
 
 #### Backend
 1. `cd backend`
-2. Prüfe die Prisma-Umgebung:
-   - Die Datei `prisma/.env` enthält standardmäßig `DATABASE_URL="file:./dev.db"` für die SQLite-Dev-Datenbank.
-   - Passe den Pfad bei Bedarf an (z. B. für persistente Volumes) und kopiere die Datei für weitere Umgebungen.
+2. Stelle sicher, dass `./.env` aus der Vorlage erzeugt ist:
+   - `cp .env.example .env` legt eine lokale Entwicklungsdatei mit `DATABASE_URL="file:./dev.db"` an.
+   - Prisma CLI und Server teilen sich damit dieselbe Datenbank-URL; separate `prisma/.env`-Dateien werden nicht mehr benötigt.
 3. Prisma-Schema anwenden und Seed laden (optional, für Demodaten):
    ```bash
    npm run prisma:migrate

--- a/backend/prisma/.env
+++ b/backend/prisma/.env
@@ -1,2 +1,0 @@
-# SQLite development database for Prisma CLI and seed scripts
-DATABASE_URL="file:./dev.db"

--- a/rollback.sh
+++ b/rollback.sh
@@ -119,7 +119,6 @@ remove_path "$BACKEND_DIR/prisma/test.db"
 remove_path "$BACKEND_DIR/.env.local"
 
 reset_from_example "$BACKEND_DIR/.env.example" "$BACKEND_DIR/.env"
-restore_tracked_file "backend/prisma/.env"
 restore_tracked_file "backend/package-lock.json"
 
 log INFO 'Rollback für Frontend starten'


### PR DESCRIPTION
## Summary
- remove the tracked `backend/prisma/.env` so Prisma CLI only reads the consolidated backend `.env`
- clean up `.gitignore` and `rollback.sh`, and refresh the README backend setup instructions accordingly
- document the change in a dated changelog entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc4469fc6c8333bafa72c06ce5c10c