### PR TITLE
Refine model detail presentation

### DIFF
--- a/ChangeLog/2025-09-19-3396953.md
+++ b/ChangeLog/2025-09-19-3396953.md
@@ -1,0 +1,13 @@
+# Änderungsbericht zum Commit 3396953
+
+## Überblick
+Am 19.09.2025 wurde die Modelldetailansicht im Frontend überarbeitet. Ziel war eine klarere Präsentation der Kerndaten sowie ein intuitiver Download-Einstieg direkt neben dem Vorschaubild.
+
+## Umgesetzte Arbeiten
+- Die Detailansicht ordnet Basisinformationen jetzt in einer zweispaltigen Zusammenfassung an. Links fasst eine Tabelle Modellname, Version, Kurator, Upload-Datum, Dateigröße und Checksumme zusammen, rechts steht das Vorschaubild mit nachgelagerter Download-Aktion.
+- Für den Download wurde ein prominenter Call-to-Action ergänzt, der direkt auf die im Storage hinterlegte Modell-Datei verweist. Fällt kein Vorschaubild an, informiert eine eingeblendete Hinweismeldung.
+- Die begleitenden Styles heben die neue Struktur hervor: Kartenrahmen, Tabellenstil sowie Hover-Zustände für den Download-Button sind auf das bestehende Dark-UI-Design abgestimmt.
+- Die Projektübersicht erhielt einen aktualisierten Highlight-Eintrag, der die modernisierte Detaildarstellung kommuniziert und so das README auf aktuellem Stand hält.
+
+## Auswirkungen
+Die Überarbeitung sorgt für eine ruhigere Informationsarchitektur in der Modelldetailansicht. Kurator:innen und Nutzer:innen erkennen relevante Eckdaten auf den ersten Blick und können das Modell unmittelbar herunterladen, ohne zwischen technischen Storage-Begriffen navigieren zu müssen.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ den Upload- und Kuration-Workflow.
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.
 - **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, 5-Spalten-Kacheln und nahtlosem Infinite Scroll samt aktiven Filterhinweisen.
