### PR TITLE
Add gallery upload flow with multi-image support

### DIFF
--- a/ChangeLog/2025-09-19-ecb521e.md
+++ b/ChangeLog/2025-09-19-ecb521e.md
@@ -1,0 +1,10 @@
+# Changelog 2025-09-19 – Commit ecb521e
+
+## Überblick
+- Neues Galerie-Upload-Erlebnis mit eigenem Wizard, Mehrfachauswahl, Limit-Hinweisen und Bild-spezifischen Validierungen.
+- Backend-Uploads akzeptieren jetzt Multi-Bild-Drafts, legen für jede Datei Assets/Galerieeinträge an und liefern kontextsensitive Antworten.
+- Galerie-Explorer bindet den neuen Entwurfs-Button an, App verwaltet getrennte Wizard-Modi und aktualisiert Toast-Handling.
+- README wurde um den Galerie-Entwurf sowie den erweiterten Wizard-Modus ergänzt.
+
+## Details
+Der Galerie-Wizard nutzt denselben Drei-Schritte-Ablauf wie der bestehende Upload-Assistent, zeigt jedoch bildspezifische Texte, Upload-Limits (12 Dateien, 2 GB) und erzwingt Bild-Formate im Galerie-Kontext. Die Backend-Routen speichern jede Bilddatei als Asset samt Galerieeintrag, aktualisieren Cover und liefern die Anzahl importierter Bilder zurück. Das Frontend unterscheidet jetzt zwischen Asset- und Galerie-Uploads, bietet eine neue Limit-Hilfestellung und ruft den Galerie-Wizard direkt aus dem Explorer heraus auf. Dokumentation und API-Client spiegeln die neuen Parameter wider.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ den Upload- und Kuration-Workflow.
 
 - **Dashboard-Navigation** – Linke Seitenleiste mit direkter Umschaltung zwischen Home, Models und Images sowie Live-Service-Status für Frontend, Backend und MinIO.
 - **Upload-Wizard** – dreistufiger Assistent für Basisdaten, Dateiupload & Review inklusive Validierungen, Drag & Drop sowie Rückmeldung aus dem produktiven Upload-Endpunkt (`POST /api/uploads`).
+- **Galerie-Entwürfe** – separater Bild-Upload aus dem Galerie-Explorer, Multi-Upload (bis 12 Dateien/2 GB) mit automatischer Galerie-Auswahl oder -Neuanlage.
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.
 - **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, Pagination und aktiven Filterhinweisen.
@@ -122,7 +123,7 @@ Der aktuelle Prototyp fokussiert sich auf einen klaren Kontrollraum mit Service-
 - **Home-Dashboard** – Kachel-Layout mit den neuesten Modellen und Bildern inklusive Kurator:innen, Versionen, Prompts und Tag-Highlights.
 - **Models** – Der ausgebaute Model Explorer bleibt Dreh- und Angelpunkt für LoRA-Recherchen mit Volltext, Typ- und Größenfiltern sowie Lazy-Loading.
 - **Images** – Die Bildgalerie kombiniert Volltextsuche, Sortierung und Tag-Anrisse mit kuratierten Alben samt Collage-Layout und Zoom-Lightbox.
