### PR TITLE
Refine home page card layout

### DIFF
--- a/ChangeLog/2025-09-19-commit-tbd-home-grid.md
+++ b/ChangeLog/2025-09-19-commit-tbd-home-grid.md
@@ -1,0 +1,18 @@
+# Changelog – 2025-09-19
+
+## Übersicht
+- Startseite auf das zweispaltige Dashboard-Design der Explorer ausgerichtet.
+- Neu gestaltete Karten für Modelle und Bilder inklusive klarer Meta-Blöcke.
+- Tag-Verlinkungen führen jetzt direkt zu vorgefilterten Explorer-Ansichten.
+- Dokumentation der Änderungen in der README aktualisiert.
+
+## Details
+### Frontend
+- Home-Ansicht verwendet jetzt modulare `home-card`-Kacheln mit exakt fünf Einträgen pro Abschnitt.
+- Responsive Grid-Konfiguration ermöglicht zwei gestapelte Bereiche („Neueste Modelle“ und „Neueste Bilder“).
+- Kurator:in, Model-Bezeichnung und Name werden pro Asset hervorgehoben.
+- Tags wurden als interaktive Buttons umgesetzt und triggern entsprechende Filter in Model- bzw. Galerie-Explorer.
+- Galerie-Explorer berücksichtigt Tag-Begriffe innerhalb der Volltextsuche.
+
+### Dokumentation
+- README-Highlight zum Home-Dashboard auf den neuen Aufbau mit Tag-basierten Deep Links angepasst.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Der aktuelle Prototyp fokussiert sich auf einen klaren Kontrollraum mit Service-
 - **Neue Shell** – Ein dauerhaft sichtbares Sidebar-Layout bündelt die Hauptnavigation (Home, Models, Images) und zeigt den Status von Frontend, Backend und MinIO auf einen Blick.
 - **Admin-Panel** – Skaliert für vierstellige Bestände mit Filterchips, Mehrfachauswahl, Bulk-Löschungen sowie direkter Galerie-
   und Albumbearbeitung inklusive Reihung und Metadatenpflege.
-- **Home-Dashboard** – Kachel-Layout mit den neuesten Modellen und Bildern inklusive Kurator:innen, Versionen, Prompts und Tag-Highlights.
+- **Home-Dashboard** – Zweigeteilte 5er-Grids für neue Modelle und Bilder mit klaren Meta-Blöcken (Name, Model, Kurator:in) und klickbaren Tag-Badges, die direkt in die gefilterten Explorer springen.
 - **Models** – Der ausgebaute Model Explorer bündelt Volltext, Typ- und Größenfilter mit einem festen 5er-Grid, Detail-Dialog samt Metadaten und Deep-Links direkt in die zugehörigen Bildgalerien.
 - **Images** – Der Galerie-Explorer nutzt feste Grid-Kacheln mit zufälligen Vorschaubildern, Scrollpagination sowie eine dialogbasierte Detailansicht pro Sammlung mit EXIF- und Promptanzeige in einer bildfüllenden Lightbox.
 - **Upload-Wizard** – Jederzeit erreichbar über die Shell; validiert Eingaben, verwaltet Datei-Drops und liefert unmittelbares Backend-Feedback – inklusive eigenem Galerie-Modus für Bildserien.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -13,6 +13,8 @@ interface AssetExplorerProps {
   onNavigateToGallery?: (galleryId: string) => void;
   initialAssetId?: string | null;
   onCloseDetail?: () => void;
+  externalSearchQuery?: string | null;
+  onExternalSearchApplied?: () => void;
 }
 
 type FileSizeFilter = 'all' | 'small' | 'medium' | 'large' | 'unknown';
