### PR TITLE
Refactor UI with service status dashboard

### DIFF
--- a/ChangeLog/20250919-bb636b9.md
+++ b/ChangeLog/20250919-bb636b9.md
@@ -1,0 +1,9 @@
+# Changelog 20250919
+
+## Commit bb636b9
+
+- Überarbeitete Frontend-Shell mit permanenter Sidebar-Navigation (Home, Models, Images).
+- Neuer Service-Status für Frontend, Backend und MinIO inklusive Backend-Endpunkt `/api/meta/status`.
+- Startseite zeigt jüngste Modelle und Bilder im Kachel-Layout.
+- Separater Image-Galerie-Explorer ergänzt bestehende Galerie-Ansichten.
+- README aktualisiert, um neue Struktur und Bedienung zu dokumentieren.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ den Upload- und Kuration-Workflow.
 
 ## Highlights
 
+- **Dashboard-Navigation** – Linke Seitenleiste mit direkter Umschaltung zwischen Home, Models und Images sowie Live-Service-Status für Frontend, Backend und MinIO.
 - **Upload-Wizard** – dreistufiger Assistent für Basisdaten, Dateiupload & Review inklusive Validierungen, Drag & Drop sowie Rückmeldung aus dem produktiven Upload-Endpunkt (`POST /api/uploads`).
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.
@@ -114,16 +115,15 @@ Standard-Ports:
 
 ## Frontend-Erlebnis
 
-Der aktuelle Prototyp setzt auf ein produktionsnahes Panel mit Echtzeitdaten und hochwertiger UI:
+Der aktuelle Prototyp fokussiert sich auf einen klaren Kontrollraum mit Service-Transparenz und datengetriebenen Explorern:
 
-- **Produktionsstartseite** – Sticky-Topbar mit Statusindikator, Hero-Layout samt Pipeline-Karte, Trust-Metriken und CTA-Panels für sofortige Aktionen.
-- **Upload-Wizard** – Start aus Hero, Topbar oder LoRA-Explorer, validiert Pflichtangaben, verwaltet Tag-Chips, Drag-and-Drop-Dateien und übergibt an den realen Upload-Endpunkt inklusive Server-Feedback.
-- **LoRA-Datenbank** – Volltextsuche, Tag- und Typ-Filter, Dateigrößen-Buckets sowie Kurator:innen-Auswahl. Ein Lazy-Loading reduziert das Rendering bei mehr als 100.000 Assets auf handliche Batches.
-- **Galerie-Explorer** – Sichtbarkeitsumschalter, Inhaltstyp-Filter (Bilder, LoRAs, leere Galerien) und Sortierungen nach Aktualität oder Umfang. Ein Vorschauraster zeigt die ersten Einträge jeder Galerie.
-- **Filter-Feedback** – Aktive Filter werden als Badges visualisiert und lassen sich einzeln oder gesammelt zurücksetzen, um den Workflow transparent zu halten.
+- **Neue Shell** – Ein dauerhaft sichtbares Sidebar-Layout bündelt die Hauptnavigation (Home, Models, Images) und zeigt den Status von Frontend, Backend und MinIO auf einen Blick.
+- **Home-Dashboard** – Kachel-Layout mit den neuesten Modellen und Bildern inklusive Kurator:innen, Versionen, Prompts und Tag-Highlights.
+- **Models** – Der ausgebaute Model Explorer bleibt Dreh- und Angelpunkt für LoRA-Recherchen mit Volltext, Typ- und Größenfiltern sowie Lazy-Loading.
+- **Images** – Die Bildgalerie kombiniert Volltextsuche, Sortierung und Tag-Anrisse mit dem bestehenden Galerie-Explorer für kuratierte Sets.
+- **Upload-Wizard** – Jederzeit erreichbar über die Shell; validiert Eingaben, verwaltet Datei-Drops und liefert unmittelbares Backend-Feedback.
 
-Die Filterleisten nutzen ausschließlich clientseitige Daten und können ohne zusätzliche Servercalls auf große Resultsets
-reagieren.
+Die Explorer-Filter arbeiten vollständig clientseitig und reagieren selbst auf große Datenmengen ohne zusätzliche Server-Requests.
 
 ### Upload-Pipeline & Backend
 

--- a/backend/src/routes/meta.ts
+++ b/backend/src/routes/meta.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
 import { prisma } from '../lib/prisma';
+import { storageBuckets, storageClient } from '../lib/storage';
 
 export const metaRouter = Router();
 
