### PR TITLE
feat(frontend): add filterable lora and gallery explorers

### DIFF
--- a/ChangeLog/2025-09-18-pending.md
+++ b/ChangeLog/2025-09-18-pending.md
@@ -1,12 +1,26 @@
-# Änderungsprotokoll – 18.09.2025
+# VisionSuit Changelog – 2025-09-18
 
-> Hinweis: Dieser Eintrag dient als Vorlage für die nächste Änderung. Die finale Commit-ID und Inhalte werden beim nächsten Update ergänzt.
+## Überblick
+- Frontend erweitert um datengetriebene Explorer für LoRA-Assets und kuratierte Galerien.
+- Neue Filter- und Sortierleisten, die bei sehr großen Datenmengen (100k+) performant bleiben.
+- UI-Optimierungen für Karten, Vorschauraster und Ladezustände.
+- README um den aktualisierten Frontend-Workflow ergänzt.
 
-## Zusammenfassung
-- Noch offen – wird mit der kommenden Änderung ausgefüllt.
+## Details
+### LoRA-Datenbank
+- Implementiert `AssetExplorer` mit Volltextsuche, Tag-/Typfiltern, Dateigrößen-Buckets, Kurator:innenauswahl und Lazy Loading.
+- Überarbeitet `AssetCard` inklusive Vorschaubild, aktualisiertem Metablock und Anzeige des letzten Update-Datums.
+- Ergänzt wiederverwendbare `FilterChip`-Komponente.
 
-## Technische Details
-- Noch offen – wird mit der kommenden Änderung ausgefüllt.
+### Galerie-Explorer
+- Erstellt `GalleryExplorer` mit Sichtbarkeits-, Inhaltstyp- und Kurator:innenfiltern sowie sortierbaren Ergebnislisten.
+- Aktualisiert `GalleryCard` um Vorschauraster, das erste Einträge (Bilder/LoRAs) anzeigt, plus verbesserte Metadaten.
 
-## Tests & Prüfung
-- Noch offen – wird mit der kommenden Änderung ausgefüllt.
+### Styling & UX
+- Fügt umfangreiche Styles für Filterleisten, Badges und Result-Infos hinzu.
+- Aktualisiert Skeletons und Panel-Footer für konsistente Lade- und „Mehr laden“-Erlebnisse.
+
+### Dokumentation
+- README um Abschnitt „Frontend-Erlebnis" erweitert und Architektur-Tableau angepasst.
+
+_Commit-Referenz: wird nach dem Merge mit der finalen Commit-ID ergänzt._

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ den Upload- und Kuration-Workflow.
 | **Backend**   | Express 5 (TypeScript) + Prisma + SQLite. Stellt REST-Endpunkte für Assets, Galerien und Statistiken bereit. |
 | **Datenbank** | Prisma-Schema für Benutzer, LoRA-Assets, Galerie-Einträge und Tagging inklusive Referenzen & Constraints.    |
 | **Storage**   | MinIO (S3-kompatibel) verwaltet Buckets für Modell- und Bilddateien und wird automatisch provisioniert.      |
-| **Frontend**  | Vite + React (TypeScript). Liefert einen ersten UI-Entwurf mit Platzhalterkarten und Statusanzeigen.         |
+| **Frontend**  | Vite + React (TypeScript). Enthält einen datengetriebenen Explorer für LoRA-Assets & Galerien inkl. Filter. |
 
 ## Installation & Setup
 
@@ -101,6 +101,22 @@ Standard-Ports:
    node -v
    ```
    Sollte die Ausgabe eine Version kleiner als 18 zeigen, bitte Node.js aktualisieren (z. B. via `nvm`).
+4. Öffne `http://localhost:5173`, um den Explorer mit Echtzeit-Filtern für LoRAs und Galerien zu testen.
+
+## Frontend-Erlebnis
+
+Der aktuelle Prototyp stellt zwei kuratierte Übersichten bereit, die mit realen API-Daten arbeiten und auch bei sehr großen
+Beständen performant bleiben:
+
+- **LoRA-Datenbank** – Volltextsuche, Tag- und Typ-Filter, Dateigrößen-Buckets sowie Kurator:innen-Auswahl. Ein Lazy-Loading
+  reduziert das Rendering bei mehr als 100.000 Assets auf handliche Batches.
+- **Galerie-Explorer** – Sichtbarkeitsumschalter, Inhaltstyp-Filter (Bilder, LoRAs, leere Galerien) und Sortierungen nach
+  Aktualität oder Umfang. Ein Vorschauraster zeigt die ersten Einträge jeder Galerie.
+- **Filter-Feedback** – Aktive Filter werden als Badges visualisiert und lassen sich einzeln oder gesammelt zurücksetzen, um den
+  Workflow transparent zu halten.
+
+Die Filterleisten nutzen ausschließlich clientseitige Daten und können ohne zusätzliche Servercalls auf große Resultsets
+reagieren.
 
 ## API-Schnittstellen (Auszug)
 - `GET /health` – Health-Check des Servers.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { AssetCard } from './components/AssetCard';
-import { GalleryCard } from './components/GalleryCard';
+import { AssetExplorer } from './components/AssetExplorer';
+import { GalleryExplorer } from './components/GalleryExplorer';
 import { StatCard } from './components/StatCard';
 import { api } from './lib/api';
 import type { Gallery, MetaStats, ModelAsset } from './types/api';
 