-- **Upload-Wizard** – Jederzeit erreichbar über die Shell; validiert Eingaben, verwaltet Datei-Drops und liefert unmittelbares Backend-Feedback.
+- **Upload-Wizard** – Jederzeit erreichbar über die Shell; validiert Eingaben, verwaltet Datei-Drops und liefert unmittelbares Backend-Feedback – inklusive eigenem Galerie-Modus für Bildserien.
 
 Die Explorer-Filter arbeiten vollständig clientseitig und reagieren selbst auf große Datenmengen ohne zusätzliche Server-Requests.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,7 +69,8 @@ export const App = () => {
   const [galleries, setGalleries] = useState<Gallery[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [isUploadWizardOpen, setIsUploadWizardOpen] = useState(false);
+  const [isAssetUploadOpen, setIsAssetUploadOpen] = useState(false);
+  const [isGalleryUploadOpen, setIsGalleryUploadOpen] = useState(false);
   const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [serviceStatus, setServiceStatus] = useState<Record<ServiceStatusKey, ServiceIndicator>>(createInitialStatus);
 
@@ -273,7 +274,7 @@ export const App = () => {
         <AssetExplorer
           assets={assets}
           isLoading={isLoading}
-          onStartUpload={() => setIsUploadWizardOpen(true)}
+          onStartUpload={() => setIsAssetUploadOpen(true)}
         />
       );
     }
@@ -282,7 +283,11 @@ export const App = () => {
       return (
         <div className="content__stack">
           <ImageGallery images={images} isLoading={isLoading} />
-          <GalleryExplorer galleries={galleries} isLoading={isLoading} />
+          <GalleryExplorer
+            galleries={galleries}
+            isLoading={isLoading}
+            onStartGalleryDraft={() => setIsGalleryUploadOpen(true)}
+          />
         </div>
       );
     }
@@ -350,7 +355,7 @@ export const App = () => {
                 <button
                   type="button"
                   className="content__action content__action--primary"
-                  onClick={() => setIsUploadWizardOpen(true)}
+                  onClick={() => setIsAssetUploadOpen(true)}
                 >
                   Upload starten
                 </button>
@@ -365,8 +370,15 @@ export const App = () => {
       </div>
 
       <UploadWizard
-        isOpen={isUploadWizardOpen}
-        onClose={() => setIsUploadWizardOpen(false)}
+        mode="asset"
+        isOpen={isAssetUploadOpen}
+        onClose={() => setIsAssetUploadOpen(false)}
+        onComplete={handleWizardCompletion}
+      />
+      <UploadWizard
+        mode="gallery"
+        isOpen={isGalleryUploadOpen}
+        onClose={() => setIsGalleryUploadOpen(false)}
         onComplete={handleWizardCompletion}
       />
     </div>

--- a/frontend/src/components/GalleryExplorer.tsx
+++ b/frontend/src/components/GalleryExplorer.tsx
@@ -8,6 +8,7 @@ import { GalleryAlbum } from './GalleryAlbum';
 interface GalleryExplorerProps {
   galleries: Gallery[];
   isLoading: boolean;
+  onStartGalleryDraft: () => void;
 }
 
 type VisibilityFilter = 'all' | 'public' | 'private';
@@ -37,7 +38,7 @@ const matchesSearch = (gallery: Gallery, query: string) => {
 const galleryHasImage = (gallery: Gallery) => gallery.entries.some((entry) => Boolean(entry.imageAsset));
 const galleryHasModel = (gallery: Gallery) => gallery.entries.some((entry) => Boolean(entry.modelAsset));
 
-export const GalleryExplorer = ({ galleries, isLoading }: GalleryExplorerProps) => {
+export const GalleryExplorer = ({ galleries, isLoading, onStartGalleryDraft }: GalleryExplorerProps) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [visibility, setVisibility] = useState<VisibilityFilter>('all');
   const [entryFilter, setEntryFilter] = useState<EntryFilter>('all');
@@ -150,7 +151,9 @@ export const GalleryExplorer = ({ galleries, isLoading }: GalleryExplorerProps) 
             Sammlungen.
           </p>
         </div>
-        <button type="button" className="panel__action">Galerie-Entwurf starten</button>
+        <button type="button" className="panel__action" onClick={onStartGalleryDraft}>
+          Galerie-Entwurf starten
+        </button>
       </header>
 
       <div className="filter-toolbar" aria-label="Filter für Galerien">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,6 +14,7 @@ export class ApiError extends Error {
 
 interface CreateUploadDraftPayload {
   assetType: 'lora' | 'image';
+  context?: 'asset' | 'gallery';
   title: string;
   description?: string;
   visibility: 'private' | 'public';
@@ -30,7 +31,9 @@ interface CreateUploadDraftResponse {
   assetId?: string;
   assetSlug?: string;
   imageId?: string;
+  imageIds?: string[];
   gallerySlug?: string;
+  entryIds?: string[];
 }
 
 const request = async <T>(path: string): Promise<T> => {
@@ -67,6 +70,7 @@ const parseError = async (response: Response): Promise<never> => {
 const postUploadDraft = async (payload: CreateUploadDraftPayload) => {
   const formData = new FormData();
   formData.append('assetType', payload.assetType);
+  formData.append('context', payload.context ?? 'asset');
   formData.append('title', payload.title);
   formData.append('visibility', payload.visibility);
 

--- a/frontend/src/lib/uploadLimits.ts
+++ b/frontend/src/lib/uploadLimits.ts
@@ -1,0 +1,2 @@
+export const MAX_UPLOAD_FILES = 12;
+export const MAX_TOTAL_SIZE_BYTES = 2_147_483_648; // 2 GB


### PR DESCRIPTION
## Summary
- add a gallery-specific branch in the upload wizard with multi-upload UX, limit hints, and image-only validation
- extend the upload endpoint to create gallery entries for every uploaded image and expose counts in the response
- document the new gallery draft workflow and record the work in the dated changelog entry

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cd5602de148333b2d5c18e9d68687a