### PR TITLE
feat: wire uploads into minio-backed explorers

### DIFF
--- a/ChangeLog/2025-09-20-pending.md
+++ b/ChangeLog/2025-09-20-pending.md
@@ -1,0 +1,22 @@
+# Änderungsbericht – 20.09.2025 (Commit pending)
+
+## Überblick
+- Upload-Pipeline speichert Dateien nun direkt in MinIO, erzeugt Model-/Image-Assets und pflegt Galerien sofort nach dem Upload.
+- API liefert vollständige Storage-Metadaten inklusive öffentlicher URLs, sodass Explorer und Karten produktive Daten zeigen.
+- Frontend zieht die neuen Felder ein, verlinkt Storage-Objekte und aktualisiert Erfolgsmeldungen für den Wizard.
+
+## Backend
+- `POST /api/uploads` überträgt Dateien in die vorgesehenen Buckets (`uploads/{uuid}/…`), berechnet Safetensor-Checksummen, erzeugt UploadDrafts mit Status `processed` und legt Model-/Image-Assets samt Galerie-Einträgen an.
+- Ergänzende Helfer (`slugify`, Bucket-Resolver) sorgen für robuste Slug-Bildung, Tag-Upserts und korrekte S3-URIs (`s3://bucket/object`).
+- Assets- & Galerie-Endpunkte mappen Storage-Felder auf öffentliche URLs, reichen Bucket/Object-Namen durch und aktualisieren Seed-Daten auf das neue S3-Schema.
+
+## Frontend
+- `AssetCard` zeigt Storage-Bucket samt anklickbarem Objektpfad, Suchfunktion berücksichtigt Objekt-Namen.
+- Upload-Wizard verarbeitet neue API-Antworten (Asset-/Galerie-Slug), formuliert Statusmeldungen mit Explorer-Hinweis.
+- Typdefinitionen & API-Client kennen zusätzliche Storage-Felder, Explorer bleibt filter- & sortierfähig.
+
+## Dokumentation & Tests
+- README ergänzt: Direkt-Ingest nach MinIO, sofortige Explorer-Verfügbarkeit und Storage-Metadaten im Response.
+- Tests: `npm run lint` & `npm run build` (Backend + Frontend).
+
+_Commit-Referenz wird nach dem Merge mit der finalen ID ergänzt._

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ den Upload- und Kuration-Workflow.
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB) und automatischem Übergang in die Analyse-Queue.
 - **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, Pagination und aktiven Filterhinweisen.
+- **Direkte MinIO-Ingests** – Uploads landen unmittelbar in den konfigurierten Buckets, werden automatisch mit Tags versehen und tauchen ohne Wartezeit in Explorer & Galerien auf.
 
 ## Architekturüberblick
 
@@ -126,9 +127,9 @@ reagieren.
 ### Upload-Pipeline & Backend
 
 1. **Session anlegen** – Der Wizard legt per `POST /api/uploads` einen `UploadDraft` inklusive Owner, Sichtbarkeit, Tags und erwarteter Dateien an.
-2. **Ingest & Validierung** – Der Endpunkt prüft Dateitypen, 2-GB-Gesamtlimit, Pflichtfelder sowie Galerie-Zuordnung und persistiert eine vollständige Dateiliste.
-3. **Analyse-Queue** – Hintergrund-Worker lesen Checksums, Safetensor-Header oder EXIF-/Prompt-Daten aus und schreiben Ergebnisse zurück in die Asset-Datenmodelle.
-4. **Release & Audit** – Nach erfolgreicher Analyse erscheinen Assets im Explorer; Audit-Timestamps bleiben in `UploadDraft` erhalten und dokumentieren den Workflow.
+2. **Direkter Storage-Ingest** – Dateien werden gestreamt nach MinIO übertragen (`s3://bucket/object`), inklusive SHA-256-Prüfsumme für LoRA-Safetensors und optionaler Preview-Grafiken.
+3. **Asset-Erzeugung & Linking** – Das Backend erzeugt sofort `ModelAsset`- bzw. `ImageAsset`-Datensätze, verknüpft Tags, erstellt auf Wunsch neue Galerien und setzt Cover-Bilder automatisch.
+4. **Explorer-Refresh & Audit** – UploadDrafts erhalten einen `processed`-Status, Explorer-Kacheln sind direkt sichtbar und alle Storage-Informationen (Bucket, Object-Key, Public-URL) werden im API-Response ausgespielt.
 
 ## API-Schnittstellen (Auszug)
 - `GET /health` – Health-Check des Servers.

