### PR TITLE
Redesign model explorer grid with gallery links

### DIFF
--- a/ChangeLog/2025-09-19-7c08273.md
+++ b/ChangeLog/2025-09-19-7c08273.md
@@ -1,0 +1,12 @@
+# Änderungsbericht 2025-09-19 · Commit 7c08273
+
+## Überblick
+- Modell-Explorer auf ein festes 5er-Grid mit einheitlichen Kachelbreiten und Lazy-Loading per Intersection Observer umgestellt.
+- Detail-Sidebar ergänzt, die Metadaten, Tags, Speicherpfade und verknüpfte Galerien eines ausgewählten LoRA-Modells visualisiert.
+- Verknüpfungen zwischen Modellen und Galerien geschaffen: Direktaufruf der passenden Bildsammlung aus dem Modell-Detail sowie Modell-Backlinks in der Galerie-Ansicht.
+- Frontend-Styles für neue Layouts, Buttons und Badges ausgearbeitet und README-Highlights auf den aktuellen Funktionsumfang angepasst.
+
+## Auswirkungen
+- Benutzerinnen erhalten eine klar strukturierte Modellübersicht mit stets fünf Assets je Zeile und unendlichem Scrollen ohne Nachlade-Button.
+- Der Informationsfluss zwischen LoRA-Modellen und Bildgalerien wurde bidirektional, wodurch Kurator:innen schneller zwischen verwandten Inhalten navigieren können.
+- Die aktualisierten Styles stellen sicher, dass neue Bedienelemente visuell zum bestehenden VisionSuit-Auftritt passen.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ den Upload- und Kuration-Workflow.
 - **Galerie-Entwürfe** – separater Bild-Upload aus dem Galerie-Explorer, Multi-Upload (bis 12 Dateien/2 GB) mit rollenbasiertem Galerie-Dropdown oder direkter Neuanlage.
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.
-- **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, Pagination und aktiven Filterhinweisen.
+- **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, 5-Spalten-Kacheln und nahtlosem Infinite Scroll samt aktiven Filterhinweisen.
 - **Direkte MinIO-Ingests** – Uploads landen unmittelbar in den konfigurierten Buckets, werden automatisch mit Tags versehen und tauchen ohne Wartezeit in Explorer & Galerien auf.
 - **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:objectId` durch das Backend geproxied; eine Datenbank-Tabelle ordnet die anonymisierten Objekt-IDs wieder den ursprünglichen Dateinamen zu.
 - **Galerie-Explorer** – Fünfspaltiges Grid mit zufälligen Vorschaubildern, fixen Kachelbreiten, Detailpanel pro Sammlung und EXIF-Lightbox für jedes Bild.
@@ -142,7 +142,7 @@ Der aktuelle Prototyp fokussiert sich auf einen klaren Kontrollraum mit Service-
 - **Admin-Panel** – Skaliert für vierstellige Bestände mit Filterchips, Mehrfachauswahl, Bulk-Löschungen sowie direkter Galerie-
   und Albumbearbeitung inklusive Reihung und Metadatenpflege.
 - **Home-Dashboard** – Kachel-Layout mit den neuesten Modellen und Bildern inklusive Kurator:innen, Versionen, Prompts und Tag-Highlights.
-- **Models** – Der ausgebaute Model Explorer bleibt Dreh- und Angelpunkt für LoRA-Recherchen mit Volltext, Typ- und Größenfiltern sowie Lazy-Loading.
+- **Models** – Der ausgebaute Model Explorer bündelt Volltext, Typ- und Größenfilter mit einem festen 5er-Grid, Detail-Sidebar samt Metadaten und Deep-Links direkt in die zugehörigen Bildgalerien.
 - **Images** – Der Galerie-Explorer nutzt feste Grid-Kacheln mit zufälligen Vorschaubildern, Scrollpagination, Detailpanel pro Sammlung sowie EXIF- und Promptanzeige in einer bildfüllenden Lightbox.
 - **Upload-Wizard** – Jederzeit erreichbar über die Shell; validiert Eingaben, verwaltet Datei-Drops und liefert unmittelbares Backend-Feedback – inklusive eigenem Galerie-Modus für Bildserien.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -85,6 +85,8 @@ export const App = () => {
   const [isLoginOpen, setIsLoginOpen] = useState(false);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
+  const [focusedAssetId, setFocusedAssetId] = useState<string | null>(null);
+  const [focusedGalleryId, setFocusedGalleryId] = useState<string | null>(null);
   const availableViews = useMemo<ViewKey[]>(() => {
     const views: ViewKey[] = ['home', 'models', 'images'];
     if (authUser?.role === 'ADMIN') {
@@ -211,6 +213,18 @@ export const App = () => {
       return;
     }
     setIsGalleryUploadOpen(true);
+  };
+
+  const handleNavigateToGallery = (galleryId: string) => {
+    setFocusedGalleryId(galleryId);
+    setFocusedAssetId(null);
+    setActiveView('images');
+  };
+
+  const handleNavigateToModel = (modelId: string) => {
+    setFocusedAssetId(modelId);
+    setFocusedGalleryId(null);
+    setActiveView('models');
   };
 
   const handleLoginSubmit = async (email: string, password: string) => {
@@ -380,8 +394,11 @@ export const App = () => {
       return (
         <AssetExplorer
           assets={assets}
+          galleries={galleries}
           isLoading={isLoading}
           onStartUpload={handleOpenAssetUpload}
+          onNavigateToGallery={handleNavigateToGallery}
+          initialAssetId={focusedAssetId}
         />
       );
     }
@@ -392,6 +409,8 @@ export const App = () => {
           galleries={galleries}
           isLoading={isLoading}
           onStartGalleryDraft={handleOpenGalleryUpload}
+          onNavigateToModel={handleNavigateToModel}
+          initialGalleryId={focusedGalleryId}
         />
       );
     }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1609,6 +1609,326 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
+.asset-explorer__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.asset-explorer__grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.asset-explorer__grid > .skeleton {
+  min-height: 200px;
+}
+
+.asset-explorer__detail {
+  position: sticky;
+  top: 110px;
+  align-self: start;
+}
+
+.asset-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  padding: 1.75rem;
+  border-radius: 26px;
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(30, 64, 175, 0.35));
+  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.45);
+}
+
+.asset-detail--empty {
+  justify-content: center;
+  align-items: center;
+  min-height: 320px;
+  color: rgba(203, 213, 225, 0.75);
+  text-align: center;
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.asset-detail__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.asset-detail__header h3 {
+  margin: 0.25rem 0 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.asset-detail__header p {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.asset-detail__version {
+  display: inline-block;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.18);
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.9);
+}
+
+.asset-detail__close {
+  border: none;
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(226, 232, 240, 0.85);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.asset-detail__close:hover,
+.asset-detail__close:focus-visible {
+  color: #ffffff;
+  background: rgba(59, 130, 246, 0.35);
+  outline: none;
+}
+
+.asset-detail__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(203, 213, 225, 0.9);
+}
+
+.asset-detail__description--muted {
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.asset-detail__preview {
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.55);
+  max-height: 220px;
+}
+
+.asset-detail__preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.asset-detail__section h4 {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.asset-detail__section dl {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.asset-detail__section dl > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.asset-detail__section dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.asset-detail__section dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.95);
+  word-break: break-word;
+}
+
+.asset-detail__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.asset-detail__tags span {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  font-size: 0.75rem;
+  color: rgba(191, 219, 254, 0.9);
+}
+
+.asset-detail__metadata {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 18px;
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.asset-detail__metadata dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.asset-detail__metadata dd {
+  margin: 0.4rem 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.asset-detail__gallery-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.asset-detail__gallery-button {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: rgba(22, 101, 52, 0.32);
+  color: rgba(187, 247, 208, 0.95);
+  padding: 0.6rem 0.9rem;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.asset-detail__gallery-button:hover,
+.asset-detail__gallery-button:focus-visible {
+  background: rgba(34, 197, 94, 0.45);
+  color: #0f172a;
+  outline: none;
+}
+
+.asset-explorer__sentinel {
+  width: 100%;
+  height: 1px;
+}
+
+.asset-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 20px;
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  background: rgba(15, 23, 42, 0.65);
+  color: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.asset-tile:hover,
+.asset-tile:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(96, 165, 250, 0.45);
+  box-shadow: 0 22px 45px rgba(2, 6, 23, 0.4);
+  outline: none;
+}
+
+.asset-tile--active {
+  border-color: rgba(34, 197, 94, 0.55);
+  box-shadow: 0 26px 55px rgba(34, 197, 94, 0.25);
+}
+
+.asset-tile__preview {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.asset-tile__preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.asset-tile__preview--empty {
+  color: rgba(148, 163, 184, 0.65);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.asset-tile__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+}
+
+.asset-tile__headline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.asset-tile__headline h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.asset-tile__headline span {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.75);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+}
+
+.asset-tile__body p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.asset-tile__owner {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
 .panel__action {
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.35);
@@ -3485,6 +3805,56 @@ button {
 .gallery-detail__description--muted {
   color: rgba(148, 163, 184, 0.7);
   font-style: italic;
+}
+
+.gallery-detail__models {
+  border-radius: 20px;
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  background: rgba(15, 23, 42, 0.55);
+  padding: 1rem 1.25rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.gallery-detail__models h4 {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.gallery-detail__models ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.gallery-detail__models li {
+  margin: 0;
+}
+
+.gallery-detail__model-button {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(30, 64, 175, 0.22);
+  color: rgba(191, 219, 254, 0.95);
+  padding: 0.6rem 0.85rem;
+  text-align: left;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.gallery-detail__model-button:hover,
+.gallery-detail__model-button:focus-visible {
+  background: rgba(59, 130, 246, 0.45);
+  color: #0f172a;
+  outline: none;
 }
 
 .gallery-detail__grid {


### PR DESCRIPTION
## Summary
- redesign the model explorer into a fixed five-column grid with lazy loading and a rich detail sidebar including gallery cross-links
- surface linked LoRA models inside the gallery explorer and wire view switches between models and images
- add supporting styling updates, refresh README highlights, and document the change in a dated changelog entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd948ce32883338ac2b09096dba439