### PR TITLE
Implement authentication and admin tooling

### DIFF
--- a/ChangeLog/2025-09-19-commit-tbd-auth.md
+++ b/ChangeLog/2025-09-19-commit-tbd-auth.md
@@ -1,0 +1,17 @@
+# Änderungsbericht – VisionSuit
+
+## Kontext
+- Einführung einer vollständigen Authentifizierungs- und Administrationsschicht für VisionSuit.
+- Absicherung aller Upload- und Verwaltungsfunktionen gegen anonyme Nutzung.
+
+## Durchgeführte Arbeiten
+- Backend um JWT-Auth-Flow ergänzt (`/api/auth/login`, `/api/auth/me`), Passwort-Hashing integriert und Middleware für Auth/Role-Checks bereitgestellt.
+- Upload-, Asset- und Bild-Routen überarbeitet: Owner-Zuordnung erzwungen, CRUD-Operationen rollenbasiert abgesichert und Löschpfade inklusive Storage-Cleanup gehärtet.
+- Administrations-API für Benutzerverwaltung erstellt (Anlegen, Aktualisieren, Deaktivieren, Löschen) und CLI-Skript zum Provisionieren eines initialen Admin-Accounts hinzugefügt.
+- Frontend um Auth-Context, Login-Dialog, Admin-Dashboard und tokenbasierte Upload-Steuerung erweitert; Navigation und Layout für angemeldete Nutzer:innen optimiert.
+- Styling für Sidebar, Modals und Admin-Karten erweitert sowie API-Layer um Auth-/CRUD-Endpunkte ergänzt.
+- README modernisiert (Auth-Highlights, Admin-Skript, API-Übersicht) und Linting-Anpassungen vorgenommen.
+
+## Tests & Validierung
+- `npm run lint` im Backend (TypeScript) – Erfolgreich.
+- `npm run lint` im Frontend (ESLint) – Erfolgreich.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,17 +9,21 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.16.2",
+        "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "minio": "^8.0.6",
         "morgan": "^1.10.1",
         "multer": "^2.0.2",
         "zod": "^4.1.9"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
+        "@types/jsonwebtoken": "^9.0.7",
         "@types/morgan": "^1.9.10",
         "@types/multer": "^2.0.0",
         "@types/node": "^24.5.2",
@@ -190,6 +194,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -253,6 +264,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -269,6 +291,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/multer": {
       "version": "2.0.0",
@@ -460,6 +489,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -540,6 +575,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -900,6 +941,15 @@
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1556,10 +1606,95 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/make-error": {
@@ -2287,6 +2422,18 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,21 +11,26 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:studio": "prisma studio",
-    "seed": "ts-node --transpile-only prisma/seed.ts"
+    "seed": "ts-node --transpile-only prisma/seed.ts",
+    "create-admin": "ts-node --transpile-only scripts/createAdmin.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.16.2",
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "minio": "^8.0.6",
     "morgan": "^1.10.1",
     "multer": "^2.0.2",
     "zod": "^4.1.9"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/morgan": "^1.9.10",
     "@types/multer": "^2.0.0",
     "@types/node": "^24.5.2",