-const loadingPlaceholder = {
-  assets: Array.from({ length: 3 }, (_, index) => index),
-  galleries: Array.from({ length: 2 }, (_, index) => index),
-};
+const statsPlaceholder = Array.from({ length: 3 }, (_, index) => index);
 
 export const App = () => {
   const [stats, setStats] = useState<MetaStats | null>(null);
@@ -31,6 +28,7 @@ export const App = () => {
         setStats(fetchedStats);
         setAssets(fetchedAssets);
         setGalleries(fetchedGalleries);
+        setErrorMessage(null);
       } catch (error) {
         console.error(error);
         setErrorMessage('Backend noch nicht erreichbar. Bitte Server prüfen oder später erneut versuchen.');
@@ -85,59 +83,14 @@ export const App = () => {
           </header>
           <div className="panel__grid panel__grid--stats">
             {isLoading && statsList.length === 0
-              ? loadingPlaceholder.assets.map((key) => <div key={key} className="skeleton" />)
+              ? statsPlaceholder.map((key) => <div key={key} className="skeleton" />)
               : statsList.map((item) => <StatCard key={item.label} {...item} />)}
           </div>
           {errorMessage ? <p className="panel__error">{errorMessage}</p> : null}
         </section>
 
-        <section className="panel">
-          <header className="panel__header">
-            <div>
-              <h2 className="panel__title">LoRA Assets</h2>
-              <p className="panel__subtitle">
-                Erste Liste deiner Safetensor-Modelle. In den nächsten Iterationen folgen Filter, Versionierung und Download-Handling.
-              </p>
-            </div>
-            <button type="button" className="panel__action panel__action--primary">
-              Upload-Workflow öffnen
-            </button>
-          </header>
-          <div className="panel__grid panel__grid--columns">
-            {isLoading
-              ? loadingPlaceholder.assets.map((key) => <div key={key} className="skeleton skeleton--card" />)
-              : assets.map((asset) => <AssetCard key={asset.id} asset={asset} />)}
-          </div>
-          {!isLoading && assets.length === 0 ? (
-            <p className="panel__empty">
-              Noch keine Assets vorhanden. Nutze den Seed oder lade dein erstes LoRA hoch.
-            </p>
-          ) : null}
-        </section>
-
-        <section className="panel">
-          <header className="panel__header">
-            <div>
-              <h2 className="panel__title">Kurierte Galerien</h2>
-              <p className="panel__subtitle">
-                VisionSuit bündelt Renderings, Modelle und Kontextinformationen für deine Community.
-              </p>
-            </div>
-            <button type="button" className="panel__action">
-              Galerie-Entwurf starten
-            </button>
-          </header>
-          <div className="panel__grid panel__grid--columns">
-            {isLoading
-              ? loadingPlaceholder.galleries.map((key) => <div key={key} className="skeleton skeleton--card" />)
-              : galleries.map((gallery) => <GalleryCard key={gallery.id} gallery={gallery} />)}
-          </div>
-          {!isLoading && galleries.length === 0 ? (
-            <p className="panel__empty">
-              Noch keine Galerie angelegt. Nutze den Workflow-Button, um deinen ersten Entwurf zu starten.
-            </p>
-          ) : null}
-        </section>
+        <AssetExplorer assets={assets} isLoading={isLoading} />
+        <GalleryExplorer galleries={galleries} isLoading={isLoading} />
       </div>
     </div>
   );

--- a/frontend/src/components/AssetCard.tsx
+++ b/frontend/src/components/AssetCard.tsx
@@ -10,42 +10,60 @@ const formatFileSize = (bytes?: number | null) => {
   return `${(bytes / 1_000_000).toFixed(1)} MB`;
 };
 
-export const AssetCard = ({ asset }: AssetCardProps) => (
-  <article className="asset-card">
-    <header className="asset-card__header">
-      <div>
-        <h3 className="asset-card__title">{asset.title}</h3>
-        <p className="asset-card__version">Version {asset.version}</p>
-      </div>
-      <span className="asset-card__badge">
-        {asset.tags.find((tag) => tag.category === 'model-type')?.label ?? 'Asset'}
-      </span>
-    </header>
-    <p className="asset-card__description">{asset.description ?? 'Noch keine Beschreibung hinterlegt.'}</p>
-    <dl className="asset-card__meta">
-      <div>
-        <dt>Dateipfad</dt>
-        <dd title={asset.storagePath} className="asset-card__mono">
-          {asset.storagePath}
-        </dd>
-      </div>
-      <div>
-        <dt>Dateigröße</dt>
-        <dd>{formatFileSize(asset.fileSize)}</dd>
-      </div>
-      <div>
-        <dt>Checksumme</dt>
-        <dd className="asset-card__mono">{asset.checksum ?? '–'}</dd>
-      </div>
-      <div>
-        <dt>Kurator</dt>
-        <dd>{asset.owner.displayName}</dd>
-      </div>
-    </dl>
-    <footer className="asset-card__tags">
-      {asset.tags.map((tag) => (
-        <span key={tag.id}>{tag.label}</span>
-      ))}
-    </footer>
-  </article>
-);
+const formatDate = (value: string) =>
+  new Date(value).toLocaleDateString('de-DE', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+export const AssetCard = ({ asset }: AssetCardProps) => {
+  const modelType = asset.tags.find((tag) => tag.category === 'model-type')?.label ?? 'Asset';
+
+  return (
+    <article className="asset-card">
+      {asset.previewImage ? (
+        <div className="asset-card__media">
+          <img src={asset.previewImage} alt={`Preview von ${asset.title}`} loading="lazy" />
+        </div>
+      ) : null}
+      <header className="asset-card__header">
+        <div>
+          <h3 className="asset-card__title">{asset.title}</h3>
+          <p className="asset-card__version">Version {asset.version}</p>
+        </div>
+        <span className="asset-card__badge">{modelType}</span>
+      </header>
+      <p className="asset-card__description">{asset.description ?? 'Noch keine Beschreibung hinterlegt.'}</p>
+      <dl className="asset-card__meta">
+        <div>
+          <dt>Dateipfad</dt>
+          <dd title={asset.storagePath} className="asset-card__mono">
+            {asset.storagePath}
+          </dd>
+        </div>
+        <div>
+          <dt>Dateigröße</dt>
+          <dd>{formatFileSize(asset.fileSize)}</dd>
+        </div>
+        <div>
+          <dt>Checksumme</dt>
+          <dd className="asset-card__mono">{asset.checksum ?? '–'}</dd>
+        </div>
+        <div>
+          <dt>Kurator</dt>
+          <dd>{asset.owner.displayName}</dd>
+        </div>
+        <div>
+          <dt>Aktualisiert</dt>
+          <dd>{formatDate(asset.updatedAt)}</dd>
+        </div>
+      </dl>
+      <footer className="asset-card__tags">
+        {asset.tags.map((tag) => (
+          <span key={tag.id}>{tag.label}</span>
+        ))}
+      </footer>
+    </article>
+  );
+};

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -1,0 +1,354 @@
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+
+import type { ModelAsset } from '../types/api';
+
+import { AssetCard } from './AssetCard';
+import { FilterChip } from './FilterChip';
+
+interface AssetExplorerProps {
+  assets: ModelAsset[];
+  isLoading: boolean;
+}
+
+type FileSizeFilter = 'all' | 'small' | 'medium' | 'large' | 'unknown';
+type SortOption = 'recent' | 'alpha' | 'size-desc' | 'size-asc';
+
+type OwnerOption = { id: string; label: string };
+type TagOption = { id: string; label: string; count: number };
+
+type TypeOption = { id: string; label: string; count: number };
+
+const ASSET_BATCH_SIZE = 24;
+
+const fileSizeLabels: Record<Exclude<FileSizeFilter, 'all'>, string> = {
+  small: '≤ 50 MB',
+  medium: '50 – 200 MB',
+  large: '≥ 200 MB',
+  unknown: 'Unbekannt',
+};
+
+const categorizeFileSize = (value?: number | null): FileSizeFilter => {
+  if (value == null) return 'unknown';
+  const megabytes = value / 1_000_000;
+  if (megabytes < 50) return 'small';
+  if (megabytes < 200) return 'medium';
+  return 'large';
+};
+
+const normalize = (value?: string | null) => value?.toLowerCase().normalize('NFKD') ?? '';
+
+const matchesSearch = (asset: ModelAsset, query: string) => {
+  if (!query) return true;
+  const haystack = [
+    asset.title,
+    asset.slug,
+    asset.description ?? '',
+    asset.owner.displayName,
+    asset.version,
+    ...asset.tags.map((tag) => tag.label),
+  ]
+    .map((entry) => normalize(entry))
+    .join(' ');
+
+  return haystack.includes(query);
+};
+
+const findModelType = (asset: ModelAsset) => asset.tags.find((tag) => tag.category === 'model-type');
+
+export const AssetExplorer = ({ assets, isLoading }: AssetExplorerProps) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedType, setSelectedType] = useState<string>('all');
+  const [selectedOwner, setSelectedOwner] = useState<string>('all');
+  const [fileSizeFilter, setFileSizeFilter] = useState<FileSizeFilter>('all');
+  const [sortOption, setSortOption] = useState<SortOption>('recent');
+  const [visibleLimit, setVisibleLimit] = useState(ASSET_BATCH_SIZE);
+
+  const deferredSearch = useDeferredValue(searchTerm);
+  const normalizedQuery = normalize(deferredSearch.trim());
+
+  const { ownerOptions, tagOptions, typeOptions } = useMemo(() => {
+    const ownersMap = new Map<string, OwnerOption>();
+    const tagsMap = new Map<string, TagOption>();
+    const typesMap = new Map<string, TypeOption>();
+
+    assets.forEach((asset) => {
+      if (!ownersMap.has(asset.owner.id)) {
+        ownersMap.set(asset.owner.id, { id: asset.owner.id, label: asset.owner.displayName });
+      }
+
+      asset.tags.forEach((tag) => {
+        const map = tag.category === 'model-type' ? typesMap : tagsMap;
+        const existing = map.get(tag.id);
+        if (existing) {
+          existing.count += 1;
+        } else {
+          map.set(tag.id, { id: tag.id, label: tag.label, count: 1 });
+        }
+      });
+    });
+
+    const sortByCount = (first: TagOption, second: TagOption) => second.count - first.count;
+
+    return {
+      ownerOptions: Array.from(ownersMap.values()).sort((a, b) => a.label.localeCompare(b.label, 'de')),
+      tagOptions: Array.from(tagsMap.values()).sort(sortByCount).slice(0, 18),
+      typeOptions: Array.from(typesMap.values()).sort(sortByCount),
+    };
+  }, [assets]);
+
+  const filteredAssets = useMemo(() => {
+    const selectedTagIds = new Set(selectedTags);
+
+    const filtered = assets.filter((asset) => {
+      if (!matchesSearch(asset, normalizedQuery)) return false;
+
+      if (selectedType !== 'all') {
+        const typeTag = findModelType(asset);
+        if (!typeTag || typeTag.id !== selectedType) return false;
+      }
+
+      if (selectedOwner !== 'all' && asset.owner.id !== selectedOwner) return false;
+
+      if (fileSizeFilter !== 'all' && categorizeFileSize(asset.fileSize) !== fileSizeFilter) return false;
+
+      if (selectedTagIds.size > 0) {
+        const assetTagIds = asset.tags
+          .filter((tag) => tag.category !== 'model-type')
+          .map((tag) => tag.id);
+        for (const tagId of selectedTagIds) {
+          if (!assetTagIds.includes(tagId)) return false;
+        }
+      }
+
+      return true;
+    });
+
+    const sorters: Record<SortOption, (a: ModelAsset, b: ModelAsset) => number> = {
+      recent: (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      alpha: (a, b) => a.title.localeCompare(b.title, 'de'),
+      'size-desc': (a, b) => (b.fileSize ?? 0) - (a.fileSize ?? 0),
+      'size-asc': (a, b) => (a.fileSize ?? Infinity) - (b.fileSize ?? Infinity),
+    };
+
+    return filtered.sort(sorters[sortOption]);
+  }, [assets, normalizedQuery, selectedOwner, selectedType, fileSizeFilter, selectedTags, sortOption]);
+
+  useEffect(() => {
+    setVisibleLimit(ASSET_BATCH_SIZE);
+  }, [normalizedQuery, selectedOwner, selectedType, fileSizeFilter, selectedTags, sortOption]);
+
+  const visibleAssets = useMemo(() => filteredAssets.slice(0, visibleLimit), [filteredAssets, visibleLimit]);
+
+  const activeFilters = useMemo(() => {
+    const filters: { id: string; label: string; onClear: () => void }[] = [];
+
+    if (normalizedQuery) {
+      filters.push({ id: 'search', label: `Suche: “${deferredSearch.trim()}”`, onClear: () => setSearchTerm('') });
+    }
+
+    if (selectedOwner !== 'all') {
+      const owner = ownerOptions.find((option) => option.id === selectedOwner);
+      if (owner) {
+        filters.push({ id: `owner-${owner.id}`, label: `Kurator:in · ${owner.label}`, onClear: () => setSelectedOwner('all') });
+      }
+    }
+
+    if (selectedType !== 'all') {
+      const type = typeOptions.find((option) => option.id === selectedType);
+      if (type) {
+        filters.push({ id: `type-${type.id}`, label: `Typ · ${type.label}`, onClear: () => setSelectedType('all') });
+      }
+    }
+
+    if (fileSizeFilter !== 'all') {
+      filters.push({
+        id: `size-${fileSizeFilter}`,
+        label: `Größe · ${fileSizeLabels[fileSizeFilter]}`,
+        onClear: () => setFileSizeFilter('all'),
+      });
+    }
+
+    selectedTags.forEach((tagId) => {
+      const tag = tagOptions.find((option) => option.id === tagId);
+      if (tag) {
+        filters.push({
+          id: `tag-${tag.id}`,
+          label: `Tag · ${tag.label}`,
+          onClear: () => setSelectedTags((prev) => prev.filter((value) => value !== tagId)),
+        });
+      }
+    });
+
+    return filters;
+  }, [deferredSearch, fileSizeFilter, normalizedQuery, ownerOptions, selectedOwner, selectedTags, tagOptions, typeOptions, selectedType]);
+
+  const resetFilters = () => {
+    setSelectedOwner('all');
+    setSelectedType('all');
+    setSelectedTags([]);
+    setFileSizeFilter('all');
+    setSortOption('recent');
+    setSearchTerm('');
+  };
+
+  const loadMoreAssets = () => {
+    setVisibleLimit((current) => Math.min(filteredAssets.length, current + ASSET_BATCH_SIZE));
+  };
+
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <div>
+          <h2 className="panel__title">LoRA-Datenbank</h2>
+          <p className="panel__subtitle">
+            Durchsuche kuratierte Safetensor-Modelle, filtere nach Tags, Dateigrößen oder Kurator:innen und sortiere große Bestände
+            ohne Performance-Einbruch.
+          </p>
+        </div>
+        <button type="button" className="panel__action panel__action--primary">
+          Upload-Workflow öffnen
+        </button>
+      </header>
+
+      <div className="filter-toolbar" aria-label="Filter für LoRA-Datenbank">
+        <div className="filter-toolbar__row">
+          <label className="filter-toolbar__search">
+            <span className="sr-only">Suche in LoRA-Assets</span>
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Titel, Tags oder Personen durchsuchen"
+              disabled={isLoading && assets.length === 0}
+            />
+          </label>
+
+          <label className="filter-toolbar__control">
+            <span>Sortierung</span>
+            <select
+              value={sortOption}
+              onChange={(event) => setSortOption(event.target.value as SortOption)}
+              className="filter-select"
+            >
+              <option value="recent">Aktualisiert · Neueste zuerst</option>
+              <option value="alpha">Titel · A → Z</option>
+              <option value="size-desc">Dateigröße · Groß → Klein</option>
+              <option value="size-asc">Dateigröße · Klein → Groß</option>
+            </select>
+          </label>
+
+          <label className="filter-toolbar__control">
+            <span>Kurator:in</span>
+            <select
+              value={selectedOwner}
+              onChange={(event) => setSelectedOwner(event.target.value)}
+              className="filter-select"
+            >
+              <option value="all">Alle Personen</option>
+              {ownerOptions.map((owner) => (
+                <option key={owner.id} value={owner.id}>
+                  {owner.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="filter-toolbar__control">
+            <span>Model-Typ</span>
+            <select
+              value={selectedType}
+              onChange={(event) => setSelectedType(event.target.value)}
+              className="filter-select"
+            >
+              <option value="all">Alle Typen</option>
+              {typeOptions.map((type) => (
+                <option key={type.id} value={type.id}>
+                  {type.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="filter-toolbar__chips" role="group" aria-label="Dateigröße filtern">
+            <FilterChip
+              label="Alle Größen"
+              isActive={fileSizeFilter === 'all'}
+              onClick={() => setFileSizeFilter('all')}
+            />
+            {(Object.keys(fileSizeLabels) as Exclude<FileSizeFilter, 'all'>[]).map((key) => (
+              <FilterChip
+                key={key}
+                label={fileSizeLabels[key]}
+                isActive={fileSizeFilter === key}
+                onClick={() => setFileSizeFilter(key)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {tagOptions.length > 0 ? (
+          <div className="filter-toolbar__tag-row" role="group" aria-label="Tags filtern">
+            <span className="filter-toolbar__tag-label">Beliebte Tags</span>
+            <div className="filter-toolbar__tag-chips">
+              {tagOptions.map((tag) => (
+                <FilterChip
+                  key={tag.id}
+                  label={tag.label}
+                  count={tag.count}
+                  isActive={selectedTags.includes(tag.id)}
+                  onClick={() =>
+                    setSelectedTags((previous) =>
+                      previous.includes(tag.id)
+                        ? previous.filter((value) => value !== tag.id)
+                        : [...previous, tag.id],
+                    )
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {activeFilters.length > 0 ? (
+          <div className="filter-toolbar__active">
+            <span className="filter-toolbar__active-label">Aktive Filter:</span>
+            <div className="filter-toolbar__active-chips">
+              {activeFilters.map((filter) => (
+                <button key={filter.id} type="button" className="active-filter" onClick={filter.onClear}>
+                  <span>{filter.label}</span>
+                  <span aria-hidden="true">×</span>
+                </button>
+              ))}
+            </div>
+            <button type="button" className="filter-toolbar__reset" onClick={resetFilters}>
+              Alle Filter zurücksetzen
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="result-info" role="status">
+        {isLoading && assets.length === 0 ? 'Lade LoRA-Assets …' : `Zeigt ${visibleAssets.length} von ${filteredAssets.length} Assets`}
+      </div>
+
+      <div className="panel__grid panel__grid--columns">
+        {isLoading && assets.length === 0
+          ? Array.from({ length: 6 }).map((_, index) => <div key={index} className="skeleton skeleton--card" />)
+          : visibleAssets.map((asset) => <AssetCard key={asset.id} asset={asset} />)}
+      </div>
+
+      {!isLoading && filteredAssets.length === 0 ? (
+        <p className="panel__empty">Keine Assets entsprechen den aktuellen Filtern.</p>
+      ) : null}
+
+      {!isLoading && visibleAssets.length < filteredAssets.length ? (
+        <div className="panel__footer">
+          <button type="button" className="panel__action panel__action--ghost" onClick={loadMoreAssets}>
+            Weitere {Math.min(ASSET_BATCH_SIZE, filteredAssets.length - visibleAssets.length)} Assets laden
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/frontend/src/components/FilterChip.tsx
+++ b/frontend/src/components/FilterChip.tsx
@@ -1,0 +1,26 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+interface FilterChipProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
+  label: ReactNode;
+  isActive?: boolean;
+  tone?: 'default' | 'solid';
+  count?: number;
+}
+
+export const FilterChip = ({
+  label,
+  isActive = false,
+  tone = 'default',
+  count,
+  className = '',
+  ...buttonProps
+}: FilterChipProps) => (
+  <button
+    type="button"
+    className={`filter-chip filter-chip--${tone} ${isActive ? 'filter-chip--active' : ''} ${className}`.trim()}
+    {...buttonProps}
+  >
+    <span className="filter-chip__label">{label}</span>
+    {typeof count === 'number' ? <span className="filter-chip__count">{count}</span> : null}
+  </button>
+);

--- a/frontend/src/components/GalleryCard.tsx
+++ b/frontend/src/components/GalleryCard.tsx
@@ -7,38 +7,62 @@ const formatDate = (value: string) =>
     day: 'numeric',
   });
 
-export const GalleryCard = ({ gallery }: { gallery: Gallery }) => (
-  <article className="gallery-card">
-    <header className="gallery-card__header">
-      <div>
-        <h3 className="gallery-card__title">{gallery.title}</h3>
-        <p className="gallery-card__curator">Kuratiert von {gallery.owner.displayName}</p>
-      </div>
-      <span className={`gallery-card__badge ${gallery.isPublic ? 'gallery-card__badge--public' : ''}`}>
-        {gallery.isPublic ? 'Öffentlich' : 'Privat'}
-      </span>
-    </header>
-    <p className="gallery-card__description">
-      {gallery.description ?? 'Noch keine Galerie-Beschreibung hinterlegt.'}
-    </p>
-    <dl className="gallery-card__meta">
-      <div>
-        <dt>Slug</dt>
-        <dd className="gallery-card__mono">{gallery.slug}</dd>
-      </div>
-      <div>
-        <dt>Aktualisiert</dt>
-        <dd>{formatDate(gallery.updatedAt)}</dd>
-      </div>
-      <div>
-        <dt>Einträge</dt>
-        <dd>{gallery.entries.length}</dd>
-      </div>
-      <div>
-        <dt>Cover</dt>
-        <dd className="gallery-card__mono">{gallery.coverImage ?? '–'}</dd>
-      </div>
-    </dl>
-    <footer className="gallery-card__footer">Platzhalter für Vorschau-Kacheln der Galerie-Einträge.</footer>
-  </article>
-);
+export const GalleryCard = ({ gallery }: { gallery: Gallery }) => {
+  const previewItems = gallery.entries.slice(0, 4).map((entry) => {
+    const type = entry.imageAsset ? 'image' : entry.modelAsset ? 'model' : 'empty';
+    const src = entry.imageAsset?.storagePath ?? entry.modelAsset?.previewImage ?? null;
+    const title = entry.imageAsset?.title ?? entry.modelAsset?.title ?? `Slot ${entry.position}`;
+    return { id: entry.id, type, src, title };
+  });
+
+  return (
+    <article className="gallery-card">
+      <header className="gallery-card__header">
+        <div>
+          <h3 className="gallery-card__title">{gallery.title}</h3>
+          <p className="gallery-card__curator">Kuratiert von {gallery.owner.displayName}</p>
+        </div>
+        <span className={`gallery-card__badge ${gallery.isPublic ? 'gallery-card__badge--public' : ''}`}>
+          {gallery.isPublic ? 'Öffentlich' : 'Privat'}
+        </span>
+      </header>
+      <p className="gallery-card__description">
+        {gallery.description ?? 'Noch keine Galerie-Beschreibung hinterlegt.'}
+      </p>
+      <dl className="gallery-card__meta">
+        <div>
+          <dt>Slug</dt>
+          <dd className="gallery-card__mono">{gallery.slug}</dd>
+        </div>
+        <div>
+          <dt>Aktualisiert</dt>
+          <dd>{formatDate(gallery.updatedAt)}</dd>
+        </div>
+        <div>
+          <dt>Einträge</dt>
+          <dd>{gallery.entries.length}</dd>
+        </div>
+        <div>
+          <dt>Cover</dt>
+          <dd className="gallery-card__mono">{gallery.coverImage ?? '–'}</dd>
+        </div>
+      </dl>
+      <footer className="gallery-card__footer">
+        {previewItems.length > 0 ? (
+          <div className="gallery-card__preview-grid">
+            {previewItems.map((item) => (
+              <div key={item.id} className={`gallery-card__preview gallery-card__preview--${item.type}`}>
+                {item.src ? <img src={item.src} alt={item.title} loading="lazy" /> : <span>{item.title}</span>}
+              </div>
+            ))}
+            {gallery.entries.length > previewItems.length ? (
+              <div className="gallery-card__preview gallery-card__preview--more">+{gallery.entries.length - previewItems.length}</div>
+            ) : null}
+          </div>
+        ) : (
+          <span>Diese Galerie enthält noch keine Einträge.</span>
+        )}
+      </footer>
+    </article>
+  );
+};

--- a/frontend/src/components/GalleryExplorer.tsx
+++ b/frontend/src/components/GalleryExplorer.tsx
@@ -1,0 +1,248 @@
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+
+import type { Gallery } from '../types/api';
+
+import { FilterChip } from './FilterChip';
+import { GalleryCard } from './GalleryCard';
+
+interface GalleryExplorerProps {
+  galleries: Gallery[];
+  isLoading: boolean;
+}
+
+type VisibilityFilter = 'all' | 'public' | 'private';
+type EntryFilter = 'all' | 'with-image' | 'with-model' | 'empty';
+type SortOption = 'recent' | 'alpha' | 'entries-desc' | 'entries-asc';
+
+const GALLERY_BATCH_SIZE = 12;
+
+const normalize = (value?: string | null) => value?.toLowerCase().normalize('NFKD') ?? '';
+
+const matchesSearch = (gallery: Gallery, query: string) => {
+  if (!query) return true;
+  const haystack = [
+    gallery.title,
+    gallery.slug,
+    gallery.description ?? '',
+    gallery.owner.displayName,
+    ...gallery.entries
+      .map((entry) => entry.modelAsset?.title ?? entry.imageAsset?.title ?? entry.note ?? '')
+      .filter(Boolean),
+  ]
+    .map((entry) => normalize(entry))
+    .join(' ');
+  return haystack.includes(query);
+};
+
+const galleryHasImage = (gallery: Gallery) => gallery.entries.some((entry) => Boolean(entry.imageAsset));
+const galleryHasModel = (gallery: Gallery) => gallery.entries.some((entry) => Boolean(entry.modelAsset));
+
+export const GalleryExplorer = ({ galleries, isLoading }: GalleryExplorerProps) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [visibility, setVisibility] = useState<VisibilityFilter>('all');
+  const [entryFilter, setEntryFilter] = useState<EntryFilter>('all');
+  const [ownerId, setOwnerId] = useState<string>('all');
+  const [sortOption, setSortOption] = useState<SortOption>('recent');
+  const [visibleLimit, setVisibleLimit] = useState(GALLERY_BATCH_SIZE);
+
+  const deferredSearch = useDeferredValue(searchTerm);
+  const normalizedQuery = normalize(deferredSearch.trim());
+
+  const ownerOptions = useMemo(() => {
+    const ownersMap = new Map<string, { id: string; label: string }>();
+    galleries.forEach((gallery) => {
+      if (!ownersMap.has(gallery.owner.id)) {
+        ownersMap.set(gallery.owner.id, { id: gallery.owner.id, label: gallery.owner.displayName });
+      }
+    });
+    return Array.from(ownersMap.values()).sort((a, b) => a.label.localeCompare(b.label, 'de'));
+  }, [galleries]);
+
+  const filteredGalleries = useMemo(() => {
+    const filtered = galleries.filter((gallery) => {
+      if (!matchesSearch(gallery, normalizedQuery)) return false;
+
+      if (visibility !== 'all' && gallery.isPublic !== (visibility === 'public')) return false;
+
+      if (ownerId !== 'all' && gallery.owner.id !== ownerId) return false;
+
+      if (entryFilter === 'with-image' && !galleryHasImage(gallery)) return false;
+      if (entryFilter === 'with-model' && !galleryHasModel(gallery)) return false;
+      if (entryFilter === 'empty' && gallery.entries.length !== 0) return false;
+
+      return true;
+    });
+
+    const sorters: Record<SortOption, (a: Gallery, b: Gallery) => number> = {
+      recent: (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      alpha: (a, b) => a.title.localeCompare(b.title, 'de'),
+      'entries-desc': (a, b) => b.entries.length - a.entries.length,
+      'entries-asc': (a, b) => a.entries.length - b.entries.length,
+    };
+
+    return filtered.sort(sorters[sortOption]);
+  }, [entryFilter, galleries, normalizedQuery, ownerId, sortOption, visibility]);
+
+  useEffect(() => {
+    setVisibleLimit(GALLERY_BATCH_SIZE);
+  }, [normalizedQuery, visibility, entryFilter, ownerId, sortOption]);
+
+  const visibleGalleries = useMemo(() => filteredGalleries.slice(0, visibleLimit), [filteredGalleries, visibleLimit]);
+
+  const activeFilters = useMemo(() => {
+    const filters: { id: string; label: string; onClear: () => void }[] = [];
+
+    if (normalizedQuery) {
+      filters.push({ id: 'search', label: `Suche: “${deferredSearch.trim()}”`, onClear: () => setSearchTerm('') });
+    }
+
+    if (visibility !== 'all') {
+      filters.push({
+        id: `visibility-${visibility}`,
+        label: visibility === 'public' ? 'Status · Öffentlich' : 'Status · Privat',
+        onClear: () => setVisibility('all'),
+      });
+    }
+
+    if (entryFilter !== 'all') {
+      const labels: Record<EntryFilter, string> = {
+        all: '',
+        'with-image': 'Inhalte · Mit Bildern',
+        'with-model': 'Inhalte · Mit LoRAs',
+        empty: 'Inhalte · Ohne Einträge',
+      };
+      filters.push({
+        id: `entries-${entryFilter}`,
+        label: labels[entryFilter],
+        onClear: () => setEntryFilter('all'),
+      });
+    }
+
+    if (ownerId !== 'all') {
+      const owner = ownerOptions.find((option) => option.id === ownerId);
+      if (owner) {
+        filters.push({ id: `owner-${owner.id}`, label: `Kurator:in · ${owner.label}`, onClear: () => setOwnerId('all') });
+      }
+    }
+
+    return filters;
+  }, [deferredSearch, entryFilter, normalizedQuery, ownerId, ownerOptions, visibility]);
+
+  const resetFilters = () => {
+    setVisibility('all');
+    setEntryFilter('all');
+    setOwnerId('all');
+    setSortOption('recent');
+    setSearchTerm('');
+  };
+
+  const loadMore = () => {
+    setVisibleLimit((current) => Math.min(filteredGalleries.length, current + GALLERY_BATCH_SIZE));
+  };
+
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <div>
+          <h2 className="panel__title">Galerie-Explorer</h2>
+          <p className="panel__subtitle">
+            Finde kuratierte Sets anhand von Sichtbarkeit, Inhaltstyp oder Kurator:innen und blättere performant durch umfangreiche
+            Sammlungen.
+          </p>
+        </div>
+        <button type="button" className="panel__action">Galerie-Entwurf starten</button>
+      </header>
+
+      <div className="filter-toolbar" aria-label="Filter für Galerien">
+        <div className="filter-toolbar__row">
+          <label className="filter-toolbar__search">
+            <span className="sr-only">Suche in Galerien</span>
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Titel, Kurator:in oder Slug durchsuchen"
+              disabled={isLoading && galleries.length === 0}
+            />
+          </label>
+
+          <label className="filter-toolbar__control">
+            <span>Sortierung</span>
+            <select value={sortOption} onChange={(event) => setSortOption(event.target.value as SortOption)} className="filter-select">
+              <option value="recent">Aktualisiert · Neueste zuerst</option>
+              <option value="alpha">Titel · A → Z</option>
+              <option value="entries-desc">Einträge · Viele → Wenige</option>
+              <option value="entries-asc">Einträge · Wenige → Viele</option>
+            </select>
+          </label>
+
+          <div className="filter-toolbar__chips" role="group" aria-label="Sichtbarkeit filtern">
+            <FilterChip label="Alle" isActive={visibility === 'all'} onClick={() => setVisibility('all')} />
+            <FilterChip label="Öffentlich" isActive={visibility === 'public'} onClick={() => setVisibility('public')} />
+            <FilterChip label="Privat" isActive={visibility === 'private'} onClick={() => setVisibility('private')} />
+          </div>
+
+          <label className="filter-toolbar__control">
+            <span>Kurator:in</span>
+            <select value={ownerId} onChange={(event) => setOwnerId(event.target.value)} className="filter-select">
+              <option value="all">Alle Personen</option>
+              {ownerOptions.map((owner) => (
+                <option key={owner.id} value={owner.id}>
+                  {owner.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="filter-toolbar__chips" role="group" aria-label="Inhaltstyp filtern">
+          <FilterChip label="Alle Inhalte" isActive={entryFilter === 'all'} onClick={() => setEntryFilter('all')} />
+          <FilterChip label="Mit Bildern" isActive={entryFilter === 'with-image'} onClick={() => setEntryFilter('with-image')} />
+          <FilterChip label="Mit LoRAs" isActive={entryFilter === 'with-model'} onClick={() => setEntryFilter('with-model')} />
+          <FilterChip label="Ohne Einträge" isActive={entryFilter === 'empty'} onClick={() => setEntryFilter('empty')} />
+        </div>
+
+        {activeFilters.length > 0 ? (
+          <div className="filter-toolbar__active">
+            <span className="filter-toolbar__active-label">Aktive Filter:</span>
+            <div className="filter-toolbar__active-chips">
+              {activeFilters.map((filter) => (
+                <button key={filter.id} type="button" className="active-filter" onClick={filter.onClear}>
+                  <span>{filter.label}</span>
+                  <span aria-hidden="true">×</span>
+                </button>
+              ))}
+            </div>
+            <button type="button" className="filter-toolbar__reset" onClick={resetFilters}>
+              Alle Filter zurücksetzen
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="result-info" role="status">
+        {isLoading && galleries.length === 0
+          ? 'Lade Galerien …'
+          : `Zeigt ${visibleGalleries.length} von ${filteredGalleries.length} Galerien`}
+      </div>
+
+      <div className="panel__grid panel__grid--columns">
+        {isLoading && galleries.length === 0
+          ? Array.from({ length: 4 }).map((_, index) => <div key={index} className="skeleton skeleton--card" />)
+          : visibleGalleries.map((gallery) => <GalleryCard key={gallery.id} gallery={gallery} />)}
+      </div>
+
+      {!isLoading && filteredGalleries.length === 0 ? (
+        <p className="panel__empty">Keine Galerien entsprechen den aktiven Filtern.</p>
+      ) : null}
+
+      {!isLoading && visibleGalleries.length < filteredGalleries.length ? (
+        <div className="panel__footer">
+          <button type="button" className="panel__action panel__action--ghost" onClick={loadMore}>
+            Weitere {Math.min(GALLERY_BATCH_SIZE, filteredGalleries.length - visibleGalleries.length)} Galerien laden
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -101,6 +101,11 @@ body {
   box-shadow: 0 24px 60px rgba(2, 6, 23, 0.45);
 }
 
+.panel__footer {
+  display: flex;
+  justify-content: center;
+}
+
 .panel--frosted {
   background: rgba(15, 23, 42, 0.55);
   backdrop-filter: blur(16px);
@@ -166,6 +171,16 @@ body {
 
 .panel__action--primary:hover {
   border-color: rgba(165, 180, 252, 0.95);
+  color: #ffffff;
+}
+
+.panel__action--ghost {
+  border-color: rgba(148, 163, 184, 0.2);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.panel__action--ghost:hover {
+  border-color: rgba(226, 232, 240, 0.5);
   color: #ffffff;
 }
 
@@ -247,6 +262,22 @@ body {
   border: 1px solid rgba(148, 163, 184, 0.2);
   background: rgba(2, 6, 23, 0.55);
   box-shadow: 0 16px 48px rgba(2, 6, 23, 0.35);
+}
+
+.asset-card__media {
+  position: relative;
+  overflow: hidden;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.asset-card__media img {
+  display: block;
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  filter: saturate(1.15);
 }
 
 .asset-card__header,
@@ -354,6 +385,246 @@ body {
   background: rgba(15, 23, 42, 0.6);
   border: 1px dashed rgba(148, 163, 184, 0.25);
   color: rgba(203, 213, 225, 0.75);
+  min-height: 104px;
+  display: flex;
+  align-items: center;
+}
+
+.gallery-card__preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(70px, 1fr));
+  gap: 0.65rem;
+  width: 100%;
+}
+
+.gallery-card__preview {
+  position: relative;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.65);
+  min-height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  text-align: center;
+  color: rgba(203, 213, 225, 0.85);
+  overflow: hidden;
+}
+
+.gallery-card__preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-card__preview--image {
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.gallery-card__preview--model {
+  border-color: rgba(165, 180, 252, 0.4);
+  background: rgba(76, 29, 149, 0.28);
+}
+
+.gallery-card__preview--empty {
+  border-style: dashed;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.gallery-card__preview--more {
+  border-color: rgba(34, 197, 94, 0.4);
+  background: rgba(34, 197, 94, 0.12);
+  font-weight: 600;
+}
+
+.filter-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(2, 6, 23, 0.5);
+}
+
+.filter-toolbar__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.filter-toolbar__search {
+  flex: 1 1 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.filter-toolbar__search input {
+  width: 100%;
+  padding: 0.7rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.75);
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-toolbar__search input:focus {
+  outline: none;
+  border-color: rgba(129, 140, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.25);
+}
+
+.filter-toolbar__control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.filter-toolbar__control span {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.filter-select {
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.75);
+  color: #e2e8f0;
+  font-size: 0.85rem;
+}
+
+.filter-toolbar__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-toolbar__tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.filter-toolbar__tag-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.filter-toolbar__tag-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.filter-chip:hover {
+  transform: translateY(-1px);
+  border-color: rgba(226, 232, 240, 0.5);
+}
+
+.filter-chip--solid {
+  background: rgba(99, 102, 241, 0.3);
+  border-color: rgba(129, 140, 248, 0.6);
+}
+
+.filter-chip--active {
+  background: rgba(129, 140, 248, 0.25);
+  border-color: rgba(129, 140, 248, 0.8);
+  color: #c7d2fe;
+}
+
+.filter-chip__count {
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  background: rgba(30, 41, 59, 0.85);
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.filter-toolbar__active {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  font-size: 0.8rem;
+}
+
+.filter-toolbar__active-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-toolbar__active-label {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.7rem;
+}
+
+.active-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  background: rgba(248, 113, 113, 0.1);
+  color: rgba(252, 165, 165, 0.95);
+  cursor: pointer;
+}
+
+.filter-toolbar__reset {
+  border: none;
+  background: none;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.result-info {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 button {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,23 @@ import { createHash, webcrypto } from 'node:crypto'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-type HashCapableCrypto = Crypto & {
+type SupportedDataView =
+  | ArrayBuffer
+  | DataView
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | BigInt64Array
+  | BigUint64Array
+  | Float32Array
+  | Float64Array
+  | Buffer
+
+type HashCapableCrypto = typeof webcrypto & {
   hash?: (
     algorithm: string | { name?: string },
     data: SupportedDataView | string,
@@ -29,22 +45,6 @@ const ensureNodeCryptoHashPolyfill = () => {
 
       throw new TypeError('Unsupported algorithm supplied to crypto.hash polyfill')
     }
-
-    type SupportedDataView =
-      | ArrayBuffer
-      | DataView
-      | Int8Array
-      | Uint8Array
-      | Uint8ClampedArray
-      | Int16Array
-      | Uint16Array
-      | Int32Array
-      | Uint32Array
-      | BigInt64Array
-      | BigUint64Array
-      | Float32Array
-      | Float64Array
-      | Buffer
 
     const toBuffer = (data: SupportedDataView | string) => {
       if (typeof data === 'string') {


### PR DESCRIPTION
## Summary
- add a LoRA asset explorer with fulltext search, tag/type filters, filesize buckets, curator selection, and lazy loading batches for very large datasets
- add a gallery explorer with visibility/inventory filters, curated previews, and matching load-more handling
- refresh shared cards, introduce reusable filter chips, extend styling, document the frontend explorer workflow, and log the change

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc60a06c848333994a4eae57ca3a09