### PR TITLE
Refine upload actions and gallery selection

### DIFF
--- a/ChangeLog/2025-09-19-commit-tbd-ui-streamline.md
+++ b/ChangeLog/2025-09-19-commit-tbd-ui-streamline.md
@@ -1,0 +1,25 @@
+# VisionSuit – Änderungsbericht
+
+## Übersicht
+- UI-Entrümpelung der Dashboard-Header-Leiste (Aktualisieren/Upload entfernt)
+- Präzisere Call-to-Action-Beschriftungen in Models- und Galerie-Explorer
+- Galerie-Upload-Assistent mit Dropdown zur Auswahl bestehender Sammlungen inkl. Rollenfilter
+
+## Details
+### Dashboard-Header
+- Entfernt die redundanten Aktionen "Aktualisieren" und "Upload starten" aus dem Haupt-Header.
+- Fokus bleibt auf Titel und Beschreibung der aktiven Ansicht.
+
+### Explorer-Aktionen
+- Models-Bereich: Button-Label zu "LoRA-Upload öffnen" vereinheitlicht.
+- Galerie-Bereich: Call-to-Action zu "Galerie-Upload öffnen" umbenannt.
+
+### Upload-Wizard
+- Bestehende Galerien werden beim Öffnen automatisch geladen und nach Rolle gefiltert (Admin = alle, Curator = eigene).
+- Radio-Option "Bestehende Galerie" nutzt jetzt ein Dropdown mit Titeln + Kurator:innen.
+- Fehler-/Hinweistexte für Ladefehler oder fehlende Galerien ergänzt.
+- Review-Schritt zeigt ausgewählte Galerie verständlich an.
+- Styling für Dropdown & Hilfetext hinzugefügt.
+
+### Dokumentation
+- README-Highlight zu Galerie-Entwürfen aktualisiert (Hinweis auf rollenbasiertes Dropdown).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ den Upload- und Kuration-Workflow.
 - **Dashboard-Navigation** – Linke Seitenleiste mit direkter Umschaltung zwischen Home, Models und Images sowie Live-Service-Status für Frontend, Backend und MinIO.
 - **Rollenbasierte Authentifizierung** – Login-Dialog mit JWT-Token, persistiertem Zustand und Admin-Dashboard für Benutzer-, Modell- und Bildverwaltung.
 - **Upload-Wizard** – dreistufiger Assistent für Basisdaten, Dateiupload & Review inklusive Validierungen, Drag & Drop sowie Rückmeldung aus dem produktiven Upload-Endpunkt (`POST /api/uploads`).
-- **Galerie-Entwürfe** – separater Bild-Upload aus dem Galerie-Explorer, Multi-Upload (bis 12 Dateien/2 GB) mit automatischer Galerie-Auswahl oder -Neuanlage.
+- **Galerie-Entwürfe** – separater Bild-Upload aus dem Galerie-Explorer, Multi-Upload (bis 12 Dateien/2 GB) mit rollenbasiertem Galerie-Dropdown oder direkter Neuanlage.
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.
 - **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, Pagination und aktiven Filterhinweisen.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -475,18 +475,6 @@ export const App = () => {
                 <h1 className="content__title">{viewMeta[activeView].title}</h1>
                 <p className="content__subtitle">{viewMeta[activeView].description}</p>
               </div>
-              <div className="content__actions">
-                <button type="button" className="content__action" onClick={() => refreshData()}>
-                  Aktualisieren
-                </button>
-                <button
-                  type="button"
-                  className="content__action content__action--primary"
-                  onClick={handleOpenAssetUpload}
-                >
-                  Upload starten
-                </button>
-              </div>
             </header>
 
             {errorMessage ? <div className="content__alert">{errorMessage}</div> : null}

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -209,7 +209,7 @@ export const AssetExplorer = ({ assets, isLoading, onStartUpload }: AssetExplore
           </p>
         </div>
         <button type="button" className="panel__action panel__action--primary" onClick={() => onStartUpload?.()}>
-          Upload-Assistent starten
+          LoRA-Upload öffnen
         </button>
       </header>
 

--- a/frontend/src/components/GalleryExplorer.tsx
+++ b/frontend/src/components/GalleryExplorer.tsx
@@ -152,7 +152,7 @@ export const GalleryExplorer = ({ galleries, isLoading, onStartGalleryDraft }: G
           </p>
         </div>
         <button type="button" className="panel__action" onClick={onStartGalleryDraft}>
-          Galerie-Entwurf starten
+          Galerie-Upload öffnen
         </button>
       </header>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2713,6 +2713,31 @@ main {
   display: block;
 }
 
+.upload-wizard__gallery-select label {
+  display: block;
+}
+
+.upload-wizard__gallery-select select {
+  width: 100%;
+  padding: 0.7rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.75);
+  color: #e2e8f0;
+  font-size: 0.9rem;
+}
+
+.upload-wizard__gallery-select select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.upload-wizard__helper {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
 .upload-wizard__files {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- drop the redundant refresh/upload buttons from the dashboard header and keep the focus on view metadata
- rename the model and gallery panel CTAs to more descriptive upload labels
- extend the gallery upload wizard with a role-filtered dropdown, better review output and helper/error messaging
- update the README highlight to mention the role-aware gallery dropdown and add a matching changelog entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6c0854f88333861cc8c6cf689265