--- a/backend/prisma/migrations/20250919135347_add_authentication/migration.sql
+++ b/backend/prisma/migrations/20250919135347_add_authentication/migration.sql
@@ -1,0 +1,122 @@
+/*
+  Warnings:
+
+  - Added the required column `ownerId` to the `ImageAsset` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `ownerId` to the `UploadDraft` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_ImageAsset" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "width" INTEGER,
+    "height" INTEGER,
+    "fileSize" INTEGER,
+    "storagePath" TEXT NOT NULL,
+    "prompt" TEXT,
+    "negativePrompt" TEXT,
+    "seed" TEXT,
+    "model" TEXT,
+    "sampler" TEXT,
+    "cfgScale" REAL,
+    "steps" INTEGER,
+    "ownerId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ImageAsset_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_ImageAsset" ("cfgScale", "createdAt", "description", "fileSize", "height", "id", "model", "negativePrompt", "ownerId", "prompt", "sampler", "seed", "steps", "storagePath", "title", "updatedAt", "width")
+SELECT "cfgScale",
+       "createdAt",
+       "description",
+       "fileSize",
+       "height",
+       "id",
+       "model",
+       "negativePrompt",
+       (SELECT "id" FROM "User" ORDER BY "createdAt" ASC LIMIT 1),
+       "prompt",
+       "sampler",
+       "seed",
+       "steps",
+       "storagePath",
+       "title",
+       "updatedAt",
+       "width"
+FROM "ImageAsset";
+DROP TABLE "ImageAsset";
+ALTER TABLE "new_ImageAsset" RENAME TO "ImageAsset";
+CREATE UNIQUE INDEX "ImageAsset_storagePath_key" ON "ImageAsset"("storagePath");
+CREATE TABLE "new_UploadDraft" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "assetType" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "visibility" TEXT NOT NULL,
+    "category" TEXT,
+    "galleryMode" TEXT NOT NULL,
+    "targetGallery" TEXT,
+    "tags" JSONB NOT NULL,
+    "files" JSONB NOT NULL,
+    "fileCount" INTEGER NOT NULL,
+    "totalSize" BIGINT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'queued',
+    "ownerId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "UploadDraft_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_UploadDraft" ("assetType", "category", "createdAt", "description", "fileCount", "files", "galleryMode", "id", "ownerId", "status", "tags", "targetGallery", "title", "totalSize", "updatedAt", "visibility")
+SELECT "assetType",
+       "category",
+       "createdAt",
+       "description",
+       "fileCount",
+       "files",
+       "galleryMode",
+       "id",
+       (SELECT "id" FROM "User" ORDER BY "createdAt" ASC LIMIT 1),
+       "status",
+       "tags",
+       "targetGallery",
+       "title",
+       "totalSize",
+       "updatedAt",
+       "visibility"
+FROM "UploadDraft";
+DROP TABLE "UploadDraft";
+ALTER TABLE "new_UploadDraft" RENAME TO "UploadDraft";
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'CURATOR',
+    "bio" TEXT,
+    "avatarUrl" TEXT,
+    "passwordHash" TEXT NOT NULL DEFAULT '',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "lastLoginAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("avatarUrl", "bio", "createdAt", "displayName", "email", "id", "role", "passwordHash", "isActive", "lastLoginAt", "updatedAt")
+SELECT "avatarUrl",
+       "bio",
+       "createdAt",
+       "displayName",
+       "email",
+       "id",
+       "role",
+       '' AS "passwordHash",
+       true AS "isActive",
+       NULL AS "lastLoginAt",
+       "updatedAt"
+FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,10 +19,15 @@ model User {
   role        UserRole     @default(CURATOR)
   bio         String?
   avatarUrl   String?
+  passwordHash String      @default("")
+  isActive    Boolean      @default(true)
+  lastLoginAt DateTime?
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
   galleries   Gallery[]    @relation("GalleryOwner")
   assets      ModelAsset[] @relation("AssetOwner")
+  images      ImageAsset[] @relation("ImageOwner")
+  uploadDrafts UploadDraft[]
 }
 
 model Gallery {
@@ -75,6 +80,8 @@ model ImageAsset {
   steps          Int?
   tags           ImageTag[]
   galleries      GalleryEntry[] @relation("GalleryImage")
+  ownerId        String
+  owner          User           @relation("ImageOwner", fields: [ownerId], references: [id])
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
 }
@@ -147,6 +154,8 @@ model UploadDraft {
   fileCount     Int
   totalSize     BigInt
   status        String   @default("queued")
+  ownerId       String
+  owner         User     @relation(fields: [ownerId], references: [id])
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, UserRole } from '@prisma/client';
+import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
@@ -35,14 +36,18 @@ const ensureStorageObject = async (
 };
 
 const main = async () => {
+  const curatorPassword = await bcrypt.hash('curator123', 12);
+
   const curator = await prisma.user.upsert({
     where: { email: 'curator@visionsuit.local' },
-    update: {},
+    update: { passwordHash: curatorPassword, isActive: true },
     create: {
       email: 'curator@visionsuit.local',
       displayName: 'VisionSuit Curator',
       role: UserRole.CURATOR,
       bio: 'Kuratiert hochwertige KI-Galerien und Modell-Assets.',
+      passwordHash: curatorPassword,
+      isActive: true,
     },
   });
 
@@ -136,6 +141,7 @@ const main = async () => {
       sampler: 'DPM++ 2M',
       cfgScale: 7.5,
       steps: 30,
+      ownerId: curator.id,
       tags: {
         create: tags
           .filter((tag) => ['sci-fi', 'portrait', 'cinematic'].includes(tag.label))

--- a/backend/scripts/createAdmin.ts
+++ b/backend/scripts/createAdmin.ts
@@ -1,0 +1,106 @@
+import { PrismaClient, UserRole } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+import '../src/config';
+
+interface CliOptions {
+  email?: string;
+  password?: string;
+  name?: string;
+  bio?: string;
+}
+
+const parseArgs = (): CliOptions => {
+  const args = process.argv.slice(2);
+  const options: CliOptions = {};
+
+  for (const arg of args) {
+    const [key, ...rest] = arg.split('=');
+    const value = rest.join('=');
+
+    if (!key.startsWith('--')) {
+      continue;
+    }
+
+    const normalizedKey = key.slice(2);
+
+    switch (normalizedKey) {
+      case 'email':
+        options.email = value || undefined;
+        break;
+      case 'password':
+        options.password = value || undefined;
+        break;
+      case 'name':
+      case 'displayName':
+        options.name = value || undefined;
+        break;
+      case 'bio':
+        options.bio = value || undefined;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return options;
+};
+
+const prisma = new PrismaClient();
+
+const run = async () => {
+  const options = parseArgs();
+
+  if (!options.email) {
+    throw new Error('Missing required --email argument');
+  }
+
+  if (!options.password) {
+    throw new Error('Missing required --password argument');
+  }
+
+  const displayName = options.name?.trim();
+  if (!displayName) {
+    throw new Error('Missing required --name argument');
+  }
+
+  const email = options.email.trim().toLowerCase();
+  const passwordHash = await bcrypt.hash(options.password, 12);
+
+  const result = await prisma.user.upsert({
+    where: { email },
+    update: {
+      displayName,
+      passwordHash,
+      role: UserRole.ADMIN,
+      bio: options.bio ?? undefined,
+      isActive: true,
+    },
+    create: {
+      email,
+      displayName,
+      passwordHash,
+      role: UserRole.ADMIN,
+      bio: options.bio ?? undefined,
+      isActive: true,
+    },
+  });
+
+  // eslint-disable-next-line no-console
+  console.log('Admin account ready:', {
+    id: result.id,
+    email: result.email,
+    displayName: result.displayName,
+    role: result.role,
+  });
+};
+
+run()
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('[create-admin] Failed to provision admin:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -45,6 +45,24 @@ const requireString = (value: string | undefined, key: string, fallback?: string
   throw new Error(`Missing required configuration value for ${key}`);
 };
 
+const toExpiresIn = (value: string | undefined, fallback: string | number): string | number => {
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return fallback;
+  }
+
+  const numeric = Number.parseInt(trimmed, 10);
+  if (!Number.isNaN(numeric) && numeric >= 0) {
+    return numeric;
+  }
+
+  return trimmed;
+};
+
 const storageDriver = process.env.STORAGE_DRIVER ?? 'minio';
 
 if (storageDriver !== 'minio') {
@@ -70,6 +88,14 @@ export const appConfig = {
   host: process.env.HOST ?? '0.0.0.0',
   port: toNumber(process.env.PORT, 4000),
   databaseUrl: process.env.DATABASE_URL ?? 'file:./dev.db',
+  auth: {
+    jwtSecret: requireString(
+      process.env.AUTH_JWT_SECRET,
+      'AUTH_JWT_SECRET',
+      'visionsuit-dev-secret-change-me',
+    ),
+    tokenExpiresIn: toExpiresIn(process.env.AUTH_TOKEN_EXPIRES_IN, '12h'),
+  },
   storage: {
     driver: storageDriver,
     endpoint: minioHost,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import { appConfig } from './config';
 import { createApp } from './app';
 import { prisma } from './lib/prisma';
 import { initializeStorage } from './lib/storage';
+import './types/express';
 
 const start = async () => {
   try {

--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -1,0 +1,58 @@
+import bcrypt from 'bcryptjs';
+import jwt, { type Secret, type SignOptions } from 'jsonwebtoken';
+import type { User, UserRole } from '@prisma/client';
+
+import { appConfig } from '../config';
+
+export interface AuthTokenPayload {
+  sub: string;
+  role: UserRole;
+  displayName: string;
+  email: string;
+}
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  displayName: string;
+  role: UserRole;
+  bio?: string | null;
+  avatarUrl?: string | null;
+}
+
+export const hashPassword = (password: string) => bcrypt.hash(password, 12);
+
+export const verifyPassword = (password: string, passwordHash: string | null | undefined) => {
+  if (!passwordHash || passwordHash.length === 0) {
+    return Promise.resolve(false);
+  }
+
+  return bcrypt.compare(password, passwordHash);
+};
+
+export const createAccessToken = (payload: AuthTokenPayload) => {
+  const options = { expiresIn: appConfig.auth.tokenExpiresIn } as unknown as SignOptions;
+  return jwt.sign(payload, appConfig.auth.jwtSecret as Secret, options);
+};
+
+export const verifyAccessToken = (token: string): AuthTokenPayload => {
+  const decoded = jwt.verify(token, appConfig.auth.jwtSecret);
+  const normalized = typeof decoded === 'string' ? JSON.parse(decoded) : decoded;
+
+  const { sub, role, displayName, email } = normalized as Partial<AuthTokenPayload>;
+
+  if (!sub || !role || !displayName || !email) {
+    throw new Error('Invalid token payload');
+  }
+
+  return { sub, role, displayName, email };
+};
+
+export const toAuthUser = (user: Pick<User, 'id' | 'email' | 'displayName' | 'role' | 'bio' | 'avatarUrl'>): AuthenticatedUser => ({
+  id: user.id,
+  email: user.email,
+  displayName: user.displayName,
+  role: user.role,
+  bio: user.bio,
+  avatarUrl: user.avatarUrl,
+});

--- a/backend/src/lib/middleware/auth.ts
+++ b/backend/src/lib/middleware/auth.ts
@@ -1,0 +1,77 @@
+import type { NextFunction, Request, Response } from 'express';
+
+import { prisma } from '../prisma';
+import { toAuthUser, verifyAccessToken } from '../auth';
+
+const extractToken = (req: Request): string | null => {
+  const header = req.headers.authorization;
+  if (typeof header !== 'string') {
+    return null;
+  }
+
+  const trimmed = header.trim();
+  if (trimmed.toLowerCase().startsWith('bearer ')) {
+    return trimmed.slice(7).trim();
+  }
+
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const token = extractToken(req);
+    if (!token) {
+      res.status(401).json({ message: 'Authentication token missing.' });
+      return;
+    }
+
+    const payload = verifyAccessToken(token);
+    const user = await prisma.user.findUnique({
+      where: { id: payload.sub },
+      select: {
+        id: true,
+        email: true,
+        displayName: true,
+        role: true,
+        bio: true,
+        avatarUrl: true,
+        isActive: true,
+      },
+    });
+
+    if (!user || !user.isActive) {
+      res.status(401).json({ message: 'Benutzerkonto nicht verfügbar oder deaktiviert.' });
+      return;
+    }
+
+    req.user = toAuthUser(user);
+    next();
+  } catch (error) {
+    res.status(401).json({ message: 'Token ungültig oder abgelaufen.' });
+  }
+};
+
+export const requireAdmin = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.user || req.user.role !== 'ADMIN') {
+    res.status(403).json({ message: 'Administratorrechte erforderlich.' });
+    return;
+  }
+
+  next();
+};
+
+export const requireSelfOrAdmin = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    res.status(401).json({ message: 'Authentifizierung erforderlich.' });
+    return;
+  }
+
+  const targetId = req.params.userId ?? req.params.id;
+
+  if (req.user.role === 'ADMIN' || (targetId && targetId === req.user.id)) {
+    next();
+    return;
+  }
+
+  res.status(403).json({ message: 'Keine Berechtigung für diese Aktion.' });
+};

--- a/backend/src/routes/assets.ts
+++ b/backend/src/routes/assets.ts
@@ -1,8 +1,11 @@
+import type { Prisma } from '@prisma/client';
 import { ImageAsset, ModelAsset, Tag, User } from '@prisma/client';
 import { Router } from 'express';
+import { z } from 'zod';
 
 import { prisma } from '../lib/prisma';
-import { resolveStorageLocation } from '../lib/storage';
+import { requireAuth } from '../lib/middleware/auth';
+import { resolveStorageLocation, storageClient } from '../lib/storage';
 
 type HydratedModelAsset = ModelAsset & {
   tags: { tag: Tag }[];
@@ -11,6 +14,7 @@ type HydratedModelAsset = ModelAsset & {
 
 type HydratedImageAsset = ImageAsset & {
   tags: { tag: Tag }[];
+  owner: Pick<User, 'id' | 'displayName' | 'email'>;
 };
 
 const mapModelAsset = (asset: HydratedModelAsset) => {
@@ -60,11 +64,126 @@ const mapImageAsset = (asset: HydratedImageAsset) => {
       cfgScale: asset.cfgScale,
       steps: asset.steps,
     },
+    owner: asset.owner,
     tags: asset.tags.map(({ tag }) => tag),
     createdAt: asset.createdAt,
     updatedAt: asset.updatedAt,
   };
 };
+
+const normalizeTagLabels = (tags?: string[]) => {
+  if (!tags) {
+    return [] as string[];
+  }
+
+  return Array.from(
+    new Set(
+      tags
+        .map((tag) => tag.trim().toLowerCase())
+        .filter((tag) => tag.length > 0),
+    ),
+  );
+};
+
+const ensureTags = async (tx: Prisma.TransactionClient, labels: string[]) =>
+  Promise.all(
+    labels.map((label) =>
+      tx.tag.upsert({
+        where: { label },
+        update: {},
+        create: { label },
+        select: { id: true },
+      }),
+    ),
+  );
+
+const removeStorageObject = async (bucket: string | null, objectName: string | null) => {
+  if (!bucket || !objectName) {
+    return;
+  }
+
+  try {
+    await storageClient.removeObject(bucket, objectName);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('[assets] Failed to delete object from storage', bucket, objectName, error);
+  }
+};
+
+const updateModelSchema = z.object({
+  title: z.string().trim().min(1).max(180).optional(),
+  description: z
+    .string()
+    .trim()
+    .max(1500)
+    .nullable()
+    .optional()
+    .transform((value) => {
+      if (value == null) {
+        return null;
+      }
+
+      return value.length > 0 ? value : null;
+    }),
+  version: z.string().trim().max(80).optional(),
+  tags: z.array(z.string()).optional(),
+  ownerId: z.string().trim().min(1).optional(),
+});
+
+const updateImageSchema = z.object({
+  title: z.string().trim().min(1).max(200).optional(),
+  description: z
+    .string()
+    .trim()
+    .max(1500)
+    .nullable()
+    .optional()
+    .transform((value) => {
+      if (value == null) {
+        return null;
+      }
+
+      return value.length > 0 ? value : null;
+    }),
+  prompt: z
+    .string()
+    .trim()
+    .max(2000)
+    .nullable()
+    .optional()
+    .transform((value) => {
+      if (value == null) {
+        return null;
+      }
+
+      return value.length > 0 ? value : null;
+    }),
+  negativePrompt: z
+    .string()
+    .trim()
+    .max(2000)
+    .nullable()
+    .optional()
+    .transform((value) => {
+      if (value == null) {
+        return null;
+      }
+
+      return value.length > 0 ? value : null;
+    }),
+  metadata: z
+    .object({
+      seed: z.string().trim().nullable().optional(),
+      model: z.string().trim().nullable().optional(),
+      sampler: z.string().trim().nullable().optional(),
+      cfgScale: z.number().nullable().optional(),
+      steps: z.number().nullable().optional(),
+    })
+    .partial()
+    .optional(),
+  tags: z.array(z.string()).optional(),
+  ownerId: z.string().trim().min(1).optional(),
+});
 
 export const assetsRouter = Router();
 
@@ -87,11 +206,325 @@ assetsRouter.get('/models', async (_req, res, next) => {
 assetsRouter.get('/images', async (_req, res, next) => {
   try {
     const images = await prisma.imageAsset.findMany({
-      include: { tags: { include: { tag: true } } },
+      include: {
+        tags: { include: { tag: true } },
+        owner: { select: { id: true, displayName: true, email: true } },
+      },
       orderBy: { createdAt: 'desc' },
     });
 
     res.json(images.map(mapImageAsset));
+  } catch (error) {
+    next(error);
+  }
+});
+
+assetsRouter.put('/models/:id', requireAuth, async (req, res, next) => {
+  try {
+    const { id: assetId } = req.params;
+    if (!assetId) {
+      res.status(400).json({ message: 'Model-ID fehlt.' });
+      return;
+    }
+
+    const parsed = updateModelSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ message: 'Übermittelte Daten sind ungültig.', errors: parsed.error.flatten() });
+      return;
+    }
+
+    const asset = await prisma.modelAsset.findUnique({
+      where: { id: assetId },
+      include: {
+        tags: { include: { tag: true } },
+        owner: { select: { id: true, displayName: true, email: true } },
+      },
+    });
+
+    if (!asset) {
+      res.status(404).json({ message: 'Das angeforderte Modell wurde nicht gefunden.' });
+      return;
+    }
+
+    if (!req.user) {
+      res.status(401).json({ message: 'Authentifizierung erforderlich.' });
+      return;
+    }
+
+    if (asset.ownerId !== req.user.id && req.user.role !== 'ADMIN') {
+      res.status(403).json({ message: 'Keine Berechtigung zum Bearbeiten dieses Modells.' });
+      return;
+    }
+
+    if (parsed.data.ownerId && parsed.data.ownerId !== asset.ownerId && req.user.role !== 'ADMIN') {
+      res.status(403).json({ message: 'Nur Administrator:innen können den Besitz ändern.' });
+      return;
+    }
+
+    const shouldUpdateTags = parsed.data.tags !== undefined;
+    const normalizedTags = shouldUpdateTags ? normalizeTagLabels(parsed.data.tags) : [];
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const data: Prisma.ModelAssetUpdateInput = {};
+
+      if (parsed.data.title) {
+        data.title = parsed.data.title;
+      }
+
+      if (parsed.data.description !== undefined) {
+        data.description = parsed.data.description;
+      }
+
+      if (parsed.data.version) {
+        data.version = parsed.data.version;
+      }
+
+      if (parsed.data.ownerId && parsed.data.ownerId !== asset.ownerId) {
+        data.owner = { connect: { id: parsed.data.ownerId } };
+      }
+
+      if (shouldUpdateTags) {
+        await tx.assetTag.deleteMany({ where: { assetId: asset.id } });
+        if (normalizedTags.length > 0) {
+          const tagRecords = await ensureTags(tx, normalizedTags);
+          data.tags = {
+            create: tagRecords.map((tag) => ({ tagId: tag.id })),
+          };
+        }
+      }
+
+      return tx.modelAsset.update({
+        where: { id: asset.id },
+        data,
+        include: {
+          tags: { include: { tag: true } },
+          owner: { select: { id: true, displayName: true, email: true } },
+        },
+      });
+    });
+
+    res.json(mapModelAsset(updated));
+  } catch (error) {
+    next(error);
+  }
+});
+
+assetsRouter.delete('/models/:id', requireAuth, async (req, res, next) => {
+  try {
+    const { id: assetId } = req.params;
+    if (!assetId) {
+      res.status(400).json({ message: 'Model-ID fehlt.' });
+      return;
+    }
+
+    const asset = await prisma.modelAsset.findUnique({
+      where: { id: assetId },
+      select: { id: true, ownerId: true, storagePath: true, previewImage: true },
+    });
+
+    if (!asset) {
+      res.status(404).json({ message: 'Das Modell wurde nicht gefunden.' });
+      return;
+    }
+
+    if (!req.user) {
+      res.status(401).json({ message: 'Authentifizierung erforderlich.' });
+      return;
+    }
+
+    if (asset.ownerId !== req.user.id && req.user.role !== 'ADMIN') {
+      res.status(403).json({ message: 'Keine Berechtigung zum Löschen dieses Modells.' });
+      return;
+    }
+
+    const storage = resolveStorageLocation(asset.storagePath);
+    const preview = resolveStorageLocation(asset.previewImage);
+
+    await prisma.$transaction(async (tx) => {
+      await tx.galleryEntry.deleteMany({ where: { assetId: asset.id } });
+      await tx.assetTag.deleteMany({ where: { assetId: asset.id } });
+      if (storage.objectName) {
+        await tx.storageObject.deleteMany({ where: { id: storage.objectName } });
+      }
+      if (preview.objectName) {
+        await tx.storageObject.deleteMany({ where: { id: preview.objectName } });
+      }
+      if (asset.previewImage) {
+        await tx.gallery.updateMany({
+          where: { coverImage: asset.previewImage },
+          data: { coverImage: null },
+        });
+      }
+      await tx.modelAsset.delete({ where: { id: asset.id } });
+    });
+
+    await removeStorageObject(storage.bucket, storage.objectName);
+    await removeStorageObject(preview.bucket, preview.objectName);
+
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+assetsRouter.put('/images/:id', requireAuth, async (req, res, next) => {
+  try {
+    const parsed = updateImageSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ message: 'Übermittelte Daten sind ungültig.', errors: parsed.error.flatten() });
+      return;
+    }
+
+    const { id: imageId } = req.params;
+    if (!imageId) {
+      res.status(400).json({ message: 'Bild-ID fehlt.' });
+      return;
+    }
+
+    const image = await prisma.imageAsset.findUnique({
+      where: { id: imageId },
+      include: {
+        tags: { include: { tag: true } },
+        owner: { select: { id: true, displayName: true, email: true } },
+      },
+    });
+
+    if (!image) {
+      res.status(404).json({ message: 'Bild konnte nicht gefunden werden.' });
+      return;
+    }
+
+    if (!req.user) {
+      res.status(401).json({ message: 'Authentifizierung erforderlich.' });
+      return;
+    }
+
+    if (image.ownerId !== req.user.id && req.user.role !== 'ADMIN') {
+      res.status(403).json({ message: 'Keine Berechtigung zum Bearbeiten dieses Bildes.' });
+      return;
+    }
+
+    if (parsed.data.ownerId && parsed.data.ownerId !== image.ownerId && req.user.role !== 'ADMIN') {
+      res.status(403).json({ message: 'Nur Administrator:innen können den Besitz ändern.' });
+      return;
+    }
+
+    const shouldUpdateTags = parsed.data.tags !== undefined;
+    const normalizedTags = shouldUpdateTags ? normalizeTagLabels(parsed.data.tags) : [];
+
+    const updated = await prisma.$transaction(async (tx) => {
+      const data: Prisma.ImageAssetUpdateInput = {};
+
+      if (parsed.data.title) {
+        data.title = parsed.data.title;
+      }
+
+      if (parsed.data.description !== undefined) {
+        data.description = parsed.data.description;
+      }
+
+      if (parsed.data.prompt !== undefined) {
+        data.prompt = parsed.data.prompt;
+      }
+
+      if (parsed.data.negativePrompt !== undefined) {
+        data.negativePrompt = parsed.data.negativePrompt;
+      }
+
+      if (parsed.data.metadata) {
+        if (parsed.data.metadata.seed !== undefined) {
+          data.seed = parsed.data.metadata.seed;
+        }
+        if (parsed.data.metadata.model !== undefined) {
+          data.model = parsed.data.metadata.model;
+        }
+        if (parsed.data.metadata.sampler !== undefined) {
+          data.sampler = parsed.data.metadata.sampler;
+        }
+        if (parsed.data.metadata.cfgScale !== undefined) {
+          data.cfgScale = parsed.data.metadata.cfgScale ?? null;
+        }
+        if (parsed.data.metadata.steps !== undefined) {
+          data.steps = parsed.data.metadata.steps ?? null;
+        }
+      }
+
+      if (parsed.data.ownerId && parsed.data.ownerId !== image.ownerId) {
+        data.owner = { connect: { id: parsed.data.ownerId } };
+      }
+
+      if (shouldUpdateTags) {
+        await tx.imageTag.deleteMany({ where: { imageId: image.id } });
+        if (normalizedTags.length > 0) {
+          const tagRecords = await ensureTags(tx, normalizedTags);
+          data.tags = {
+            create: tagRecords.map((tag) => ({ tagId: tag.id })),
+          };
+        }
+      }
+
+      return tx.imageAsset.update({
+        where: { id: image.id },
+        data,
+        include: {
+          tags: { include: { tag: true } },
+          owner: { select: { id: true, displayName: true, email: true } },
+        },
+      });
+    });
+
+    res.json(mapImageAsset(updated));
+  } catch (error) {
+    next(error);
+  }
+});
+
+assetsRouter.delete('/images/:id', requireAuth, async (req, res, next) => {
+  try {
+    const { id: imageId } = req.params;
+    if (!imageId) {
+      res.status(400).json({ message: 'Bild-ID fehlt.' });
+      return;
+    }
+
+    const image = await prisma.imageAsset.findUnique({
+      where: { id: imageId },
+      select: { id: true, ownerId: true, storagePath: true },
+    });
+
+    if (!image) {
+      res.status(404).json({ message: 'Bild konnte nicht gefunden werden.' });
+      return;
+    }
+
+    if (!req.user) {
+      res.status(401).json({ message: 'Authentifizierung erforderlich.' });
+      return;
+    }
+
+    if (image.ownerId !== req.user.id && req.user.role !== 'ADMIN') {
+      res.status(403).json({ message: 'Keine Berechtigung zum Löschen dieses Bildes.' });
+      return;
+    }
+
+    const storage = resolveStorageLocation(image.storagePath);
+
+    await prisma.$transaction(async (tx) => {
+      await tx.galleryEntry.deleteMany({ where: { imageId: image.id } });
+      await tx.imageTag.deleteMany({ where: { imageId: image.id } });
+      if (storage.objectName) {
+        await tx.storageObject.deleteMany({ where: { id: storage.objectName } });
+      }
+      await tx.gallery.updateMany({
+        where: { coverImage: image.storagePath },
+        data: { coverImage: null },
+      });
+      await tx.imageAsset.delete({ where: { id: image.id } });
+    });
+
+    await removeStorageObject(storage.bucket, storage.objectName);
+
+    res.status(204).send();
   } catch (error) {
     next(error);
   }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,72 @@
+import { Router } from 'express';
+import { z } from 'zod';
+
+import { prisma } from '../lib/prisma';
+import { createAccessToken, toAuthUser, verifyPassword } from '../lib/auth';
+import { requireAuth } from '../lib/middleware/auth';
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export const authRouter = Router();
+
+authRouter.post('/login', async (req, res, next) => {
+  try {
+    const result = loginSchema.safeParse(req.body);
+    if (!result.success) {
+      res.status(400).json({ message: 'Bitte gültige Zugangsdaten angeben.' });
+      return;
+    }
+
+    const { email, password } = result.data;
+    const user = await prisma.user.findUnique({
+      where: { email: email.toLowerCase() },
+      select: {
+        id: true,
+        email: true,
+        displayName: true,
+        role: true,
+        bio: true,
+        avatarUrl: true,
+        passwordHash: true,
+        isActive: true,
+      },
+    });
+
+    if (!user || !user.isActive) {
+      res.status(401).json({ message: 'Benutzerkonto nicht gefunden oder deaktiviert.' });
+      return;
+    }
+
+    const passwordValid = await verifyPassword(password, user.passwordHash);
+    if (!passwordValid) {
+      res.status(401).json({ message: 'E-Mail oder Passwort sind nicht korrekt.' });
+      return;
+    }
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { lastLoginAt: new Date() },
+    });
+
+    const token = createAccessToken({
+      sub: user.id,
+      role: user.role,
+      displayName: user.displayName,
+      email: user.email,
+    });
+
+    res.json({
+      token,
+      user: toAuthUser(user),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+authRouter.get('/me', requireAuth, async (req, res) => {
+  res.json({ user: req.user });
+});

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,15 +1,19 @@
 import { Router } from 'express';
 
 import { assetsRouter } from './assets';
+import { authRouter } from './auth';
 import { galleriesRouter } from './galleries';
 import { metaRouter } from './meta';
 import { uploadsRouter } from './uploads';
 import { storageRouter } from './storage';
+import { usersRouter } from './users';
 
 export const router = Router();
 
+router.use('/auth', authRouter);
 router.use('/assets', assetsRouter);
 router.use('/galleries', galleriesRouter);
 router.use('/meta', metaRouter);
 router.use('/uploads', uploadsRouter);
 router.use('/storage', storageRouter);
+router.use('/users', usersRouter);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,0 +1,162 @@
+import { Router } from 'express';
+import { z } from 'zod';
+
+import { prisma } from '../lib/prisma';
+import { hashPassword, toAuthUser } from '../lib/auth';
+import { requireAdmin, requireAuth } from '../lib/middleware/auth';
+
+const createUserSchema = z.object({
+  email: z.string().email(),
+  displayName: z.string().min(2).max(160),
+  password: z.string().min(8),
+  role: z.enum(['CURATOR', 'ADMIN']).default('CURATOR'),
+  bio: z.string().max(600).optional(),
+  avatarUrl: z.string().url().optional(),
+});
+
+const updateUserSchema = z.object({
+  email: z.string().email().optional(),
+  displayName: z.string().min(2).max(160).optional(),
+  password: z.string().min(8).optional(),
+  role: z.enum(['CURATOR', 'ADMIN']).optional(),
+  bio: z.string().max(600).nullable().optional(),
+  avatarUrl: z.string().url().nullable().optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const usersRouter = Router();
+
+usersRouter.use(requireAuth, requireAdmin);
+
+usersRouter.get('/', async (_req, res, next) => {
+  try {
+    const users = await prisma.user.findMany({
+      orderBy: { createdAt: 'asc' },
+    });
+
+    res.json({ users: users.map((user) => ({
+      ...toAuthUser(user),
+      isActive: user.isActive,
+      lastLoginAt: user.lastLoginAt,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    })) });
+  } catch (error) {
+    next(error);
+  }
+});
+
+usersRouter.post('/', async (req, res, next) => {
+  try {
+    const result = createUserSchema.safeParse(req.body);
+    if (!result.success) {
+      res.status(400).json({ message: 'Benutzer konnte nicht erstellt werden.', errors: result.error.flatten() });
+      return;
+    }
+
+    const payload = result.data;
+    const passwordHash = await hashPassword(payload.password);
+
+    const user = await prisma.user.create({
+      data: {
+        email: payload.email.toLowerCase(),
+        displayName: payload.displayName,
+        role: payload.role,
+        passwordHash,
+        bio: payload.bio ?? null,
+        avatarUrl: payload.avatarUrl ?? null,
+        isActive: true,
+      },
+    });
+
+    res.status(201).json({ user: { ...toAuthUser(user), isActive: user.isActive } });
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2002') {
+      res.status(409).json({ message: 'E-Mail-Adresse wird bereits verwendet.' });
+      return;
+    }
+
+    next(error);
+  }
+});
+
+usersRouter.put('/:id', async (req, res, next) => {
+  try {
+    const result = updateUserSchema.safeParse(req.body);
+    if (!result.success) {
+      res.status(400).json({ message: 'Aktualisierung fehlgeschlagen.', errors: result.error.flatten() });
+      return;
+    }
+
+    const payload = result.data;
+    const updates: Record<string, unknown> = {};
+
+    if (payload.email) {
+      updates.email = payload.email.toLowerCase();
+    }
+
+    if (payload.displayName) {
+      updates.displayName = payload.displayName;
+    }
+
+    if (payload.role) {
+      updates.role = payload.role;
+    }
+
+    if (payload.bio !== undefined) {
+      updates.bio = payload.bio;
+    }
+
+    if (payload.avatarUrl !== undefined) {
+      updates.avatarUrl = payload.avatarUrl;
+    }
+
+    if (payload.isActive !== undefined) {
+      updates.isActive = payload.isActive;
+    }
+
+    if (payload.password) {
+      updates.passwordHash = await hashPassword(payload.password);
+    }
+
+    const user = await prisma.user.update({
+      where: { id: req.params.id },
+      data: updates,
+    });
+
+    res.json({ user: { ...toAuthUser(user), isActive: user.isActive } });
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2025') {
+      res.status(404).json({ message: 'Benutzer wurde nicht gefunden.' });
+      return;
+    }
+
+    if (error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2002') {
+      res.status(409).json({ message: 'E-Mail-Adresse wird bereits verwendet.' });
+      return;
+    }
+
+    next(error);
+  }
+});
+
+usersRouter.delete('/:id', async (req, res, next) => {
+  try {
+    const targetId = req.params.id;
+
+    if (req.user?.id === targetId) {
+      res.status(400).json({ message: 'Das eigene Konto kann nicht gelöscht werden.' });
+      return;
+    }
+
+    await prisma.user.delete({ where: { id: targetId } });
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2025') {
+      res.status(404).json({ message: 'Benutzer wurde nicht gefunden.' });
+      return;
+    }
+
+    next(error);
+  }
+});

--- a/backend/src/types/express/index.d.ts
+++ b/backend/src/types/express/index.d.ts
@@ -1,0 +1,11 @@
+import type { AuthenticatedUser } from '../../lib/auth';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: AuthenticatedUser;
+    }
+  }
+}
+
+export {};

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -1,0 +1,468 @@
+import { FormEvent, useMemo, useState } from 'react';
+
+import { api } from '../lib/api';
+import type { ImageAsset, ModelAsset, User } from '../types/api';
+
+interface AdminPanelProps {
+  users: User[];
+  models: ModelAsset[];
+  images: ImageAsset[];
+  token: string;
+  onRefresh: () => Promise<void>;
+}
+
+type AdminTab = 'users' | 'models' | 'images';
+
+const parseCommaList = (value: string) =>
+  value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+export const AdminPanel = ({ users, models, images, token, onRefresh }: AdminPanelProps) => {
+  const [activeTab, setActiveTab] = useState<AdminTab>('users');
+  const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const userOptions = useMemo(() => users.map((user) => ({ id: user.id, label: user.displayName })), [users]);
+
+  const resetStatus = () => setStatus(null);
+
+  const withStatus = async (action: () => Promise<void>, successMessage: string) => {
+    resetStatus();
+    setIsBusy(true);
+    try {
+      await action();
+      setStatus({ type: 'success', message: successMessage });
+      await onRefresh();
+    } catch (error) {
+      setStatus({ type: 'error', message: error instanceof Error ? error.message : 'Aktion fehlgeschlagen.' });
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleCreateUser = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const email = (formData.get('email') as string | null)?.trim();
+    const displayName = (formData.get('displayName') as string | null)?.trim();
+    const password = formData.get('password') as string | null;
+    const role = (formData.get('role') as string | null) ?? 'CURATOR';
+    const bio = (formData.get('bio') as string | null)?.trim();
+
+    if (!email || !displayName || !password) {
+      setStatus({ type: 'error', message: 'Alle Pflichtfelder müssen ausgefüllt sein.' });
+      return;
+    }
+
+    await withStatus(
+      () =>
+        api
+          .createUser(token, {
+            email,
+            displayName,
+            password,
+            role,
+            bio: bio && bio.length > 0 ? bio : undefined,
+          })
+          .then(() => {
+            event.currentTarget.reset();
+          }),
+      'Benutzer:in wurde angelegt.',
+    );
+  };
+
+  const handleUpdateUser = async (event: FormEvent<HTMLFormElement>, userId: string) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const displayName = (formData.get('displayName') as string | null)?.trim();
+    const role = (formData.get('role') as string | null) ?? undefined;
+    const bio = (formData.get('bio') as string | null)?.trim();
+    const password = (formData.get('password') as string | null)?.trim();
+    const isActive = formData.get('isActive') === 'on';
+
+    const payload: Record<string, unknown> = {
+      displayName: displayName ?? undefined,
+      role,
+      bio: bio && bio.length > 0 ? bio : null,
+      isActive,
+    };
+
+    if (password && password.length > 0) {
+      payload.password = password;
+    }
+
+    await withStatus(
+      () =>
+        api.updateUser(token, userId, payload).then(() => {
+          const passwordField = event.currentTarget.querySelector<HTMLInputElement>('input[name="password"]');
+          if (passwordField) {
+            passwordField.value = '';
+          }
+        }),
+      'Benutzerdaten wurden aktualisiert.',
+    );
+  };
+
+  const handleDeleteUser = async (userId: string) => {
+    if (!window.confirm('Soll dieser Account wirklich gelöscht werden?')) {
+      return;
+    }
+
+    await withStatus(() => api.deleteUser(token, userId), 'Benutzer:in wurde gelöscht.');
+  };
+
+  const handleUpdateModel = async (event: FormEvent<HTMLFormElement>, model: ModelAsset) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const title = (formData.get('title') as string | null)?.trim();
+    const version = (formData.get('version') as string | null)?.trim();
+    const description = (formData.get('description') as string | null)?.trim();
+    const tagsValue = (formData.get('tags') as string | null) ?? '';
+    const ownerId = (formData.get('ownerId') as string | null) ?? model.owner.id;
+
+    const payload = {
+      title: title ?? undefined,
+      version: version ?? undefined,
+      description: description && description.length > 0 ? description : null,
+      tags: parseCommaList(tagsValue),
+      ownerId,
+    };
+
+    await withStatus(() => api.updateModelAsset(token, model.id, payload), 'Modell wurde aktualisiert.');
+  };
+
+  const handleDeleteModel = async (model: ModelAsset) => {
+    if (!window.confirm(`Modell "${model.title}" wirklich löschen?`)) {
+      return;
+    }
+
+    await withStatus(() => api.deleteModelAsset(token, model.id), 'Modell wurde gelöscht.');
+  };
+
+  const handleUpdateImage = async (event: FormEvent<HTMLFormElement>, image: ImageAsset) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const title = (formData.get('title') as string | null)?.trim();
+    const description = (formData.get('description') as string | null)?.trim();
+    const prompt = (formData.get('prompt') as string | null)?.trim();
+    const negativePrompt = (formData.get('negativePrompt') as string | null)?.trim();
+    const tagsValue = (formData.get('tags') as string | null) ?? '';
+    const ownerId = (formData.get('ownerId') as string | null) ?? image.owner.id;
+    const seed = (formData.get('seed') as string | null)?.trim();
+    const modelName = (formData.get('model') as string | null)?.trim();
+    const sampler = (formData.get('sampler') as string | null)?.trim();
+    const cfgScaleRaw = (formData.get('cfgScale') as string | null)?.trim();
+    const stepsRaw = (formData.get('steps') as string | null)?.trim();
+    const cfgScale = cfgScaleRaw && cfgScaleRaw.length > 0 ? Number.parseFloat(cfgScaleRaw) : null;
+    const steps = stepsRaw && stepsRaw.length > 0 ? Number.parseInt(stepsRaw, 10) : null;
+
+    const payload = {
+      title: title ?? undefined,
+      description: description && description.length > 0 ? description : null,
+      prompt: prompt && prompt.length > 0 ? prompt : null,
+      negativePrompt: negativePrompt && negativePrompt.length > 0 ? negativePrompt : null,
+      tags: parseCommaList(tagsValue),
+      ownerId,
+      metadata: {
+        seed: seed && seed.length > 0 ? seed : null,
+        model: modelName && modelName.length > 0 ? modelName : null,
+        sampler: sampler && sampler.length > 0 ? sampler : null,
+        cfgScale: cfgScale !== null && !Number.isNaN(cfgScale) ? cfgScale : null,
+        steps: steps !== null && !Number.isNaN(steps) ? steps : null,
+      },
+    };
+
+    await withStatus(() => api.updateImageAsset(token, image.id, payload), 'Bild wurde aktualisiert.');
+  };
+
+  const handleDeleteImage = async (image: ImageAsset) => {
+    if (!window.confirm(`Bild "${image.title}" wirklich löschen?`)) {
+      return;
+    }
+
+    await withStatus(() => api.deleteImageAsset(token, image.id), 'Bild wurde gelöscht.');
+  };
+
+  return (
+    <section className="admin">
+      <header className="admin__header">
+        <nav className="admin__tabs" aria-label="Administration Tabs">
+          {(
+            [
+              { id: 'users', label: 'User' },
+              { id: 'models', label: 'Modelle' },
+              { id: 'images', label: 'Bilder' },
+            ] as { id: AdminTab; label: string }[]
+          ).map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              className={`admin__tab${activeTab === tab.id ? ' admin__tab--active' : ''}`}
+              onClick={() => {
+                setActiveTab(tab.id);
+                resetStatus();
+              }}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+        {status ? <p className={`admin__status admin__status--${status.type}`}>{status.message}</p> : null}
+      </header>
+
+      {activeTab === 'users' ? (
+        <div className="admin__panel">
+          <section className="admin__section">
+            <h3>Neuen Account anlegen</h3>
+            <form className="admin__form" onSubmit={handleCreateUser}>
+              <div className="admin__form-grid">
+                <label>
+                  <span>E-Mail</span>
+                  <input name="email" type="email" required disabled={isBusy} />
+                </label>
+                <label>
+                  <span>Anzeigename</span>
+                  <input name="displayName" required disabled={isBusy} />
+                </label>
+                <label>
+                  <span>Passwort</span>
+                  <input name="password" type="password" required disabled={isBusy} />
+                </label>
+                <label>
+                  <span>Rolle</span>
+                  <select name="role" defaultValue="CURATOR" disabled={isBusy}>
+                    <option value="CURATOR">Kurator:in</option>
+                    <option value="ADMIN">Admin</option>
+                  </select>
+                </label>
+              </div>
+              <label>
+                <span>Bio</span>
+                <textarea name="bio" rows={2} disabled={isBusy} />
+              </label>
+              <button type="submit" className="button button--primary" disabled={isBusy}>
+                Account erstellen
+              </button>
+            </form>
+          </section>
+
+          <section className="admin__section">
+            <h3>Bestehende Accounts</h3>
+            <div className="admin__list">
+              {users.length === 0 ? <p className="admin__empty">Keine Benutzer:innen vorhanden.</p> : null}
+              {users.map((user) => (
+                <form key={user.id} className="admin-card" onSubmit={(event) => handleUpdateUser(event, user.id)}>
+                  <header className="admin-card__header">
+                    <div>
+                      <h4>{user.displayName}</h4>
+                      <span className="admin-card__subtitle">{user.email}</span>
+                    </div>
+                    <span className={`admin-card__badge admin-card__badge--${user.role.toLowerCase()}`}>{user.role}</span>
+                  </header>
+                  <div className="admin-card__body">
+                    <label>
+                      <span>Anzeigename</span>
+                      <input name="displayName" defaultValue={user.displayName} disabled={isBusy} />
+                    </label>
+                    <label>
+                      <span>Rolle</span>
+                      <select name="role" defaultValue={user.role} disabled={isBusy}>
+                        <option value="CURATOR">Kurator:in</option>
+                        <option value="ADMIN">Admin</option>
+                      </select>
+                    </label>
+                    <label>
+                      <span>Bio</span>
+                      <textarea name="bio" rows={2} defaultValue={user.bio ?? ''} disabled={isBusy} />
+                    </label>
+                    <label>
+                      <span>Neues Passwort</span>
+                      <input name="password" type="password" placeholder="Optional" disabled={isBusy} />
+                    </label>
+                    <label className="admin-card__checkbox">
+                      <input type="checkbox" name="isActive" defaultChecked={user.isActive !== false} disabled={isBusy} />
+                      Konto aktiv
+                    </label>
+                  </div>
+                  <footer className="admin-card__actions">
+                    <button type="submit" className="button" disabled={isBusy}>
+                      Speichern
+                    </button>
+                    <button
+                      type="button"
+                      className="button button--danger"
+                      onClick={() => handleDeleteUser(user.id)}
+                      disabled={isBusy}
+                    >
+                      Löschen
+                    </button>
+                  </footer>
+                </form>
+              ))}
+            </div>
+          </section>
+        </div>
+      ) : null}
+
+      {activeTab === 'models' ? (
+        <div className="admin__panel">
+          <h3>Modelle verwalten</h3>
+          <div className="admin__list">
+            {models.length === 0 ? <p className="admin__empty">Keine Modelle vorhanden.</p> : null}
+            {models.map((model) => (
+              <form key={model.id} className="admin-card" onSubmit={(event) => handleUpdateModel(event, model)}>
+                <header className="admin-card__header">
+                  <div>
+                    <h4>{model.title}</h4>
+                    <span className="admin-card__subtitle">von {model.owner.displayName}</span>
+                  </div>
+                  <span className="admin-card__badge">{model.version}</span>
+                </header>
+                <div className="admin-card__body">
+                  <label>
+                    <span>Titel</span>
+                    <input name="title" defaultValue={model.title} disabled={isBusy} />
+                  </label>
+                  <label>
+                    <span>Version</span>
+                    <input name="version" defaultValue={model.version} disabled={isBusy} />
+                  </label>
+                  <label>
+                    <span>Beschreibung</span>
+                    <textarea name="description" rows={3} defaultValue={model.description ?? ''} disabled={isBusy} />
+                  </label>
+                  <label>
+                    <span>Tags</span>
+                    <input
+                      name="tags"
+                      defaultValue={model.tags.map((tag) => tag.label).join(', ')}
+                      placeholder="Kommagetrennt"
+                      disabled={isBusy}
+                    />
+                  </label>
+                  <label>
+                    <span>Besitzer:in</span>
+                    <select name="ownerId" defaultValue={model.owner.id} disabled={isBusy}>
+                      {userOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <footer className="admin-card__actions">
+                  <button type="submit" className="button" disabled={isBusy}>
+                    Speichern
+                  </button>
+                  <button
+                    type="button"
+                    className="button button--danger"
+                    onClick={() => handleDeleteModel(model)}
+                    disabled={isBusy}
+                  >
+                    Löschen
+                  </button>
+                </footer>
+              </form>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {activeTab === 'images' ? (
+        <div className="admin__panel">
+          <h3>Bilder verwalten</h3>
+          <div className="admin__list">
+            {images.length === 0 ? <p className="admin__empty">Keine Bilder vorhanden.</p> : null}
+            {images.map((image) => (
+              <form key={image.id} className="admin-card" onSubmit={(event) => handleUpdateImage(event, image)}>
+                <header className="admin-card__header">
+                  <div>
+                    <h4>{image.title}</h4>
+                    <span className="admin-card__subtitle">von {image.owner.displayName}</span>
+                  </div>
+                  <span className="admin-card__badge">{new Date(image.updatedAt).toLocaleDateString('de-DE')}</span>
+                </header>
+                <div className="admin-card__body">
+                  <label>
+                    <span>Titel</span>
+                    <input name="title" defaultValue={image.title} disabled={isBusy} />
+                  </label>
+                  <label>
+                    <span>Beschreibung</span>
+                    <textarea name="description" rows={2} defaultValue={image.description ?? ''} disabled={isBusy} />
+                  </label>
+                  <label>
+                    <span>Prompt</span>
+                    <textarea name="prompt" rows={2} defaultValue={image.prompt ?? ''} disabled={isBusy} />
+                  </label>
+                  <label>
+                    <span>Negativer Prompt</span>
+                    <textarea name="negativePrompt" rows={2} defaultValue={image.negativePrompt ?? ''} disabled={isBusy} />
+                  </label>
+                  <label>
+                    <span>Tags</span>
+                    <input
+                      name="tags"
+                      defaultValue={image.tags.map((tag) => tag.label).join(', ')}
+                      placeholder="Kommagetrennt"
+                      disabled={isBusy}
+                    />
+                  </label>
+                  <label>
+                    <span>Besitzer:in</span>
+                    <select name="ownerId" defaultValue={image.owner.id} disabled={isBusy}>
+                      {userOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <div className="admin__form-grid">
+                    <label>
+                      <span>Seed</span>
+                      <input name="seed" defaultValue={image.metadata?.seed ?? ''} disabled={isBusy} />
+                    </label>
+                    <label>
+                      <span>Model</span>
+                      <input name="model" defaultValue={image.metadata?.model ?? ''} disabled={isBusy} />
+                    </label>
+                    <label>
+                      <span>Sampler</span>
+                      <input name="sampler" defaultValue={image.metadata?.sampler ?? ''} disabled={isBusy} />
+                    </label>
+                    <label>
+                      <span>CFG</span>
+                      <input name="cfgScale" defaultValue={image.metadata?.cfgScale?.toString() ?? ''} disabled={isBusy} />
+                    </label>
+                    <label>
+                      <span>Steps</span>
+                      <input name="steps" defaultValue={image.metadata?.steps?.toString() ?? ''} disabled={isBusy} />
+                    </label>
+                  </div>
+                </div>
+                <footer className="admin-card__actions">
+                  <button type="submit" className="button" disabled={isBusy}>
+                    Speichern
+                  </button>
+                  <button
+                    type="button"
+                    className="button button--danger"
+                    onClick={() => handleDeleteImage(image)}
+                    disabled={isBusy}
+                  >
+                    Löschen
+                  </button>
+                </footer>
+              </form>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/frontend/src/components/LoginDialog.tsx
+++ b/frontend/src/components/LoginDialog.tsx
@@ -1,0 +1,90 @@
+import { FormEvent, useState, useEffect } from 'react';
+
+interface LoginDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (email: string, password: string) => Promise<void>;
+  isSubmitting?: boolean;
+  errorMessage?: string | null;
+}
+
+export const LoginDialog = ({ isOpen, onClose, onSubmit, isSubmitting = false, errorMessage }: LoginDialogProps) => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setEmail('');
+      setPassword('');
+      setLocalError(null);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLocalError(null);
+
+    if (!email.trim() || !password) {
+      setLocalError('Bitte E-Mail und Passwort eingeben.');
+      return;
+    }
+
+    try {
+      await onSubmit(email.trim(), password);
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : 'Anmeldung fehlgeschlagen.');
+    }
+  };
+
+  const displayError = localError ?? errorMessage;
+
+  return (
+    <div className="modal" role="dialog" aria-modal="true" aria-labelledby="login-dialog-title">
+      <div className="modal__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="modal__content modal__content--compact">
+        <header className="modal__header">
+          <h2 id="login-dialog-title">Anmeldung</h2>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Dialog schließen">
+            ×
+          </button>
+        </header>
+        <form className="modal__body" onSubmit={handleSubmit}>
+          <label className="form-field">
+            <span>E-Mail</span>
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              autoComplete="email"
+              required
+            />
+          </label>
+          <label className="form-field">
+            <span>Passwort</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete="current-password"
+              required
+            />
+          </label>
+          {displayError ? <p className="form-error">{displayError}</p> : null}
+          <div className="modal__actions">
+            <button type="button" className="button" onClick={onClose} disabled={isSubmitting}>
+              Abbrechen
+            </button>
+            <button type="submit" className="button button--primary" disabled={isSubmitting}>
+              {isSubmitting ? 'Anmeldung…' : 'Anmelden'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -191,6 +191,96 @@ body {
   color: rgba(226, 232, 240, 0.85);
 }
 
+.sidebar__auth {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+}
+
+.sidebar__auth-name {
+  margin: 0;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.sidebar__auth-role {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(191, 219, 254, 0.7);
+}
+
+.sidebar__auth-button {
+  margin-top: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.sidebar__auth-button:hover:not(:disabled),
+.sidebar__auth-button:focus-visible:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.6);
+  background: rgba(30, 64, 175, 0.6);
+}
+
+.sidebar__auth-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sidebar__auth-button--primary {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.6), rgba(14, 165, 233, 0.45));
+  border-color: transparent;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.button {
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  padding: 0.55rem 1.1rem;
+  border-radius: 10px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.button:hover:not(:disabled),
+.button:focus-visible:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(59, 130, 246, 0.55);
+  background: rgba(30, 64, 175, 0.55);
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.65), rgba(14, 165, 233, 0.45));
+  border-color: transparent;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.button--danger {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.35);
+  color: rgba(254, 226, 226, 0.9);
+}
+
 .content {
   display: flex;
   flex-direction: column;
@@ -421,6 +511,113 @@ body {
   color: rgba(148, 163, 184, 0.8);
 }
 
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.65);
+  backdrop-filter: blur(6px);
+}
+
+.modal__content {
+  position: relative;
+  width: min(460px, calc(100% - 2rem));
+  padding: 2.5rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.modal__content--compact {
+  width: min(420px, calc(100% - 2rem));
+  padding: 2rem;
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.modal__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #f8fafc;
+}
+
+.modal__close {
+  border: none;
+  background: rgba(15, 23, 42, 0.8);
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 1.4rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+
+.modal__close:hover,
+.modal__close:focus-visible {
+  background: rgba(59, 130, 246, 0.45);
+  color: #0f172a;
+  transform: rotate(90deg);
+}
+
+.modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.form-field input {
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+}
+
+.form-field input:focus-visible {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.form-error {
+  margin: 0;
+  color: rgba(248, 113, 113, 0.85);
+  font-size: 0.85rem;
+}
+
 .image-gallery__grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -482,6 +679,180 @@ body {
   font-size: 1rem;
   font-weight: 600;
   color: #f8fafc;
+}
+
+.admin {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.admin__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.admin__tabs {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.admin__tab {
+  padding: 0.55rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  color: rgba(226, 232, 240, 0.85);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+
+.admin__tab--active {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.55), rgba(14, 165, 233, 0.4));
+  border-color: transparent;
+  color: #0f172a;
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.3);
+}
+
+.admin__status {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.admin__status--success {
+  color: rgba(134, 239, 172, 0.9);
+}
+
+.admin__status--error {
+  color: rgba(248, 113, 113, 0.9);
+}
+
+.admin__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.admin__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.admin__form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.admin__empty {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.admin__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.35);
+}
+
+.admin-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.admin-card__header h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #f8fafc;
+}
+
+.admin-card__subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.admin-card__badge {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.2);
+  color: rgba(191, 219, 254, 0.9);
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.admin-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-card__body label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.admin-card__body input,
+.admin-card__body textarea,
+.admin-card__body select {
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  font-size: 0.9rem;
+}
+
+.admin-card__body textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.admin-card__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.admin-card__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.85);
 }
 
 .image-card__timestamp {

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -1,0 +1,127 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { api } from './api';
+import type { User } from '../types/api';
+
+interface AuthContextValue {
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  refreshUser: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'visionsuit.auth.token';
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(() => {
+    try {
+      return window.localStorage.getItem(STORAGE_KEY);
+    } catch (error) {
+      console.warn('Failed to access localStorage:', error);
+      return null;
+    }
+  });
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const loadUser = async () => {
+      if (!token) {
+        setUser(null);
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const { user: currentUser } = await api.getCurrentUser(token);
+        if (!isActive) return;
+        setUser(currentUser);
+      } catch (error) {
+        if (!isActive) return;
+        console.warn('Failed to fetch current user', error);
+        setUser(null);
+        setToken(null);
+        try {
+          window.localStorage.removeItem(STORAGE_KEY);
+        } catch (storageError) {
+          console.warn('Failed to clear localStorage token', storageError);
+        }
+      } finally {
+        if (isActive) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadUser();
+
+    return () => {
+      isActive = false;
+    };
+  }, [token]);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const response = await api.login(email, password);
+    setToken(response.token);
+    setUser(response.user);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, response.token);
+    } catch (error) {
+      console.warn('Failed to persist auth token', error);
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    setToken(null);
+    setUser(null);
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.warn('Failed to remove auth token', error);
+    }
+  }, []);
+
+  const refreshUser = useCallback(async () => {
+    if (!token) {
+      setUser(null);
+      return;
+    }
+
+    const { user: currentUser } = await api.getCurrentUser(token);
+    setUser(currentUser);
+  }, [token]);
+
+  const value = useMemo(
+    () => ({
+      user,
+      token,
+      isAuthenticated: Boolean(user && token),
+      isLoading,
+      login,
+      logout,
+      refreshUser,
+    }),
+    [user, token, isLoading, login, logout, refreshUser],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+
+  return context;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,14 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './App.tsx';
+import './index.css';
+import { AuthProvider } from './lib/auth';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
-)
+);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -4,6 +4,21 @@ export interface Tag {
   category?: string | null;
 }
 
+export type UserRole = 'CURATOR' | 'ADMIN';
+
+export interface User {
+  id: string;
+  email: string;
+  displayName: string;
+  role: UserRole;
+  bio?: string | null;
+  avatarUrl?: string | null;
+  isActive?: boolean;
+  lastLoginAt?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 export interface ModelAsset {
   id: string;
   slug: string;
@@ -49,6 +64,11 @@ export interface ImageAsset {
   prompt?: string | null;
   negativePrompt?: string | null;
   metadata?: ImageAssetMetadata | null;
+  owner: {
+    id: string;
+    displayName: string;
+    email: string;
+  };
   tags: Tag[];
   createdAt: string;
   updatedAt: string;
@@ -101,4 +121,9 @@ export interface ServiceStatusResponse {
     backend: ServiceStatusDetails;
     minio: ServiceStatusDetails;
   };
+}
+
+export interface AuthResponse {
+  token: string;
+  user: User;
 }


### PR DESCRIPTION
## Summary
- add JWT authentication layer with new Prisma migration, admin user CLI, and auth/user API routes
- enforce ownership on uploads and asset CRUD while exposing admin user management endpoints
- wire frontend auth context, login dialog, admin dashboard, and refreshed styling plus documentation updates

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cd5f8042648333bd7a45f99ca3b0c4