### PR TITLE
Fix storage route wildcard handling

### DIFF
--- a/ChangeLog/2025-09-19-commit-tbd.md
+++ b/ChangeLog/2025-09-19-commit-tbd.md
@@ -1,0 +1,8 @@
+# Änderungsbericht (Commit wird nach Merge ergänzt)
+
+## Zusammenfassung
+- Behebt den Storage-Proxyrouten-Pfad, damit Express 5 den Platzhalter akzeptiert.
+- Fügt eine gemeinsame Handler-Funktion für GET- und HEAD-Anfragen hinzu, um Wiederholungen zu vermeiden.
+
+## Details
+Die bisherige Route verwendete den Ausdruck `/:bucket/:objectKey(.*)`, der mit der in Express 5 verwendeten Version von `path-to-regexp` kollidierte. Dadurch schlug der Serverstart fehl. Die neue Variante `/:bucket/*` verarbeitet nun geschachtelte Objektpfade zuverlässig und leitet die erste Platzhaltervariable (`req.params[0]`) als Objekt-Key weiter. Zudem wird derselbe Handler sowohl für GET- als auch für HEAD-Anfragen verwendet. Der finale Commit-Hash wird nach dem Merge in den Dateinamen übertragen.

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -35,7 +35,7 @@ const sendBucketNotAllowed = (res: Response) => {
 
 export const storageRouter = Router();
 
-storageRouter.get('/:bucket/:objectKey(.*)', async (req: Request, res: Response, next: NextFunction) => {
+const handleObjectRequest = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const bucket = req.params.bucket;
 
@@ -44,7 +44,8 @@ storageRouter.get('/:bucket/:objectKey(.*)', async (req: Request, res: Response,
       return;
     }
 
-    const objectName = toProxyObjectName(req.params.objectKey);
+    const objectKeyParam = req.params[0];
+    const objectName = toProxyObjectName(objectKeyParam);
 
     if (!objectName) {
       sendNotFound(res);
@@ -104,4 +105,7 @@ storageRouter.get('/:bucket/:objectKey(.*)', async (req: Request, res: Response,
   } catch (error) {
     next(error);
   }
-});
+};
+
+storageRouter.get('/:bucket/*', handleObjectRequest);
+storageRouter.head('/:bucket/*', handleObjectRequest);


### PR DESCRIPTION
## Summary
- adjust the storage proxy route to use an Express 5 compatible wildcard pattern and centralize request handling
- document the change in the dated changelog entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd3c3ff39c8333ad3518f19dae4fa1