@@ -18,6 +19,46 @@ metaRouter.get('/stats', async (_req, res, next) => {
       imageCount,
       galleryCount,
       tagCount,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+metaRouter.get('/status', async (_req, res, next) => {
+  try {
+    const uniqueBuckets = Array.from(new Set(Object.values(storageBuckets)));
+
+    let minioStatus: 'online' | 'offline' | 'degraded' = 'online';
+    let minioMessage = 'MinIO Storage verbunden.';
+
+    for (const bucket of uniqueBuckets) {
+      try {
+        const exists = await storageClient.bucketExists(bucket);
+        if (!exists) {
+          minioStatus = 'degraded';
+          minioMessage = `Bucket "${bucket}" wurde nicht gefunden.`;
+          break;
+        }
+      } catch (error) {
+        minioStatus = 'offline';
+        minioMessage = `Keine Verbindung zu MinIO möglich: ${(error as Error).message}`;
+        break;
+      }
+    }
+
+    res.json({
+      timestamp: new Date().toISOString(),
+      services: {
+        backend: {
+          status: 'online' as const,
+          message: 'API erreichbar.',
+        },
+        minio: {
+          status: minioStatus,
+          message: minioMessage,
+        },
+      },
     });
   } catch (error) {
     next(error);

--- a/frontend/src/components/ImageGallery.tsx
+++ b/frontend/src/components/ImageGallery.tsx
@@ -1,0 +1,184 @@
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+
+import type { ImageAsset } from '../types/api';
+
+import { resolveStorageUrl } from '../lib/storage';
+
+interface ImageGalleryProps {
+  images: ImageAsset[];
+  isLoading: boolean;
+}
+
+type SortOption = 'recent' | 'alpha' | 'size-desc' | 'size-asc';
+
+const IMAGE_BATCH_SIZE = 24;
+
+const normalize = (value?: string | null) => value?.toLowerCase().normalize('NFKD') ?? '';
+
+const matchesSearch = (image: ImageAsset, query: string) => {
+  if (!query) return true;
+
+  const haystack = [
+    image.title,
+    image.prompt ?? '',
+    image.negativePrompt ?? '',
+    image.metadata.model ?? '',
+    image.metadata.sampler ?? '',
+    image.metadata.seed ?? '',
+    ...image.tags.map((tag) => tag.label ?? ''),
+  ]
+    .map((entry) => normalize(entry))
+    .join(' ');
+
+  return haystack.includes(query);
+};
+
+const formatDimensions = (image: ImageAsset) => {
+  if (!image.dimensions) {
+    return 'Unbekannt';
+  }
+
+  return `${image.dimensions.width} × ${image.dimensions.height}`;
+};
+
+const formatDate = (value: string) =>
+  new Date(value).toLocaleDateString('de-DE', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+export const ImageGallery = ({ images, isLoading }: ImageGalleryProps) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sortOption, setSortOption] = useState<SortOption>('recent');
+  const [visibleLimit, setVisibleLimit] = useState(IMAGE_BATCH_SIZE);
+
+  const deferredSearch = useDeferredValue(searchTerm);
+  const normalizedQuery = normalize(deferredSearch.trim());
+
+  const filteredImages = useMemo(() => {
+    const filtered = images.filter((image) => matchesSearch(image, normalizedQuery));
+
+    const sorters: Record<SortOption, (a: ImageAsset, b: ImageAsset) => number> = {
+      recent: (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      alpha: (a, b) => a.title.localeCompare(b.title, 'de'),
+      'size-desc': (a, b) => (b.fileSize ?? 0) - (a.fileSize ?? 0),
+      'size-asc': (a, b) => (a.fileSize ?? Number.POSITIVE_INFINITY) - (b.fileSize ?? Number.POSITIVE_INFINITY),
+    };
+
+    return filtered.sort(sorters[sortOption]);
+  }, [images, normalizedQuery, sortOption]);
+
+  useEffect(() => {
+    setVisibleLimit(IMAGE_BATCH_SIZE);
+  }, [normalizedQuery, sortOption]);
+
+  const visibleImages = useMemo(() => filteredImages.slice(0, visibleLimit), [filteredImages, visibleLimit]);
+  const remainingCount = filteredImages.length - visibleImages.length;
+
+  return (
+    <section className="panel">
+      <header className="panel__header">
+        <div>
+          <h2 className="panel__title">Image-Galerie</h2>
+          <p className="panel__subtitle">
+            Durchsuche Renderings, Prompt-Varianten und Referenzen. Titel, Prompt-Details und Model-Informationen werden in die
+            Volltextsuche einbezogen.
+          </p>
+        </div>
+      </header>
+
+      <div className="filter-toolbar" aria-label="Filter für Bilder">
+        <div className="filter-toolbar__row">
+          <label className="filter-toolbar__search">
+            <span className="sr-only">Bilder durchsuchen</span>
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Titel, Prompt oder Tags durchsuchen"
+              disabled={isLoading && images.length === 0}
+            />
+          </label>
+
+          <label className="filter-toolbar__control">
+            <span>Sortierung</span>
+            <select value={sortOption} onChange={(event) => setSortOption(event.target.value as SortOption)} className="filter-select">
+              <option value="recent">Neueste zuerst</option>
+              <option value="alpha">Titel · A → Z</option>
+              <option value="size-desc">Dateigröße · Groß → Klein</option>
+              <option value="size-asc">Dateigröße · Klein → Groß</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className="result-info" role="status">
+        {isLoading && images.length === 0
+          ? 'Lade Bilder …'
+          : `Zeigt ${visibleImages.length} von ${filteredImages.length} Bildern`}
+      </div>
+
+      <div className="image-gallery__grid">
+        {isLoading && images.length === 0
+          ? Array.from({ length: 8 }).map((_, index) => <div key={index} className="skeleton skeleton--card" />)
+          : visibleImages.map((image) => {
+              const imageUrl =
+                resolveStorageUrl(image.storagePath, image.storageBucket, image.storageObject) ?? image.storagePath;
+              return (
+                <article key={image.id} className="image-card">
+                  <div className="image-card__media">
+                    {imageUrl ? (
+                      <img src={imageUrl} alt={image.title} loading="lazy" />
+                    ) : (
+                      <span className="image-card__placeholder">Kein Vorschaubild verfügbar</span>
+                    )}
+                  </div>
+                  <div className="image-card__body">
+                    <header className="image-card__header">
+                      <h3 className="image-card__title">{image.title}</h3>
+                      <span className="image-card__timestamp">{formatDate(image.updatedAt)}</span>
+                    </header>
+                    <p className="image-card__prompt">{image.prompt ?? 'Kein Prompt hinterlegt.'}</p>
+                    <dl className="image-card__meta">
+                      <div>
+                        <dt>Dimensions</dt>
+                        <dd>{formatDimensions(image)}</dd>
+                      </div>
+                      <div>
+                        <dt>Model</dt>
+                        <dd>{image.metadata.model ?? 'Unbekannt'}</dd>
+                      </div>
+                      <div>
+                        <dt>Sampler</dt>
+                        <dd>{image.metadata.sampler ?? '–'}</dd>
+                      </div>
+                    </dl>
+                    {image.tags.length > 0 ? (
+                      <ul className="image-card__tags">
+                        {image.tags.slice(0, 6).map((tag) => (
+                          <li key={tag.id}>#{tag.label}</li>
+                        ))}
+                        {image.tags.length > 6 ? <li>+{image.tags.length - 6}</li> : null}
+                      </ul>
+                    ) : null}
+                  </div>
+                </article>
+              );
+            })}
+      </div>
+
+      {!isLoading && filteredImages.length === 0 ? (
+        <p className="panel__empty">Keine Bilder entsprechen der aktuellen Suche.</p>
+      ) : null}
+
+      {!isLoading && remainingCount > 0 ? (
+        <div className="panel__footer">
+          <button type="button" className="panel__action panel__action--ghost" onClick={() => setVisibleLimit((current) => current + IMAGE_BATCH_SIZE)}>
+            Weitere {Math.min(IMAGE_BATCH_SIZE, remainingCount)} Bilder laden
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,6 +32,536 @@ body {
   gap: 3rem;
 }
 
+.layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-height: 100vh;
+  gap: 0;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  padding: 2.5rem 2rem;
+  min-height: 100vh;
+  background: rgba(2, 6, 23, 0.82);
+  border-right: 1px solid rgba(30, 64, 175, 0.25);
+  box-shadow: 8px 0 24px rgba(15, 23, 42, 0.35);
+}
+
+.sidebar__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.sidebar__logo {
+  font-size: 1.35rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #f8fafc;
+}
+
+.sidebar__tagline {
+  font-size: 0.9rem;
+  color: rgba(191, 219, 254, 0.7);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sidebar__nav-button {
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  color: rgba(226, 232, 240, 0.85);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  text-align: left;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.sidebar__nav-button:hover,
+.sidebar__nav-button:focus-visible {
+  transform: translateX(2px);
+  border-color: rgba(96, 165, 250, 0.45);
+  color: #f8fafc;
+}
+
+.sidebar__nav-button--active {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.55), rgba(14, 165, 233, 0.4));
+  color: #0f172a;
+  border-color: transparent;
+  box-shadow: 0 18px 38px rgba(37, 99, 235, 0.3);
+}
+
+.sidebar__status {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sidebar__status h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.sidebar__status-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sidebar__status-item {
+  padding: 1rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.sidebar__status-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-weight: 500;
+  color: #f8fafc;
+}
+
+.sidebar__status-item p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 92px;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+
+.status-pill--online {
+  background: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: rgba(187, 247, 208, 0.95);
+}
+
+.status-pill--offline {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.35);
+  color: rgba(254, 226, 226, 0.92);
+}
+
+.status-pill--degraded {
+  background: rgba(234, 179, 8, 0.18);
+  border-color: rgba(234, 179, 8, 0.35);
+  color: rgba(254, 243, 199, 0.9);
+}
+
+.status-pill--unknown {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.content__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 3rem 4rem;
+}
+
+.content__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.content__title {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.content__subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 1rem;
+  color: rgba(203, 213, 225, 0.78);
+  max-width: 42rem;
+}
+
+.content__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.content__action {
+  border: 1px solid rgba(94, 234, 212, 0.3);
+  background: rgba(15, 23, 42, 0.85);
+  color: rgba(226, 232, 240, 0.88);
+  padding: 0.6rem 1.15rem;
+  border-radius: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.content__action:hover,
+.content__action:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(94, 234, 212, 0.55);
+  color: #f8fafc;
+}
+
+.content__action--primary {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.75), rgba(20, 184, 166, 0.7));
+  border-color: transparent;
+  color: #0f172a;
+  box-shadow: 0 20px 38px rgba(59, 130, 246, 0.35);
+}
+
+.content__alert {
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  background: rgba(127, 29, 29, 0.25);
+  color: rgba(254, 226, 226, 0.95);
+  font-size: 0.95rem;
+}
+
+.content__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.home-grid {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.home-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.home-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.home-section__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.home-section__header p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(203, 213, 225, 0.75);
+}
+
+.tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-radius: 20px;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  overflow: hidden;
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.4);
+}
+
+.tile__media {
+  position: relative;
+  padding-bottom: 60%;
+  background: rgba(15, 23, 42, 0.8);
+  overflow: hidden;
+}
+
+.tile__media img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(1.1);
+}
+
+.tile__placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.7);
+}
+
+.tile__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.4rem;
+}
+
+.tile__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.tile__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.tile__meta {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.tile__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.78);
+}
+
+.tile__details {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.85rem;
+}
+
+.tile__details div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.tile__details dt {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.tile__details dd {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.tile__tags {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: rgba(125, 211, 252, 0.9);
+}
+
+.empty-state {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.image-gallery__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.image-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 20px;
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+}
+
+.image-card__media {
+  position: relative;
+  padding-bottom: 62%;
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.75);
+}
+
+.image-card__media img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.image-card__placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.image-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.image-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.image-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.image-card__timestamp {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.image-card__prompt {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.78);
+}
+
+.image-card__meta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.image-card__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.image-card__meta dt {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.image-card__meta dd {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.image-card__tags {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  font-size: 0.75rem;
+  color: rgba(125, 211, 252, 0.9);
+}
+
+@media (max-width: 1100px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: relative;
+    min-height: auto;
+    border-right: none;
+    border-bottom: 1px solid rgba(30, 64, 175, 0.35);
+    box-shadow: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .content__inner {
+    padding: 2.5rem 1.75rem 3rem;
+  }
+
+  .tile-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .image-gallery__grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
 .topbar {
   position: sticky;
   top: 2rem;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Gallery, MetaStats, ModelAsset } from '../types/api';
+import type { Gallery, ImageAsset, MetaStats, ModelAsset, ServiceStatusResponse } from '../types/api';
 
 import { buildApiUrl } from '../config';
 
@@ -115,5 +115,7 @@ export const api = {
   getStats: () => request<MetaStats>('/api/meta/stats'),
   getModelAssets: () => request<ModelAsset[]>('/api/assets/models'),
   getGalleries: () => request<Gallery[]>('/api/galleries'),
+  getImageAssets: () => request<ImageAsset[]>('/api/assets/images'),
+  getServiceStatus: () => request<ServiceStatusResponse>('/api/meta/status'),
   createUploadDraft: postUploadDraft,
 };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -87,3 +87,18 @@ export interface MetaStats {
   galleryCount: number;
   tagCount: number;
 }
+
+export type ServiceHealthStatus = 'online' | 'offline' | 'degraded';
+
+export interface ServiceStatusDetails {
+  status: ServiceHealthStatus;
+  message?: string | null;
+}
+
+export interface ServiceStatusResponse {
+  timestamp: string;
+  services: {
+    backend: ServiceStatusDetails;
+    minio: ServiceStatusDetails;
+  };
+}


### PR DESCRIPTION
## Summary
- add `/api/meta/status` to expose backend and MinIO availability
- redesign the frontend shell with sidebar navigation, service indicators, and a home dashboard with model/image tiles
- extend the Images view with a dedicated gallery component and document the new UX, including a changelog entry

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cd4b0d385c8333a443ac4cc5ceb4d4