--- a/backend/src/lib/slug.ts
+++ b/backend/src/lib/slug.ts
@@ -1,0 +1,54 @@
+const DEFAULT_FALLBACK = 'item';
+
+const toAscii = (value: string) =>
+  value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\w\s-]+/g, '')
+    .trim();
+
+export const slugify = (value: string, fallback = DEFAULT_FALLBACK): string => {
+  const normalized = toAscii(value)
+    .toLowerCase()
+    .replace(/[_\s-]+/g, '-');
+
+  const compacted = normalized.replace(/^-+|-+$/g, '').replace(/-{2,}/g, '-');
+
+  if (compacted.length > 0) {
+    return compacted;
+  }
+
+  const fallbackValue = toAscii(fallback)
+    .toLowerCase()
+    .replace(/[_\s-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+
+  return fallbackValue.length > 0 ? fallbackValue : DEFAULT_FALLBACK;
+};
+
+export const buildUniqueSlug = async (
+  baseValue: string,
+  exists: (slug: string) => Promise<boolean>,
+  fallback = DEFAULT_FALLBACK,
+): Promise<string> => {
+  const base = slugify(baseValue, fallback);
+  let candidate = base;
+  let index = 2;
+
+  // eslint-disable-next-line no-await-in-loop
+  while (await exists(candidate)) {
+    candidate = `${base}-${index}`;
+    index += 1;
+  }
+
+  return candidate;
+};
+
+export const sanitizeFilename = (value: string, fallback = DEFAULT_FALLBACK) => {
+  const extensionMatch = value.match(/\.([^.]+)$/);
+  const extension = extensionMatch?.[1] ? `.${extensionMatch[1].toLowerCase()}` : '';
+  const basename = extension ? value.slice(0, -extension.length) : value;
+  const slug = slugify(basename, fallback);
+  return `${slug}${extension}`;
+};

--- a/backend/src/lib/storage.ts
+++ b/backend/src/lib/storage.ts
@@ -57,3 +57,33 @@ export const getObjectUrl = (bucket: string, objectName: string) => {
   const baseUrl = appConfig.storage.publicUrl.replace(/\/$/, '');
   return `${baseUrl}/${bucket}/${encodeObjectName(objectName)}`;
 };
+
+export interface StorageLocation {
+  bucket: string | null;
+  objectName: string | null;
+  url: string | null;
+}
+
+export const resolveStorageLocation = (value?: string | null): StorageLocation => {
+  if (!value) {
+    return { bucket: null, objectName: null, url: null };
+  }
+
+  if (value.startsWith('s3://')) {
+    const withoutScheme = value.slice('s3://'.length);
+    const [bucket, ...rest] = withoutScheme.split('/');
+    const objectName = rest.join('/');
+
+    if (!bucket || !objectName) {
+      return { bucket: null, objectName: null, url: value };
+    }
+
+    return { bucket, objectName, url: getObjectUrl(bucket, objectName) };
+  }
+
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    return { bucket: null, objectName: null, url: value };
+  }
+
+  return { bucket: null, objectName: value, url: `${appConfig.storage.publicUrl.replace(/\/$/, '')}/${value.replace(/^\//, '')}` };
+};

--- a/backend/src/routes/galleries.ts
+++ b/backend/src/routes/galleries.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
 import { prisma } from '../lib/prisma';
+import { resolveStorageLocation } from '../lib/storage';
 
 export const galleriesRouter = Router();
 
@@ -29,34 +30,55 @@ galleriesRouter.get('/', async (_req, res, next) => {
       orderBy: { createdAt: 'desc' },
     });
 
-    const response = galleries.map((gallery) => ({
-      id: gallery.id,
-      slug: gallery.slug,
-      title: gallery.title,
-      description: gallery.description,
-      coverImage: gallery.coverImage,
-      isPublic: gallery.isPublic,
-      owner: gallery.owner,
-      createdAt: gallery.createdAt,
-      updatedAt: gallery.updatedAt,
-      entries: gallery.entries.map((entry) => ({
-        id: entry.id,
-        position: entry.position,
-        note: entry.note,
-        modelAsset: entry.asset
-          ? {
-              ...entry.asset,
-              tags: entry.asset.tags.map(({ tag }) => tag),
-            }
-          : null,
-        imageAsset: entry.image
-          ? {
-              ...entry.image,
-              tags: entry.image.tags.map(({ tag }) => tag),
-            }
-          : null,
-      })),
-    }));
+    const response = galleries.map((gallery) => {
+      const cover = resolveStorageLocation(gallery.coverImage);
+
+      return {
+        id: gallery.id,
+        slug: gallery.slug,
+        title: gallery.title,
+        description: gallery.description,
+        coverImage: cover.url ?? gallery.coverImage,
+        coverImageBucket: cover.bucket,
+        coverImageObject: cover.objectName,
+        isPublic: gallery.isPublic,
+        owner: gallery.owner,
+        createdAt: gallery.createdAt,
+        updatedAt: gallery.updatedAt,
+        entries: gallery.entries.map((entry) => {
+          const modelStorage = entry.asset ? resolveStorageLocation(entry.asset.storagePath) : null;
+          const modelPreview = entry.asset ? resolveStorageLocation(entry.asset.previewImage) : null;
+          const imageStorage = entry.image ? resolveStorageLocation(entry.image.storagePath) : null;
+
+          return {
+            id: entry.id,
+            position: entry.position,
+            note: entry.note,
+            modelAsset: entry.asset
+              ? {
+                  ...entry.asset,
+                  storagePath: modelStorage?.url ?? entry.asset.storagePath,
+                  storageBucket: modelStorage?.bucket ?? null,
+                  storageObject: modelStorage?.objectName ?? null,
+                  previewImage: modelPreview?.url ?? entry.asset.previewImage,
+                  previewImageBucket: modelPreview?.bucket ?? null,
+                  previewImageObject: modelPreview?.objectName ?? null,
+                  tags: entry.asset.tags.map(({ tag }) => tag),
+                }
+              : null,
+            imageAsset: entry.image
+              ? {
+                  ...entry.image,
+                  storagePath: imageStorage?.url ?? entry.image.storagePath,
+                  storageBucket: imageStorage?.bucket ?? null,
+                  storageObject: imageStorage?.objectName ?? null,
+                  tags: entry.image.tags.map(({ tag }) => tag),
+                }
+              : null,
+          };
+        }),
+      };
+    });
 
     res.json(response);
   } catch (error) {

--- a/frontend/src/components/AssetCard.tsx
+++ b/frontend/src/components/AssetCard.tsx
@@ -37,11 +37,19 @@ export const AssetCard = ({ asset }: AssetCardProps) => {
       <p className="asset-card__description">{asset.description ?? 'Noch keine Beschreibung hinterlegt.'}</p>
       <dl className="asset-card__meta">
         <div>
-          <dt>Dateipfad</dt>
+          <dt>Storage</dt>
           <dd title={asset.storagePath} className="asset-card__mono">
-            {asset.storagePath}
+            <a href={asset.storagePath} target="_blank" rel="noopener noreferrer">
+              {asset.storageObject ?? asset.storagePath}
+            </a>
           </dd>
         </div>
+        {asset.storageBucket ? (
+          <div>
+            <dt>Bucket</dt>
+            <dd className="asset-card__mono">{asset.storageBucket}</dd>
+          </div>
+        ) : null}
         <div>
           <dt>Dateigröße</dt>
           <dd>{formatFileSize(asset.fileSize)}</dd>

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -46,6 +46,7 @@ const matchesSearch = (asset: ModelAsset, query: string) => {
     asset.description ?? '',
     asset.owner.displayName,
     asset.version,
+    asset.storageObject ?? asset.storagePath,
     ...asset.tags.map((tag) => tag.label),
   ]
     .map((entry) => normalize(entry))

--- a/frontend/src/components/UploadWizard.tsx
+++ b/frontend/src/components/UploadWizard.tsx
@@ -260,12 +260,23 @@ export const UploadWizard = ({ isOpen, onClose, onComplete }: UploadWizardProps)
       });
 
       setProgressValue(100);
