### PR TITLE
Refactor storage uploads to use ID-mapped MinIO objects

### DIFF
--- a/ChangeLog/2025-09-19-e78ced6.md
+++ b/ChangeLog/2025-09-19-e78ced6.md
@@ -1,0 +1,16 @@
+# Change Report – 2025-09-19
+
+## Commit
+- Hash: `e78ced6`
+- Message: Refactor storage to use ID mapped objects
+
+## Übersicht
+- MinIO-Downloads laufen nun ausschließlich über Objekt-IDs; eine neue Tabelle `StorageObject` übernimmt die Namensauflösung und Metadatenpflege.
+- Uploads vergeben für jede Datei eindeutige UUIDs, speichern diese als S3-Key und legen begleitende StorageObject-Einträge an.
+- Seeds & Migrationen wurden erweitert, damit Demo-Daten und künftige Deployments automatisch gültige StorageObject-Datensätze erzeugen.
+- README aktualisiert: Dokumentation des ID-basierten Storage-Proxys, neue API-Signatur und Beschreibung der Datenbankrolle von `StorageObject`.
+
+## Technische Details
+- Prisma-Migration `20250919120710_storage_object_ids` erstellt die Tabelle samt Unique-Index auf (`bucket`, `objectName`).
+- Storage-Router löst `/:bucket/:objectId`-Requests über Prisma auf, setzt Content-Disposition anhand des Originalnamens und nutzt persistierte Größen & MIME-Typen.
+- Upload-Pipeline schreibt `StorageObject`-Datensätze innerhalb der bestehenden Transaktion und legt UploadDraft-JSON mit referenzierten IDs ab.

--- a/backend/prisma/migrations/20250919120710_storage_object_ids/migration.sql
+++ b/backend/prisma/migrations/20250919120710_storage_object_ids/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "StorageObject" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "bucket" TEXT NOT NULL,
+    "objectName" TEXT NOT NULL,
+    "originalName" TEXT,
+    "contentType" TEXT,
+    "size" BIGINT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StorageObject_bucket_objectName_key" ON "StorageObject"("bucket", "objectName");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -120,6 +120,19 @@ model AssetTag {
   @@id([assetId, tagId])
 }
 
+model StorageObject {
+  id           String   @id
+  bucket       String
+  objectName   String
+  originalName String?
+  contentType  String?
+  size         BigInt?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@unique([bucket, objectName])
+}
+
 model UploadDraft {
   id            String   @id @default(cuid())
   assetType     String


### PR DESCRIPTION
## Summary
- add a dedicated `StorageObject` model plus migration and seed helpers to persist MinIO object metadata
- switch the storage proxy to resolve `/:bucket/:objectId` via Prisma and surface original filenames and content headers
- update the upload pipeline, documentation, and changelog for the new ID-based object naming flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd43b0eaf483338471ffe0568bb7fb