### PR TITLE
Restrict model uploads to single asset and preview

### DIFF
--- a/ChangeLog/2025-09-19-4fd2b2b.md
+++ b/ChangeLog/2025-09-19-4fd2b2b.md
@@ -1,0 +1,10 @@
+# Änderungsbericht 19.09.2025 – Commit 4fd2b2b
+
+## Zusammenfassung
+- Der Model-Uploader akzeptiert jetzt exakt eine Modelldatei und ein optionales Vorschaubild; zusätzliche Bilder werden blockiert.
+- Der Wizard blendet im Modellmodus die Galerie-Zuordnung und die Typ-Auswahl aus und erstellt standardmäßig eine neue Galerie.
+- Die Vorschauinformationen im Review-Schritt sowie die Hilfetexte spiegeln die neuen Upload-Grenzen wider.
+- Das README dokumentiert die neue Beschränkung für fokussierte Model-Uploads.
+
+## Validierung
+- `npm run lint` im Frontend ausgeführt, um statische Analysen gegen die angepasste Wizard-Logik laufen zu lassen.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ den Upload- und Kuration-Workflow.
 - **Dashboard-Navigation** – Linke Seitenleiste mit direkter Umschaltung zwischen Home, Models und Images sowie Live-Service-Status für Frontend, Backend und MinIO.
 - **Rollenbasierte Authentifizierung** – Login-Dialog mit JWT-Token, persistiertem Zustand und Admin-Dashboard für Benutzer-, Modell- und Bildverwaltung.
 - **Upload-Wizard** – dreistufiger Assistent für Basisdaten, Dateiupload & Review inklusive Validierungen, Drag & Drop sowie Rückmeldung aus dem produktiven Upload-Endpunkt (`POST /api/uploads`).
+- **Model-Uploads mit Fokus** – Beim Modell-Assistenten sind exakt eine Safetensor-/ZIP-Datei plus ein Vorschaubild erlaubt; zusätzliche Render lassen sich später in der Galerie ergänzen.
 - **Galerie-Entwürfe** – separater Bild-Upload aus dem Galerie-Explorer, Multi-Upload (bis 12 Dateien/2 GB) mit rollenbasiertem Galerie-Dropdown oder direkter Neuanlage.
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.


### PR DESCRIPTION
## Summary
- limit the model upload wizard to one model file plus a single optional preview image while updating validation and helper messaging
- hide gallery assignment/type options in the model flow and default to creating a fresh gallery per upload
- document the streamlined behaviour in the README and record the change in the changelog

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68cd8431d42c8333a100a9277cd8108d