### PR TITLE
Refine model metadata presentation

### DIFF
--- a/ChangeLog/2025-09-19-4b59727.md
+++ b/ChangeLog/2025-09-19-4b59727.md
@@ -1,0 +1,11 @@
+# Änderungsbericht – 19.09.2025 · Commit 4b59727
+
+## Zusammenfassung
+Die Detailansicht der Modell-Metadaten wurde neugestaltet, um verschachtelte JSON-Inhalte automatisch aufzubereiten und in einer übersichtlichen Tabelle darzustellen. Dadurch lassen sich auch umfangreiche Trainingsparameter schneller überblicken und durchsuchen.
+
+## Änderungen im Frontend
+- **AssetExplorer.tsx**: Einführung einer Normalisierung für Metadatenwerte, rekursives Aufbereiten verschachtelter Strukturen sowie Ersetzung der bisherigen Definitionsliste durch eine barrierearme Tabelle.
+- **index.css**: Ergänzung eines modernen Table-Designs inklusive Sticky-Header, Scrollbereich und optischer Hervorhebung der Werte.
+
+## Qualitätssicherung
+- `npm run lint`

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1798,22 +1798,81 @@ main {
   background: rgba(15, 23, 42, 0.45);
   border-radius: 18px;
   border: 1px solid rgba(59, 130, 246, 0.18);
+  overflow: hidden;
+}
+
+.asset-detail__metadata-scroll {
+  max-height: 26rem;
+  overflow: auto;
   padding: 1rem 1.2rem;
-  display: grid;
-  gap: 1rem;
 }
 
-.asset-detail__metadata dt {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
+.asset-detail__metadata-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 100%;
+}
+
+.asset-detail__metadata-table thead th {
+  text-align: left;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.75);
+  color: rgba(148, 163, 184, 0.85);
+  padding: 0 0.75rem 0.6rem 0;
+  position: sticky;
+  top: 0;
+  background: rgba(15, 23, 42, 0.96);
+  z-index: 1;
 }
 
-.asset-detail__metadata dd {
-  margin: 0.4rem 0 0;
+.asset-detail__metadata-table tbody tr + tr {
+  border-top: 1px solid rgba(59, 130, 246, 0.12);
+}
+
+.asset-detail__metadata-table tbody th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.78rem;
+  color: rgba(203, 213, 225, 0.95);
+  padding: 0.55rem 0.75rem 0.55rem 0;
+  vertical-align: top;
+  word-break: break-word;
+}
+
+.asset-detail__metadata-table tbody td {
+  padding: 0.55rem 0 0.55rem 0.75rem;
+  font-size: 0.82rem;
+  color: rgba(226, 232, 240, 0.95);
+  line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.asset-detail__metadata-value {
+  display: inline-block;
+  background: rgba(30, 41, 59, 0.65);
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  border-radius: 0.55rem;
+  padding: 0.25rem 0.45rem;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', monospace;
+  font-size: 0.78rem;
+  color: rgba(191, 219, 254, 0.95);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.asset-detail__metadata-scroll::-webkit-scrollbar {
+  width: 0.6rem;
+}
+
+.asset-detail__metadata-scroll::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.asset-detail__metadata-scroll::-webkit-scrollbar-thumb {
+  background: rgba(59, 130, 246, 0.35);
+  border-radius: 999px;
 }
 
 .asset-detail__gallery-links {


### PR DESCRIPTION
## Summary
- normalise and flatten model metadata so nested JSON details expand into readable key paths
- replace the definition list in the detail dialog with an accessible, scrollable metadata table
- refresh the styling around the metadata section for better scanning of long parameter lists

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd9f6710d48333a3cb4301f519268a