### PR TITLE
Harden rollback cleanup to purge Node toolchains

### DIFF
--- a/ChangeLog/2025-09-18-805a7d9.md
+++ b/ChangeLog/2025-09-18-805a7d9.md
@@ -1,0 +1,13 @@
+# Änderungsbericht 2025-09-18 – Commit 805a7d9
+
+## Zusammenfassung
+- Rollback-Skript erweitert, um neben Projektartefakten auch npm-Caches, globale Prefixes und lokal installierte Node.js-Toolchains sicher zu entfernen.
+- README ergänzt um eine detaillierte Auflistung aller Bereinigungsschritte sowie eine deutliche Warnung vor dem Entfernen von nvm/fnm/asdf/volta Toolchains.
+
+## Technische Details
+- Neue Hilfsfunktionen in `rollback.sh` leeren den `npm`-Cache, räumen globale Prefix-Verzeichnisse im Home-Verzeichnis auf und löschen Versionen aus nvm/fnm/asdf/volta sowie projektlokale Toolchain-Ordner.
+- Die Bereinigung berücksichtigt Dry-Run-Szenarien, schützt das Home-Verzeichnis vor vollständiger Löschung und protokolliert alle Schritte transparent.
+- README beschreibt jetzt Schritt für Schritt, welche Artefakte entfernt werden, inklusive Toolchain-Purge und Cache-Räumung.
+
+## Tests & Prüfung
+- `./rollback.sh --dry-run --yes`

--- a/README.md
+++ b/README.md
@@ -114,7 +114,21 @@ Weitere Schritte umfassen Upload-Flows, Review-Prozesse und erweiterte Filter-/S
 
 Für Test-Szenarien oder wenn ein kompletter Reset der Arbeitskopie benötigt wird, stellt das Repository das Skript
 `./rollback.sh` bereit. Es entfernt installierte Abhängigkeiten, löscht Build-Artefakte, setzt Konfigurationsdateien auf ihre
-Beispielwerte zurück und säubert Cache-Verzeichnisse für Front- und Backend.
+Beispielwerte zurück, säubert Cache-Verzeichnisse für Front- und Backend **und** räumt sämtliche lokal installierten Node.js
+Toolchains samt globalen npm/pnpm/yarn-Artefakten auf.
+
+**Was wird zurückgesetzt?**
+
+- npm-Abhängigkeiten und Build-Ordner in `backend/` und `frontend/`.
+- `.env`-Dateien werden aus den jeweiligen `*.env.example`-Vorlagen wiederhergestellt.
+- Projektweite Cache-Verzeichnisse (`.turbo`, `.cache`, `.eslintcache`, `.vite`, `tsconfig.tsbuildinfo`).
+- npm-Cache (`npm cache clean --force`, falls verfügbar) sowie globale Prefixes im Home-Verzeichnis (z. B. `~/.npm-global`).
+- Lokale Node-Versionen und Toolchains in Home- oder Projektpfaden (u. a. `~/.nvm`, `~/.fnm`, `~/.asdf/installs/nodejs`,
+  `~/.volta`, `./.toolchains`).
+
+> ⚠️ **Achtung**: Der Toolchain-Purge löscht alle lokal via nvm/fnm/asdf/volta installierten Node.js-Versionen sowie globale
+> npm-Installationen im Home-Verzeichnis. Prüfe mit `./rollback.sh --dry-run`, ob weitere Projekte betroffen wären, und sichere
+> ggf. benötigte Toolchains vor dem produktiven Lauf.
 
 ```bash
 # Übersicht der geplanten Schritte ohne Änderungen an der Arbeitskopie


### PR DESCRIPTION
## Summary
- extend `rollback.sh` to clear npm caches, remove global prefixes in the home directory, and delete Node.js toolchains managed by nvm/fnm/asdf/volta
- refresh the rollback section in the README with a detailed list of cleanup steps and a warning about the destructive toolchain purge
- add a changelog entry for commit 805a7d9 describing the rollback hardening

## Testing
- ./rollback.sh --dry-run --yes

------
https://chatgpt.com/codex/tasks/task_e_68cc4d73a4408333967b26d161760af9