### PR TITLE
Fix storage proxy wildcard parameter handling

### DIFF
--- a/ChangeLog/2025-09-18-eedd315.md
+++ b/ChangeLog/2025-09-18-eedd315.md
@@ -1,0 +1,10 @@
+# Änderungsbericht – 18.09.2025 (Commit eedd315)
+
+## Kontext
+- Der Express-Router verweigerte verschachtelte Objektpfade, weil die Route `/api/storage/:bucket/:objectKey(*)` seit dem Upgrade auf Express 5 nicht mehr mit `path-to-regexp` kompatibel war.
+
+## Maßnahmen
+- Den Storage-Proxy auf `router.get('/:bucket/:objectKey(.*)', handler)` angepasst, damit `objectKey` wieder die vollständigen Objektpfade inklusive Schrägstrichen übernimmt.
+
+## Qualitätssicherung
+- `npm run lint` im Backend ausgeführt; der bestehende Build bricht weiterhin mit fehlenden Typdefinitionen für `multer`, `minio` und Prisma auf.

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -35,7 +35,7 @@ const sendBucketNotAllowed = (res: Response) => {
 
 export const storageRouter = Router();
 
-storageRouter.get('/:bucket/:objectKey(*)', async (req: Request, res: Response, next: NextFunction) => {
+storageRouter.get('/:bucket/:objectKey(.*)', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const bucket = req.params.bucket;
 


### PR DESCRIPTION
## Summary
- correct the storage proxy route to use the Express 5 compatible wildcard capture
- add a changelog entry documenting commit eedd315

## Testing
- npm run lint *(fails: missing type definitions for `multer`, `minio` and Prisma models in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8807435883339be119e6b0da4cf2