### PR TITLE
Fix storage wildcard routing compatibility

### DIFF
--- a/ChangeLog/2025-09-18-37ed12b.md
+++ b/ChangeLog/2025-09-18-37ed12b.md
@@ -1,0 +1,12 @@
+# Änderungsbericht – 18.09.2025 (Commit 37ed12b)
+
+## Kontext
+- Eingehende Fehlermeldung: Express startete mit `TypeError: Missing parameter name at index 10: /:bucket/*` aufgrund des aktualisierten `path-to-regexp`-Parsers in Express 5.
+
+## Maßnahmen
+- Route `/api/storage/:bucket/:objectKey(*)` eingeführt, um die Wildcard mit einem benannten Parameter kompatibel zu halten und weiterhin verschachtelte Objektpfade zuzulassen.
+- Proxy-Handler angepasst, damit Dateinamen über den neuen Parameter `objectKey` ermittelt werden.
+- README-Highlight aktualisiert, sodass die dokumentierte Download-Route den tatsächlichen Endpunkt widerspiegelt.
+
+## Qualitätssicherung
+- `npm run lint` im Backend ausgeführt; TypeScript-Build scheiterte bereits vor der Änderung an einem bestehenden Prisma-Typkonflikt (`tx.uploadDraft`).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ den Upload- und Kuration-Workflow.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.
 - **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, Pagination und aktiven Filterhinweisen.
 - **Direkte MinIO-Ingests** – Uploads landen unmittelbar in den konfigurierten Buckets, werden automatisch mit Tags versehen und tauchen ohne Wartezeit in Explorer & Galerien auf.
-- **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:object` durch das Backend geproxied, damit Modell- und Bildassets trotz internem MinIO-Endpunkt erreichbar bleiben.
+- **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:objectKey` durch das Backend geproxied, damit Modell- und Bildassets trotz internem MinIO-Endpunkt erreichbar bleiben.
 
 ## Architekturüberblick
 

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -35,7 +35,7 @@ const sendBucketNotAllowed = (res: Response) => {
 
 export const storageRouter = Router();
 
-storageRouter.get('/:bucket/*', async (req: Request, res: Response, next: NextFunction) => {
+storageRouter.get('/:bucket/:objectKey(*)', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const bucket = req.params.bucket;
 
@@ -44,7 +44,7 @@ storageRouter.get('/:bucket/*', async (req: Request, res: Response, next: NextFu
       return;
     }
 
-    const objectName = toProxyObjectName(req.params[0]);
+    const objectName = toProxyObjectName(req.params.objectKey);
 
     if (!objectName) {
       sendNotFound(res);


### PR DESCRIPTION
## Summary
- fix the storage proxy route by naming the wildcard parameter so it works with Express 5's path-to-regexp parser
- update the README highlight to describe the corrected `/api/storage/:bucket/:objectKey` endpoint
- document the change with a dated changelog entry referencing commit 37ed12b

## Testing
- npm run lint *(fails: existing Prisma type error for `tx.uploadDraft` in src/routes/uploads.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cc85cc8b1083338472daef36513272