@@ -257,6 +259,8 @@ export const AssetExplorer = ({
   onNavigateToGallery,
   initialAssetId,
   onCloseDetail,
+  externalSearchQuery,
+  onExternalSearchApplied,
 }: AssetExplorerProps) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -271,6 +275,16 @@ export const AssetExplorer = ({
 
   const deferredSearch = useDeferredValue(searchTerm);
   const normalizedQuery = normalize(deferredSearch.trim());
+
+  useEffect(() => {
+    if (!externalSearchQuery) {
+      return;
+    }
+
+    setSearchTerm(externalSearchQuery);
+    setSelectedTags([]);
+    onExternalSearchApplied?.();
+  }, [externalSearchQuery, onExternalSearchApplied]);
 
   const { ownerOptions, tagOptions, typeOptions } = useMemo(() => {
     const ownersMap = new Map<string, OwnerOption>();

--- a/frontend/src/components/GalleryExplorer.tsx
+++ b/frontend/src/components/GalleryExplorer.tsx
@@ -13,6 +13,8 @@ interface GalleryExplorerProps {
   onNavigateToModel?: (modelId: string) => void;
   initialGalleryId?: string | null;
   onCloseDetail?: () => void;
+  externalSearchQuery?: string | null;
+  onExternalSearchApplied?: () => void;
 }
 
 type VisibilityFilter = 'all' | 'public' | 'private';
@@ -93,12 +95,14 @@ const matchesSearch = (gallery: Gallery, query: string) => {
       if (entry.note) texts.push(entry.note);
       if (entry.imageAsset?.prompt) texts.push(entry.imageAsset.prompt);
       if (entry.imageAsset?.negativePrompt) texts.push(entry.imageAsset.negativePrompt);
+      entry.imageAsset?.tags.forEach((tag) => texts.push(tag.label));
       collectImageMetadataStrings(entry.imageAsset?.metadata).forEach((value) => texts.push(value));
       if (entry.modelAsset?.metadata) {
         collectModelMetadataStrings(entry.modelAsset.metadata as Record<string, unknown> | null).forEach((value) =>
           texts.push(value),
         );
       }
+      entry.modelAsset?.tags.forEach((tag) => texts.push(tag.label));
       return texts;
     }),
   ]
@@ -175,6 +179,8 @@ export const GalleryExplorer = ({
   onNavigateToModel,
   initialGalleryId,
   onCloseDetail,
+  externalSearchQuery,
+  onExternalSearchApplied,
 }: GalleryExplorerProps) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [visibility, setVisibility] = useState<VisibilityFilter>('all');
@@ -187,6 +193,15 @@ export const GalleryExplorer = ({
 
   const deferredSearch = useDeferredValue(searchTerm);
   const normalizedQuery = normalize(deferredSearch.trim());
+
+  useEffect(() => {
+    if (!externalSearchQuery) {
+      return;
+    }
+
+    setSearchTerm(externalSearchQuery);
+    onExternalSearchApplied?.();
+  }, [externalSearchQuery, onExternalSearchApplied]);
 
   const ownerOptions = useMemo(() => {
     const ownersMap = new Map<string, { id: string; label: string }>();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -392,31 +392,47 @@ body {
   color: rgba(203, 213, 225, 0.75);
 }
 
-.tile-grid {
+.home-section__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1.5rem;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.tile {
+@media (min-width: 1280px) {
+  .home-section__grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+.home-card {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  border-radius: 20px;
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  gap: 0;
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
   background: rgba(15, 23, 42, 0.65);
   overflow: hidden;
   box-shadow: 0 18px 42px rgba(15, 23, 42, 0.4);
+  min-height: 100%;
 }
 
-.tile__media {
+.home-card--model {
+  border-color: rgba(129, 140, 248, 0.28);
+  background: linear-gradient(165deg, rgba(30, 41, 59, 0.82), rgba(2, 6, 23, 0.7));
+}
+
+.home-card--image {
+  border-color: rgba(56, 189, 248, 0.28);
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.82), rgba(2, 6, 23, 0.7));
+}
+
+.home-card__media {
   position: relative;
   padding-bottom: 60%;
-  background: rgba(15, 23, 42, 0.8);
-  overflow: hidden;
+  background: rgba(15, 23, 42, 0.85);
 }
 
-.tile__media img {
+.home-card__media img {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -425,84 +441,112 @@ body {
   filter: saturate(1.1);
 }
 
-.tile__placeholder {
+.home-card__placeholder {
   position: absolute;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 0.85rem;
-  color: rgba(203, 213, 225, 0.7);
+  color: rgba(203, 213, 225, 0.75);
 }
 
-.tile__body {
+.home-card__body {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1.4rem;
+  gap: 0.85rem;
+  padding: 1.5rem 1.6rem 1.8rem;
 }
 
-.tile__header {
+.home-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.home-card__meta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.85rem;
+}
+
+.home-card__meta div {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
 
-.tile__title {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #f8fafc;
-}
-
-.tile__meta {
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.75);
-}
-
-.tile__description {
-  margin: 0;
-  font-size: 0.9rem;
-  color: rgba(203, 213, 225, 0.78);
-}
-
-.tile__details {
-  margin: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.85rem;
-}
-
-.tile__details div {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-}
-
-.tile__details dt {
+.home-card__meta dt {
   font-size: 0.7rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(148, 163, 184, 0.75);
 }
 
-.tile__details dd {
+.home-card__meta dd {
   margin: 0;
-  font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.88rem;
+  color: rgba(226, 232, 240, 0.92);
 }
 
-.tile__tags {
+.home-card__tags {
   margin: 0;
   padding: 0;
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.55rem;
+}
+
+.home-card__tag {
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(59, 130, 246, 0.38);
+  background: rgba(37, 99, 235, 0.18);
+  color: rgba(219, 234, 254, 0.95);
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.home-card__tag:hover,
+.home-card__tag:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(59, 130, 246, 0.35);
+  outline: none;
+  background: rgba(37, 99, 235, 0.28);
+}
+
+.home-card--image .home-card__tag {
+  border-color: rgba(56, 189, 248, 0.35);
+  background: rgba(14, 165, 233, 0.18);
+  color: rgba(224, 242, 254, 0.95);
+}
+
+.home-card--image .home-card__tag:hover,
+.home-card--image .home-card__tag:focus-visible {
+  box-shadow: 0 10px 18px rgba(14, 165, 233, 0.35);
+  background: rgba(14, 165, 233, 0.28);
+}
+
+.home-card__tags-more {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: rgba(148, 163, 184, 0.85);
   font-size: 0.75rem;
-  color: rgba(125, 211, 252, 0.9);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.home-card__tags-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.7);
 }
 
 .empty-state {
@@ -1092,11 +1136,11 @@ body {
     padding: 2.5rem 1.75rem 3rem;
   }
 
-  .tile-grid {
+  .image-gallery__grid {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 
-  .image-gallery__grid {
+  .home-section__grid {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- redesign the home dashboard to use stacked five-card grids with dedicated media cards for models and images
- wire tag chips to open the respective explorer views with prefilled search queries and extend gallery search to include tag labels
- refresh styling assets and documentation, including a changelog entry for the update

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cda51bc52c83338c1f613302bae9eb