### PR TITLE
Decouple explorer detail panes into modal dialogs

### DIFF
--- a/ChangeLog/2025-09-19-commit-tbd-gallery-dialog.md
+++ b/ChangeLog/2025-09-19-commit-tbd-gallery-dialog.md
@@ -1,0 +1,13 @@
+# Changelog – 2025-09-19
+
+## Kontext
+Die gekoppelte Zwei-Spalten-Ansicht in Modell- und Galerie-Explorer führte zu eingeschränkter Übersichtlichkeit auf kleineren Displays. Ziel war eine losgelöste Detaildarstellung mit klarer Navigationsführung und wiederkehrbarer Rückkehr in die Grid-Ansicht.
+
+## Umsetzung
+- Galerie- und Modellexplorer öffnen Detailinformationen jetzt in modalen Dialogen mit eigener Backdrop-Navigation und Escape-Taste.
+- Elternansichten erhalten Rückmeldungen, wenn Dialoge geschlossen werden, damit Deep-Links aus beiden Explorer-Richtungen weiterhin funktionieren.
+- CSS-Layout wurde für frei skalierende Grid-Spalten, modale Container und responsive Höhenbegrenzungen aktualisiert.
+- README hebt den neuen Dialog-Flow der Explorer hervor, um Nutzer:innen auf die geänderte Interaktion hinzuweisen.
+
+## Tests & Validierung
+- `npm run lint`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ den Upload- und Kuration-Workflow.
 - **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, 5-Spalten-Kacheln und nahtlosem Infinite Scroll samt aktiven Filterhinweisen.
 - **Direkte MinIO-Ingests** – Uploads landen unmittelbar in den konfigurierten Buckets, werden automatisch mit Tags versehen und tauchen ohne Wartezeit in Explorer & Galerien auf.
 - **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:objectId` durch das Backend geproxied; eine Datenbank-Tabelle ordnet die anonymisierten Objekt-IDs wieder den ursprünglichen Dateinamen zu.
-- **Galerie-Explorer** – Fünfspaltiges Grid mit zufälligen Vorschaubildern, fixen Kachelbreiten, Detailpanel pro Sammlung und EXIF-Lightbox für jedes Bild.
+- **Galerie-Explorer** – Fünfspaltiges Grid mit zufälligen Vorschaubildern, fixen Kachelbreiten sowie einem eigenständigen Detail-Dialog pro Sammlung inklusive EXIF-Lightbox für jedes Bild.
 - **Robuste Metadatenanzeige** – Galerie- und Bildansichten bleiben stabil, selbst wenn Einträge ohne ausgefüllte Bild-Metadaten vom Backend geliefert werden.
 - **Automatische Metadatenerfassung** – Uploads lesen EXIF-/Stable-Diffusion-Prompts sowie Safetensors-Header aus, speichern Basismodelle direkt in der Datenbank und machen sie in Galerie- und Modell-Explorer durchsuchbar.
 
@@ -142,8 +142,8 @@ Der aktuelle Prototyp fokussiert sich auf einen klaren Kontrollraum mit Service-
 - **Admin-Panel** – Skaliert für vierstellige Bestände mit Filterchips, Mehrfachauswahl, Bulk-Löschungen sowie direkter Galerie-
   und Albumbearbeitung inklusive Reihung und Metadatenpflege.
 - **Home-Dashboard** – Kachel-Layout mit den neuesten Modellen und Bildern inklusive Kurator:innen, Versionen, Prompts und Tag-Highlights.
-- **Models** – Der ausgebaute Model Explorer bündelt Volltext, Typ- und Größenfilter mit einem festen 5er-Grid, Detail-Sidebar samt Metadaten und Deep-Links direkt in die zugehörigen Bildgalerien.
-- **Images** – Der Galerie-Explorer nutzt feste Grid-Kacheln mit zufälligen Vorschaubildern, Scrollpagination, Detailpanel pro Sammlung sowie EXIF- und Promptanzeige in einer bildfüllenden Lightbox.
+- **Models** – Der ausgebaute Model Explorer bündelt Volltext, Typ- und Größenfilter mit einem festen 5er-Grid, Detail-Dialog samt Metadaten und Deep-Links direkt in die zugehörigen Bildgalerien.
+- **Images** – Der Galerie-Explorer nutzt feste Grid-Kacheln mit zufälligen Vorschaubildern, Scrollpagination sowie eine dialogbasierte Detailansicht pro Sammlung mit EXIF- und Promptanzeige in einer bildfüllenden Lightbox.
 - **Upload-Wizard** – Jederzeit erreichbar über die Shell; validiert Eingaben, verwaltet Datei-Drops und liefert unmittelbares Backend-Feedback – inklusive eigenem Galerie-Modus für Bildserien.
 
 Die Explorer-Filter arbeiten vollständig clientseitig und reagieren selbst auf große Datenmengen ohne zusätzliche Server-Requests.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -399,6 +399,7 @@ export const App = () => {
           onStartUpload={handleOpenAssetUpload}
           onNavigateToGallery={handleNavigateToGallery}
           initialAssetId={focusedAssetId}
+          onCloseDetail={() => setFocusedAssetId(null)}
         />
       );
     }
@@ -411,6 +412,7 @@ export const App = () => {
           onStartGalleryDraft={handleOpenGalleryUpload}
           onNavigateToModel={handleNavigateToModel}
           initialGalleryId={focusedGalleryId}
+          onCloseDetail={() => setFocusedGalleryId(null)}
         />
       );
     }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1609,16 +1609,9 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.asset-explorer__layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 320px;
-  gap: 2.5rem;
-  align-items: start;
-}
-
 .asset-explorer__grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 1.5rem;
 }
 
@@ -1626,10 +1619,30 @@ main {
   min-height: 200px;
 }
 
-.asset-explorer__detail {
-  position: sticky;
-  top: 110px;
-  align-self: start;
+.asset-detail-dialog {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 4rem 1.5rem;
+  z-index: 70;
+}
+
+.asset-detail-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.78);
+  backdrop-filter: blur(6px);
+}
+
+.asset-detail-dialog__container {
+  position: relative;
+  width: min(960px, 94vw);
+  max-height: 88vh;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem;
 }
 
 .asset-detail {
@@ -1641,6 +1654,8 @@ main {
   border: 1px solid rgba(59, 130, 246, 0.28);
   background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(30, 64, 175, 0.35));
   box-shadow: 0 28px 60px rgba(2, 6, 23, 0.45);
+  max-height: 100%;
+  overflow-y: auto;
 }
 
 .asset-detail--empty {
@@ -3597,19 +3612,10 @@ button {
 }
 
 /* Gallery Explorer Refresh */
-.gallery-explorer__layout {
-  margin-top: 2.5rem;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
-  gap: 2.5rem;
-  align-items: start;
-}
-
 .gallery-explorer__grid {
   display: grid;
-  grid-template-columns: repeat(5, 192px);
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 1.5rem;
-  justify-content: center;
   align-content: start;
 }
 
@@ -3716,10 +3722,30 @@ button {
   color: rgba(148, 163, 184, 0.65);
 }
 
-.gallery-explorer__detail {
-  position: sticky;
-  top: 1.5rem;
-  align-self: start;
+.gallery-detail-dialog {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 4rem 1.5rem;
+  z-index: 70;
+}
+
+.gallery-detail-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.78);
+  backdrop-filter: blur(6px);
+}
+
+.gallery-detail-dialog__container {
+  position: relative;
+  width: min(1080px, 94vw);
+  max-height: 88vh;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem;
 }
 
 .gallery-detail {
@@ -3731,13 +3757,8 @@ button {
   border: 1px solid rgba(148, 163, 184, 0.25);
   background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.75));
   box-shadow: 0 24px 60px rgba(2, 6, 23, 0.45);
-}
-
-.gallery-detail--empty {
-  justify-content: center;
-  text-align: center;
-  color: rgba(148, 163, 184, 0.75);
-  min-height: 320px;
+  max-height: 100%;
+  overflow-y: auto;
 }
 
 .gallery-detail__header {
@@ -4032,46 +4053,44 @@ button {
 }
 
 @media (max-width: 1280px) {
-  .gallery-explorer__layout {
-    grid-template-columns: minmax(0, 1fr);
+  .gallery-detail-dialog,
+  .asset-detail-dialog {
+    padding: 3rem 1rem;
   }
 
-  .gallery-explorer__detail {
-    position: relative;
-    top: auto;
-  }
-
-  .gallery-detail {
-    margin-top: 2rem;
-  }
-}
-
-@media (max-width: 1240px) {
-  .gallery-explorer__grid {
-    grid-template-columns: repeat(4, 192px);
+  .gallery-detail-dialog__container,
+  .asset-detail-dialog__container {
+    max-height: 86vh;
   }
 }
 
 @media (max-width: 1040px) {
-  .gallery-explorer__grid {
-    grid-template-columns: repeat(3, 192px);
+  .gallery-explorer__grid,
+  .asset-explorer__grid {
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
 }
 
 @media (max-width: 860px) {
-  .gallery-explorer__grid {
-    grid-template-columns: repeat(2, 192px);
+  .gallery-explorer__grid,
+  .asset-explorer__grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   }
 
   .gallery-image-modal__body {
     grid-template-columns: minmax(0, 1fr);
   }
+
+  .gallery-detail-dialog__container,
+  .asset-detail-dialog__container {
+    width: min(720px, 96vw);
+  }
 }
 
 @media (max-width: 640px) {
-  .gallery-explorer__grid {
-    grid-template-columns: repeat(1, minmax(0, 1fr));
-    justify-content: stretch;
+  .gallery-explorer__grid,
+  .asset-explorer__grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
   }
 
   .gallery-card {
@@ -4081,10 +4100,27 @@ button {
   .gallery-detail__grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .gallery-detail-dialog,
+  .asset-detail-dialog {
+    padding: 1.75rem 0.75rem;
+  }
+
+  .gallery-detail-dialog__container,
+  .asset-detail-dialog__container {
+    width: 100%;
+    padding: 0;
+  }
 }
 
 @media (max-width: 520px) {
   .gallery-detail__grid {
     grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .gallery-detail,
+  .asset-detail {
+    border-radius: 18px;
+    padding: 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the coupled detail sidebars in gallery and model explorer with modal dialogs that can be closed via back button, backdrop or Escape
- propagate close events back to the parent view to keep deep-links functional and update layout CSS for responsive modal containers and grids
- refresh README highlights to describe the dialog-based detail flows and add a changelog entry for the work

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd976f45988333b770024a583a2c45