### PR TITLE
Fix storage wildcard routing for MinIO proxy

### DIFF
--- a/ChangeLog/2025-09-19-e59b9b2.md
+++ b/ChangeLog/2025-09-19-e59b9b2.md
@@ -1,0 +1,15 @@
+# Änderungsbericht – 19.09.2025 (Commit e59b9b2)
+
+## Überblick
+- Fehleranalyse der Storage-Routen: Pfad-Muster `/api/storage/:bucket/*` führte durch `path-to-regexp` zu einem Startfehler.
+- Routen-Definitionen und Dokumentation so angepasst, dass Wildcard-Pfade zuverlässig verarbeitet werden.
+
+## Backend
+- Storage-Router auf benannte Wildcard-Parameter (`:objectPath(*)`) umgestellt, damit Express 5 keine `Missing parameter name`-Ausnahme mehr wirft.
+- Fallback auf `req.params[0]` beibehalten, um inkompatible Laufzeitumgebungen weiterhin zu unterstützen.
+
+## Dokumentation
+- README-Einträge zu den Storage-Endpunkten auf den neuen Parameternamen `:objectPath` aktualisiert, damit Setup-Teams korrekte Beispiele erhalten.
+
+## Tests
+- `npm run lint` im Backend ausgeführt, um sicherzustellen, dass der TypeScript-Build weiterhin fehlerfrei bleibt.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ den Upload- und Kuration-Workflow.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.
 - **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, Pagination und aktiven Filterhinweisen.
 - **Direkte MinIO-Ingests** – Uploads landen unmittelbar in den konfigurierten Buckets, werden automatisch mit Tags versehen und tauchen ohne Wartezeit in Explorer & Galerien auf.
-- **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:objectKey` durch das Backend geproxied, damit Modell- und Bildassets trotz internem MinIO-Endpunkt erreichbar bleiben.
+- **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:objectPath` durch das Backend geproxied, damit Modell- und Bildassets trotz internem MinIO-Endpunkt erreichbar bleiben.
 
 ## Architekturüberblick
 
@@ -140,7 +140,7 @@ Der Upload-Endpunkt validiert pro Request bis zu **12 Dateien** und reagiert mit
 - `GET /api/assets/models` – LoRA-Assets inkl. Owner, Tags, Metadaten.
 - `GET /api/assets/images` – Bild-Assets (Prompt, Modelldaten, Tags).
 - `GET /api/galleries` – Kuratierte Galerien mit zugehörigen Assets & Bildern.
-- `GET /api/storage/:bucket/:objectKey` – Proxied-Dateizugriff für MinIO-Objekte.
+- `GET /api/storage/:bucket/:objectPath` – Proxied-Dateizugriff für MinIO-Objekte.
 - `POST /api/uploads` – Legt eine UploadDraft-Session an, prüft Limits & Validierung und plant Dateien für die Analyse-Queue ein.
 
 ## Datenmodell-Highlights
@@ -170,7 +170,7 @@ Weitere Schritte umfassen Upload-Flows, Review-Prozesse und erweiterte Filter-/S
   - Existiert bereits ein Container, kannst du ihn direkt weiterverwenden oder komfortabel neu provisionieren lassen.
 - Portainer CE lässt sich im selben Schritt (optional) bereitstellen und bietet dir ein Dashboard für MinIO und weitere Container.
 
-Da MinIO in vielen Setups nur intern erreichbar ist, übernimmt das Backend das Ausliefern der Dateien. Über den neuen Proxy-Endpunkt `/api/storage/:bucket/:objectKey` werden Content-Type, Dateigröße sowie Dateiname korrekt gesetzt, damit Downloads und Inline-Previews im Frontend zuverlässig funktionieren.
+Da MinIO in vielen Setups nur intern erreichbar ist, übernimmt das Backend das Ausliefern der Dateien. Über den neuen Proxy-Endpunkt `/api/storage/:bucket/:objectPath` werden Content-Type, Dateigröße sowie Dateiname korrekt gesetzt, damit Downloads und Inline-Previews im Frontend zuverlässig funktionieren.
 
 ## Rollback & Bereinigung
 

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -44,7 +44,7 @@ const handleObjectRequest = async (req: Request, res: Response, next: NextFuncti
       return;
     }
 
-    const objectKeyParam = req.params[0];
+    const objectKeyParam = req.params.objectPath ?? req.params[0];
     const objectName = toProxyObjectName(objectKeyParam);
 
     if (!objectName) {
@@ -107,5 +107,5 @@ const handleObjectRequest = async (req: Request, res: Response, next: NextFuncti
   }
 };
 
-storageRouter.get('/:bucket/*', handleObjectRequest);
-storageRouter.head('/:bucket/*', handleObjectRequest);
+storageRouter.get('/:bucket/:objectPath(*)', handleObjectRequest);
+storageRouter.head('/:bucket/:objectPath(*)', handleObjectRequest);


### PR DESCRIPTION
## Summary
- update the storage proxy router to use a named wildcard parameter so Express no longer throws a `path-to-regexp` error
- refresh the README to document the new `:objectPath` wildcard parameter for storage requests
- capture the change in the dated changelog entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd41850594833388bfc55cce53db11