+- **Neu gestaltete Modelldetails** – Zwei-Spalten-Layout mit kompakter Infotabelle, prominentem Preview inklusive Download-CTA und klar getrennten Metadatenbereichen.
 - **Direkte MinIO-Ingests** – Uploads landen unmittelbar in den konfigurierten Buckets, werden automatisch mit Tags versehen und tauchen ohne Wartezeit in Explorer & Galerien auf.
 - **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:objectId` durch das Backend geproxied; eine Datenbank-Tabelle ordnet die anonymisierten Objekt-IDs wieder den ursprünglichen Dateinamen zu.
 - **Galerie-Explorer** – Fünfspaltiges Grid mit zufälligen Vorschaubildern, fixen Kachelbreiten sowie einem eigenständigen Detail-Dialog pro Sammlung inklusive EXIF-Lightbox für jedes Bild.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -639,6 +639,17 @@ export const AssetExplorer = ({
     [activeAsset?.metadata],
   );
 
+  const modelDownloadUrl = useMemo(() => {
+    if (!activeAsset) {
+      return null;
+    }
+
+    return (
+      resolveStorageUrl(activeAsset.storagePath, activeAsset.storageBucket, activeAsset.storageObject) ??
+      activeAsset.storagePath
+    );
+  }, [activeAsset]);
+
   useEffect(() => {
     if (!isTagDialogOpen) {
       return undefined;
@@ -916,59 +927,73 @@ export const AssetExplorer = ({
                 </p>
               )}
 
-              {activeAsset.previewImage ? (
-                <div className="asset-detail__preview">
-                  <img
-                    src={
-                      resolveStorageUrl(
-                        activeAsset.previewImage,
-                        activeAsset.previewImageBucket,
-                        activeAsset.previewImageObject,
-                      ) ?? activeAsset.previewImage
-                    }
-                    alt={`Preview von ${activeAsset.title}`}
-                  />
+              <div className="asset-detail__summary">
+                <div className="asset-detail__info">
+                  <table className="asset-detail__info-table">
+                    <tbody>
+                      <tr>
+                        <th scope="row">Name</th>
+                        <td>{activeAsset.title}</td>
+                      </tr>
+                      <tr>
+                        <th scope="row">Version</th>
+                        <td>{activeAsset.version}</td>
+                      </tr>
+                      <tr>
+                        <th scope="row">Kurator</th>
+                        <td>{activeAsset.owner.displayName}</td>
+                      </tr>
+                      <tr>
+                        <th scope="row">Upload am</th>
+                        <td>{formatDate(activeAsset.createdAt)}</td>
+                      </tr>
+                      <tr>
+                        <th scope="row">Dateigröße</th>
+                        <td>{formatFileSize(activeAsset.fileSize)}</td>
+                      </tr>
+                      <tr>
+                        <th scope="row">Checksumme</th>
+                        <td>{activeAsset.checksum ?? '–'}</td>
+                      </tr>
+                    </tbody>
+                  </table>
                 </div>
-              ) : null}
-
-              <section className="asset-detail__section">
-                <h4>Speicher &amp; Größe</h4>
-                <dl>
-                  <div>
-                    <dt>Storage Objekt</dt>
-                    <dd>
-                      <a
-                        href={
-                          resolveStorageUrl(activeAsset.storagePath, activeAsset.storageBucket, activeAsset.storageObject) ??
-                          activeAsset.storagePath
+                <div className="asset-detail__preview-card">
+                  {activeAsset.previewImage ? (
+                    <div className="asset-detail__preview">
+                      <img
+                        src={
+                          resolveStorageUrl(
+                            activeAsset.previewImage,
+                            activeAsset.previewImageBucket,
+                            activeAsset.previewImageObject,
+                          ) ?? activeAsset.previewImage
                         }
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {activeAsset.storageObject ?? activeAsset.storagePath}
-                      </a>
-                    </dd>
-                  </div>
-                  {activeAsset.storageBucket ? (
-                    <div>
-                      <dt>Bucket</dt>
-                      <dd>{activeAsset.storageBucket}</dd>
+                        alt={`Preview von ${activeAsset.title}`}
+                      />
                     </div>
-                  ) : null}
-                  <div>
-                    <dt>Dateigröße</dt>
-                    <dd>{formatFileSize(activeAsset.fileSize)}</dd>
-                  </div>
-                  <div>
-                    <dt>Checksumme</dt>
-                    <dd>{activeAsset.checksum ?? '–'}</dd>
-                  </div>
-                  <div>
-                    <dt>Aktualisiert</dt>
-                    <dd>{formatDate(activeAsset.updatedAt)}</dd>
-                  </div>
-                </dl>
-              </section>
+                  ) : (
+                    <div className="asset-detail__preview asset-detail__preview--empty">
+                      <span>Kein Vorschaubild vorhanden.</span>
+                    </div>
+                  )}
+                  {modelDownloadUrl ? (
+                    <a
+                      className="asset-detail__download"
+                      href={modelDownloadUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      download
+                    >
+                      Modell herunterladen
+                    </a>
+                  ) : (
+                    <span className="asset-detail__download asset-detail__download--disabled">
+                      Download nicht verfügbar
+                    </span>
+                  )}
+                </div>
+              </div>
 
               <section className="asset-detail__section">
                 <h4>Tags</h4>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1931,12 +1931,69 @@ main {
   color: rgba(148, 163, 184, 0.75);
 }
 
+.asset-detail__summary {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .asset-detail__summary {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.95fr);
+    align-items: start;
+  }
+}
+
+.asset-detail__info,
+.asset-detail__preview-card {
+  padding: 1.15rem 1.35rem;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+}
+
+.asset-detail__preview-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.asset-detail__info-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.asset-detail__info-table th,
+.asset-detail__info-table td {
+  padding: 0.55rem 0;
+  font-size: 0.9rem;
+}
+
+.asset-detail__info-table th {
+  text-align: left;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.78);
+  width: 40%;
+}
+
+.asset-detail__info-table td {
+  color: rgba(226, 232, 240, 0.95);
+  word-break: break-word;
+}
+
+.asset-detail__info-table tr + tr th,
+.asset-detail__info-table tr + tr td {
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
+}
+
 .asset-detail__preview {
   border-radius: 22px;
   border: 1px solid rgba(148, 163, 184, 0.28);
   overflow: hidden;
   background: rgba(15, 23, 42, 0.55);
-  max-height: 220px;
+  max-height: 260px;
 }
 
 .asset-detail__preview img {
@@ -1944,6 +2001,56 @@ main {
   height: 100%;
   object-fit: cover;
   display: block;
+}
+
+.asset-detail__preview--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 180px;
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.asset-detail__download {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.2);
+  color: rgba(191, 219, 254, 0.95);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.asset-detail__download:hover,
+.asset-detail__download:focus-visible {
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #ffffff;
+  outline: none;
+}
+
+.asset-detail__download--disabled {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .asset-detail__section h4 {


### PR DESCRIPTION
## Summary
- reorganize the model asset detail dialog into a two-column layout with a structured info table and download action
- update styles to support the new summary cards, preview fallback, and download button states
- refresh project highlights and record the change in the dated changelog entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb15437648333905489ac0367b445