### PR TITLE
Handle missing image metadata in gallery views

### DIFF
--- a/ChangeLog/2025-09-19-commit-tbd-gallery-metadata.md
+++ b/ChangeLog/2025-09-19-commit-tbd-gallery-metadata.md
@@ -1,0 +1,18 @@
+# Änderungsbericht – 19.09.2025 (Commit TBD)
+
+## Überblick
+- Frontend robuster gegenüber fehlenden Bild-Metadaten gemacht, damit Galerien und Übersichten nicht mehr abstürzen.
+- README-Highlights um den Hinweis zur neuen Fehlertoleranz ergänzt.
+
+## Frontend
+- `ImageAsset`-Typ aktualisiert, sodass Metadaten optional vom Backend geliefert werden können.
+- Galerie-Alben und Bildlisten prüfen Metadaten-Felder konsequent per Optional-Chaining und halten Lightbox & Vorschauraster stabil.
+- Suche und Detail-Karten in der Image-Galerie berücksichtigen fehlende Metadata ohne Fehlermeldung.
+
+## Dokumentation
+- README um eine Kurznotiz zur robusten Metadatenanzeige erweitert, damit Betreiber*innen den Fix nachvollziehen können.
+
+## Tests
+- `npm run build` (Frontend)
+
+_Eintrag wird nach Release mit der finalen Commit-ID aktualisiert._

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ den Upload- und Kuration-Workflow.
 - **Direkte MinIO-Ingests** – Uploads landen unmittelbar in den konfigurierten Buckets, werden automatisch mit Tags versehen und tauchen ohne Wartezeit in Explorer & Galerien auf.
 - **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:objectId` durch das Backend geproxied; eine Datenbank-Tabelle ordnet die anonymisierten Objekt-IDs wieder den ursprünglichen Dateinamen zu.
 - **Galerie-Alben** – Collections zeigen mehrteilige Sets mit heroischen Vorschaubildern, Thumbnail-Leiste und Zoom-Lightbox für fokussierte Präsentationen.
+- **Robuste Metadatenanzeige** – Galerie- und Bildansichten bleiben stabil, selbst wenn Einträge ohne ausgefüllte Bild-Metadaten vom Backend geliefert werden.
 
 ## Architekturüberblick
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -214,11 +214,11 @@ export const App = () => {
           <dl className="tile__details">
             <div>
               <dt>Model</dt>
-              <dd>{image.metadata.model ?? 'Unbekannt'}</dd>
+              <dd>{image.metadata?.model ?? 'Unbekannt'}</dd>
             </div>
             <div>
               <dt>Sampler</dt>
-              <dd>{image.metadata.sampler ?? '–'}</dd>
+              <dd>{image.metadata?.sampler ?? '–'}</dd>
             </div>
           </dl>
           {image.tags.length > 0 ? (

--- a/frontend/src/components/GalleryAlbum.tsx
+++ b/frontend/src/components/GalleryAlbum.tsx
@@ -14,41 +14,41 @@ interface GalleryAlbumItem {
 }
 
 const buildAlbumItems = (gallery: Gallery): GalleryAlbumItem[] =>
-  gallery.entries
-    .map((entry) => {
-      if (entry.imageAsset) {
-        return {
-          id: entry.id,
-          type: 'image' as const,
-          title: entry.imageAsset.title,
-          subtitle: entry.note ?? entry.imageAsset.metadata.model ?? null,
-          description: entry.imageAsset.prompt ?? null,
-          src: resolveStorageUrl(
-            entry.imageAsset.storagePath,
-            entry.imageAsset.storageBucket,
-            entry.imageAsset.storageObject,
-          ),
-        } satisfies GalleryAlbumItem;
-      }
+  gallery.entries.reduce<GalleryAlbumItem[]>((items, entry) => {
+    if (entry.imageAsset) {
+      items.push({
+        id: entry.id,
+        type: 'image',
+        title: entry.imageAsset.title,
+        subtitle: entry.note ?? entry.imageAsset.metadata?.model ?? null,
+        description: entry.imageAsset.prompt ?? null,
+        src: resolveStorageUrl(
+          entry.imageAsset.storagePath,
+          entry.imageAsset.storageBucket,
+          entry.imageAsset.storageObject,
+        ),
+      });
+      return items;
+    }
 
-      if (entry.modelAsset) {
-        return {
-          id: entry.id,
-          type: 'model' as const,
-          title: entry.modelAsset.title,
-          subtitle: entry.modelAsset.version ? `Version ${entry.modelAsset.version}` : null,
-          description: entry.note ?? entry.modelAsset.description ?? null,
-          src: resolveStorageUrl(
-            entry.modelAsset.previewImage,
-            entry.modelAsset.previewImageBucket,
-            entry.modelAsset.previewImageObject,
-          ),
-        } satisfies GalleryAlbumItem;
-      }
+    if (entry.modelAsset) {
+      items.push({
+        id: entry.id,
+        type: 'model',
+        title: entry.modelAsset.title,
+        subtitle: entry.modelAsset.version ? `Version ${entry.modelAsset.version}` : null,
+        description: entry.note ?? entry.modelAsset.description ?? null,
+        src: resolveStorageUrl(
+          entry.modelAsset.previewImage,
+          entry.modelAsset.previewImageBucket,
+          entry.modelAsset.previewImageObject,
+        ),
+      });
+      return items;
+    }
 
-      return null;
-    })
-    .filter((item): item is GalleryAlbumItem => Boolean(item));
+    return items;
+  }, []);
 
 const COUNT_LABEL: Record<GalleryAlbumItem['type'], string> = {
   image: 'Bild',

--- a/frontend/src/components/ImageGallery.tsx
+++ b/frontend/src/components/ImageGallery.tsx
@@ -22,9 +22,9 @@ const matchesSearch = (image: ImageAsset, query: string) => {
     image.title,
     image.prompt ?? '',
     image.negativePrompt ?? '',
-    image.metadata.model ?? '',
-    image.metadata.sampler ?? '',
-    image.metadata.seed ?? '',
+    image.metadata?.model ?? '',
+    image.metadata?.sampler ?? '',
+    image.metadata?.seed ?? '',
     ...image.tags.map((tag) => tag.label ?? ''),
   ]
     .map((entry) => normalize(entry))
@@ -147,11 +147,11 @@ export const ImageGallery = ({ images, isLoading }: ImageGalleryProps) => {
                       </div>
                       <div>
                         <dt>Model</dt>
-                        <dd>{image.metadata.model ?? 'Unbekannt'}</dd>
+                        <dd>{image.metadata?.model ?? 'Unbekannt'}</dd>
                       </div>
                       <div>
                         <dt>Sampler</dt>
-                        <dd>{image.metadata.sampler ?? '–'}</dd>
+                        <dd>{image.metadata?.sampler ?? '–'}</dd>
                       </div>
                     </dl>
                     {image.tags.length > 0 ? (

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -48,7 +48,7 @@ export interface ImageAsset {
   storageObject?: string | null;
   prompt?: string | null;
   negativePrompt?: string | null;
-  metadata: ImageAssetMetadata;
+  metadata?: ImageAssetMetadata | null;
   tags: Tag[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- allow `ImageAsset` metadata to be optional and guard all gallery consumers against missing fields
- prevent the gallery album lightbox and image listings from crashing when metadata is absent
- update the highlights to mention the resilient metadata handling and document the change in the changelog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd5c8223b48333b4afb18b8adbd937