+      const details = [
+        response.assetSlug ? `Asset: ${response.assetSlug}` : null,
+        response.gallerySlug ? `Galerie: ${response.gallerySlug}` : null,
+      ]
+        .filter(Boolean)
+        .join(' · ');
+
       const result: UploadWizardResult = {
         status: 'success',
         uploadId: response.uploadId,
         message:
           response.message ??
-          'Upload-Session erstellt. Die Analyse beginnt automatisch, sobald der Hintergrund-Worker verfügbar ist.',
+          `Upload abgeschlossen. ${
+            details.length > 0
+              ? `${details} stehen unmittelbar im Explorer bereit.`
+              : 'Dateien stehen unmittelbar im Explorer bereit.'
+          }`,
       };
       setSubmitResult(result);
       onComplete?.(result);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -25,6 +25,10 @@ interface CreateUploadDraftPayload {
 interface CreateUploadDraftResponse {
   uploadId?: string;
   message?: string;
+  assetId?: string;
+  assetSlug?: string;
+  imageId?: string;
+  gallerySlug?: string;
 }
 
 const apiBaseUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:4000';

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -13,7 +13,11 @@ export interface ModelAsset {
   fileSize?: number | null;
   checksum?: string | null;
   storagePath: string;
+  storageBucket?: string | null;
+  storageObject?: string | null;
   previewImage?: string | null;
+  previewImageBucket?: string | null;
+  previewImageObject?: string | null;
   metadata?: Record<string, unknown> | null;
   owner: {
     id: string;
@@ -40,6 +44,8 @@ export interface ImageAsset {
   dimensions?: { width: number; height: number };
   fileSize?: number | null;
   storagePath: string;
+  storageBucket?: string | null;
+  storageObject?: string | null;
   prompt?: string | null;
   negativePrompt?: string | null;
   metadata: ImageAssetMetadata;
@@ -62,6 +68,8 @@ export interface Gallery {
   title: string;
   description?: string | null;
   coverImage?: string | null;
+  coverImageBucket?: string | null;
+  coverImageObject?: string | null;
   isPublic: boolean;
   owner: {
     id: string;


### PR DESCRIPTION
## Summary
- store uploaded assets directly in MinIO, create model/image records and link galleries instantly
- expose storage metadata (public URLs, bucket/object keys) in assets/galleries API responses
- refresh frontend explorers to use the new storage fields and surface upload success context

## Testing
- npm run lint (backend)
- npm run build (backend)
- npm run lint (frontend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cc7afc70a883339af436e63f7320fd