### PR TITLE
Implement model versioning workflow

### DIFF
--- a/ChangeLog/2025-09-19-5b1e08a.md
+++ b/ChangeLog/2025-09-19-5b1e08a.md
@@ -1,0 +1,19 @@
+# Changelog – 19.09.2025 (Commit 5b1e08a)
+
+## Überblick
+- Einführung eines vollwertigen Versionierungs-Workflows für bestehende Modelle inklusive Backend-API, Datenbankschema und Frontend-Integration.
+
+## Backend
+- Prisma-Schema um `ModelVersion` ergänzt und bestehende `ModelAsset`-Relation erweitert, um zusätzliche Versionen samt Safetensors-Metadaten zu speichern.
+- REST-Endpunkt `POST /api/assets/models/:id/versions` implementiert, inklusive Upload-Validierung, Storage-Handling in MinIO und Rückgabe der aktualisierten Modelcard.
+- Konsistente Aufräumroutinen für Storage-Objekte und Galerien bei Löschvorgängen erweitert, damit auch Versionen entfernt werden.
+- Typdefinition für `image-size` ergänzt, um TypeScript-Warnungen im Backend zu vermeiden.
+
+## Frontend
+- Modelcard überarbeitet: Beschreibung ersetzt den alten „Kuratiert von …“-Block, Version-Chips ermöglichen den Wechsel zwischen Safetensor-Ständen.
+- Neuer Dialog `ModelVersionDialog` ermöglicht das Anlegen zusätzlicher Versionen inkl. Preview-Upload und Erfolgsmeldung.
+- API-Client um `createModelVersion` erweitert und bestehende Modelcard-Komponenten für den neuen Workflow verdrahtet.
+- Styling angepasst, um Version-Chips und Aktionsbutton konsistent im UI darzustellen.
+
+## Qualitätssicherung
+- TypeScript-Linting für Backend (`npm run lint` im `backend`-Verzeichnis) und Frontend (`npm run lint` im `frontend`-Verzeichnis) erfolgreich ausgeführt.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ den Upload- und Kuration-Workflow.
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.
 - **Upload-Governance** – neue UploadDraft-Persistenz mit Audit-Trail, Größenlimit (≤ 2 GB), Dateianzahl-Limit (≤ 12 Dateien) und automatischem Übergang in die Analyse-Queue.
 - **Datengetriebene Explorer** – performante Filter für LoRA-Bibliothek & Galerien mit Volltextsuche, Tag-Badges, 5-Spalten-Kacheln und nahtlosem Infinite Scroll samt aktiven Filterhinweisen.
-- **Neu gestaltete Modelldetails** – Zwei-Spalten-Layout mit kompakter Infotabelle, prominentem Preview inklusive Download-CTA und klar getrennten Metadatenbereichen.
+- **Modelcard mit Versionierung** – Der Modelldialog heißt jetzt „Modelcard“, zeigt die Beschreibung direkt im Header, bietet Version-Chips zum Umschalten zwischen allen Safetensor-Ständen und enthält einen Upload-Flow für neue Versionen inklusive Preview-Handling.
 - **Direkte MinIO-Ingests** – Uploads landen unmittelbar in den konfigurierten Buckets, werden automatisch mit Tags versehen und tauchen ohne Wartezeit in Explorer & Galerien auf.
 - **Gesicherte Downloads** – Dateien werden über `/api/storage/:bucket/:objectId` durch das Backend geproxied; eine Datenbank-Tabelle ordnet die anonymisierten Objekt-IDs wieder den ursprünglichen Dateinamen zu.
 - **Galerie-Explorer** – Fünfspaltiges Grid mit zufälligen Vorschaubildern, fixen Kachelbreiten sowie einem eigenständigen Detail-Dialog pro Sammlung inklusive EXIF-Lightbox für jedes Bild.
@@ -144,7 +144,7 @@ Der aktuelle Prototyp fokussiert sich auf einen klaren Kontrollraum mit Service-
 - **Admin-Panel** – Skaliert für vierstellige Bestände mit Filterchips, Mehrfachauswahl, Bulk-Löschungen sowie direkter Galerie-
   und Albumbearbeitung inklusive Reihung und Metadatenpflege.
 - **Home-Dashboard** – Zweigeteilte 5er-Grids für neue Modelle und Bilder mit klaren Meta-Blöcken (Name, Model, Kurator:in) und klickbaren Tag-Badges, die direkt in die gefilterten Explorer springen.
-- **Models** – Der ausgebaute Model Explorer bündelt Volltext, Typ- und Größenfilter mit einem festen 5er-Grid, Detail-Dialog samt Metadaten und Deep-Links direkt in die zugehörigen Bildgalerien.
+- **Models** – Der ausgebaute Model Explorer bündelt Volltext, Typ- und Größenfilter mit einem festen 5er-Grid, Detail-Dialog samt Metadaten und Deep-Links direkt in die zugehörigen Bildgalerien. Die Modelcard bringt Version-Chips mit Live-Preview, Downloadumschaltung und einen integrierten Dialog für neue Modellversionen mit.
 - **Images** – Der Galerie-Explorer nutzt feste Grid-Kacheln mit zufälligen Vorschaubildern, Scrollpagination sowie eine dialogbasierte Detailansicht pro Sammlung mit EXIF- und Promptanzeige in einer bildfüllenden Lightbox.
 - **Upload-Wizard** – Jederzeit erreichbar über die Shell; validiert Eingaben, verwaltet Datei-Drops und liefert unmittelbares Backend-Feedback – inklusive eigenem Galerie-Modus für Bildserien.
 
@@ -184,6 +184,7 @@ Der Upload-Endpunkt validiert pro Request bis zu **12 Dateien** und reagiert mit
 - `DELETE /api/users/:id` – Benutzer:innen löschen (Admin-only, kein Self-Delete).
 - `POST /api/users/bulk-delete` – Mehrere Accounts in einem Schritt entfernen (Admin-only).
 - `POST /api/assets/models/bulk-delete` – Bulk-Löschung von Modellen inkl. Storage-Bereinigung.
+- `POST /api/assets/models/:id/versions` – Fügt einer bestehenden Modelcard eine neue Safetensor-Version inklusive Vorschaubild hinzu.
 - `POST /api/assets/images/bulk-delete` – Bulk-Löschung von Bildern und Cover-Bereinigung.
 - `PUT /api/galleries/:id` – Galerie-Metadaten, Sichtbarkeit und Reihenfolge bearbeiten.
 - `DELETE /api/galleries/:id` – Galerie inklusive Einträge löschen (Admin oder Owner).

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -59,8 +59,25 @@ model ModelAsset {
   owner        User         @relation("AssetOwner", fields: [ownerId], references: [id])
   tags         AssetTag[]
   galleryItems GalleryEntry[] @relation("GalleryModel")
+  versions     ModelVersion[]
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
+}
+
+model ModelVersion {
+  id           String      @id @default(cuid())
+  modelId      String
+  model        ModelAsset  @relation(fields: [modelId], references: [id])
+  version      String
+  storagePath  String      @unique
+  previewImage String?
+  metadata     Json?
+  fileSize     Int?
+  checksum     String?
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
+
+  @@unique([modelId, version])
 }
 
 model ImageAsset {

--- a/backend/src/types/image-size.d.ts
+++ b/backend/src/types/image-size.d.ts
@@ -1,0 +1,1 @@
+declare module 'image-size';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -186,6 +186,18 @@ export const App = () => {
     }
   };
 
+  const handleAssetUpdated = useCallback((updatedAsset: ModelAsset) => {
+    setAssets((previous) => {
+      const index = previous.findIndex((asset) => asset.id === updatedAsset.id);
+      if (index === -1) {
+        return previous;
+      }
+      const next = [...previous];
+      next[index] = updatedAsset;
+      return next;
+    });
+  }, []);
+
   const handleOpenAssetUpload = () => {
     if (!isAuthenticated) {
       setIsLoginOpen(true);
@@ -419,6 +431,8 @@ export const App = () => {
           onCloseDetail={() => setFocusedAssetId(null)}
           externalSearchQuery={modelTagQuery}
           onExternalSearchApplied={() => setModelTagQuery(null)}
+          onAssetUpdated={handleAssetUpdated}
+          authToken={token}
         />
       );
     }

--- a/frontend/src/components/ModelVersionDialog.tsx
+++ b/frontend/src/components/ModelVersionDialog.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { FormEvent, MouseEvent } from 'react';
+
+import { api, ApiError } from '../lib/api';
+import type { ModelAsset, ModelVersion } from '../types/api';
+
+interface ModelVersionDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  model: ModelAsset;
+  token: string | null | undefined;
+  onSuccess?: (updated: ModelAsset, createdVersion: ModelVersion | null) => void;
+}
+
+export const ModelVersionDialog = ({ isOpen, onClose, model, token, onSuccess }: ModelVersionDialogProps) => {
+  const [version, setVersion] = useState('');
+  const [modelFile, setModelFile] = useState<File | null>(null);
+  const [previewFile, setPreviewFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [details, setDetails] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const existingVersionIds = useMemo(() => new Set(model.versions.map((entry) => entry.id)), [model.versions]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setVersion('');
+      setModelFile(null);
+      setPreviewFile(null);
+      setError(null);
+      setDetails([]);
+      setIsSubmitting(false);
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (!isSubmitting) {
+          onClose();
+        }
+      }
+    };
+
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = '';
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, isSubmitting, onClose]);
+
+  const handleBackdropClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget && !isSubmitting) {
+        onClose();
+      }
+    },
+    [isSubmitting, onClose],
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) {
+      return;
+    }
+
+    const trimmedVersion = version.trim();
+    if (!token) {
+      setError('Bitte melde dich an, um eine neue Modellversion hochzuladen.');
+      setDetails([]);
+      return;
+    }
+
+    if (trimmedVersion.length === 0) {
+      setError('Bitte gib eine Versionsnummer an.');
+      setDetails([]);
+      return;
+    }
+
+    if (!modelFile) {
+      setError('Bitte wähle die Safetensors-Datei aus.');
+      setDetails([]);
+      return;
+    }
+
+    if (!modelFile.name.toLowerCase().endsWith('.safetensors')) {
+      setError('Die Modelldatei muss im Safetensors-Format vorliegen.');
+      setDetails([]);
+      return;
+    }
+
+    if (!previewFile) {
+      setError('Bitte wähle ein Vorschaubild aus.');
+      setDetails([]);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setDetails([]);
+
+    try {
+      const updatedAsset = await api.createModelVersion(token, model.id, {
+        version: trimmedVersion,
+        modelFile,
+        previewFile,
+      });
+
+      const createdVersion =
+        updatedAsset.versions.find((entry) => !existingVersionIds.has(entry.id)) ??
+        updatedAsset.versions.find((entry) => entry.version === trimmedVersion) ??
+        null;
+
+      onSuccess?.(updatedAsset, createdVersion);
+      onClose();
+    } catch (uploadError) {
+      if (uploadError instanceof ApiError) {
+        setError(uploadError.message);
+        setDetails(uploadError.details ?? []);
+      } else if (uploadError instanceof Error) {
+        setError(uploadError.message);
+        setDetails([]);
+      } else {
+        setError('Unbekannter Fehler beim Hochladen der Modellversion.');
+        setDetails([]);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="model-version-dialog" role="dialog" aria-modal="true" aria-labelledby="model-version-title" onClick={handleBackdropClick}>
+      <div className="model-version-dialog__content">
+        <header className="model-version-dialog__header">
+          <h3 id="model-version-title">Neue Version für {model.title}</h3>
+          <button
+            type="button"
+            className="model-version-dialog__close"
+            onClick={onClose}
+            disabled={isSubmitting}
+          >
+            Schließen
+          </button>
+        </header>
+        <form className="model-version-dialog__form" onSubmit={handleSubmit}>
+          <label className="model-version-dialog__field">
+            <span>Versionsnummer</span>
+            <input
+              type="text"
+              value={version}
+              onChange={(event) => setVersion(event.target.value)}
+              placeholder="z. B. 1.2.0"
+              disabled={isSubmitting}
+              required
+            />
+          </label>
+          <label className="model-version-dialog__field">
+            <span>Safetensors-Datei</span>
+            <input
+              type="file"
+              accept=".safetensors"
+              onChange={(event) => setModelFile(event.target.files?.[0] ?? null)}
+              disabled={isSubmitting}
+              required
+            />
+            {modelFile ? <small className="model-version-dialog__hint">{modelFile.name}</small> : null}
+          </label>
+          <label className="model-version-dialog__field">
+            <span>Vorschaubild</span>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(event) => setPreviewFile(event.target.files?.[0] ?? null)}
+              disabled={isSubmitting}
+              required
+            />
+            {previewFile ? <small className="model-version-dialog__hint">{previewFile.name}</small> : null}
+          </label>
+
+          {error ? (
+            <div className="model-version-dialog__error" role="alert">
+              <p>{error}</p>
+              {details.length > 0 ? (
+                <ul>
+                  {details.map((entry) => (
+                    <li key={entry}>{entry}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ) : null}
+
+          <footer className="model-version-dialog__actions">
+            <button type="button" onClick={onClose} className="model-version-dialog__secondary" disabled={isSubmitting}>
+              Abbrechen
+            </button>
+            <button type="submit" className="model-version-dialog__primary" disabled={isSubmitting || !token}>
+              {isSubmitting ? 'Lädt …' : 'Version hochladen'}
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1846,6 +1846,155 @@ main {
   border-radius: 999px;
 }
 
+.model-version-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.78);
+  padding: 1.5rem;
+}
+
+.model-version-dialog__content {
+  width: min(420px, 100%);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.96);
+  box-shadow: 0 28px 64px rgba(15, 23, 42, 0.55);
+  padding: 1.5rem;
+}
+
+.model-version-dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.model-version-dialog__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #f8fafc;
+}
+
+.model-version-dialog__close {
+  border: none;
+  background: transparent;
+  color: rgba(148, 163, 184, 0.75);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.model-version-dialog__close:hover,
+.model-version-dialog__close:focus-visible {
+  color: #f8fafc;
+  outline: none;
+}
+
+.model-version-dialog__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.model-version-dialog__field {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.model-version-dialog__field span {
+  font-weight: 600;
+}
+
+.model-version-dialog__field input[type='text'],
+.model-version-dialog__field input[type='file'] {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.38);
+  background: rgba(15, 23, 42, 0.58);
+  color: #f8fafc;
+  font-size: 0.9rem;
+  padding: 0.6rem 0.75rem;
+}
+
+.model-version-dialog__field input[type='file'] {
+  padding: 0.45rem 0.65rem;
+}
+
+.model-version-dialog__field input:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.55);
+  outline-offset: 2px;
+}
+
+.model-version-dialog__hint {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.model-version-dialog__error {
+  border-radius: 14px;
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  background: rgba(239, 68, 68, 0.1);
+  color: #fecaca;
+  padding: 0.85rem;
+  font-size: 0.85rem;
+}
+
+.model-version-dialog__error ul {
+  margin: 0.45rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.model-version-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.model-version-dialog__secondary,
+.model-version-dialog__primary {
+  border-radius: 999px;
+  border: none;
+  padding: 0.55rem 1.35rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.model-version-dialog__secondary {
+  background: rgba(15, 23, 42, 0.4);
+  color: rgba(226, 232, 240, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.model-version-dialog__secondary:hover,
+.model-version-dialog__secondary:focus-visible {
+  color: #f8fafc;
+  border-color: rgba(148, 163, 184, 0.6);
+  outline: none;
+}
+
+.model-version-dialog__primary {
+  background: rgba(59, 130, 246, 0.65);
+  color: #0b1120;
+  font-weight: 600;
+}
+
+.model-version-dialog__primary:hover,
+.model-version-dialog__primary:focus-visible {
+  background: rgba(59, 130, 246, 0.78);
+  outline: none;
+}
+
+.model-version-dialog__primary:disabled,
+.model-version-dialog__secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .asset-detail {
   display: flex;
   flex-direction: column;
@@ -1890,6 +2039,27 @@ main {
   color: rgba(203, 213, 225, 0.85);
 }
 
+.asset-detail__eyebrow {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  color: rgba(203, 213, 225, 0.8);
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.asset-detail__subtitle {
+  margin: 0.4rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.asset-detail__subtitle--muted {
+  color: rgba(148, 163, 184, 0.75);
+}
+
 .asset-detail__version {
   display: inline-block;
   padding: 0.25rem 0.65rem;
@@ -1900,6 +2070,70 @@ main {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(191, 219, 254, 0.9);
+}
+
+.asset-detail__version-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.75rem;
+  align-items: center;
+}
+
+.asset-detail__version-chip {
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  background: rgba(96, 165, 250, 0.14);
+  color: rgba(191, 219, 254, 0.92);
+  padding: 0.35rem 0.85rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.asset-detail__version-chip:hover,
+.asset-detail__version-chip:focus-visible {
+  background: rgba(96, 165, 250, 0.28);
+  border-color: rgba(96, 165, 250, 0.55);
+  color: #f8fafc;
+  outline: none;
+}
+
+.asset-detail__version-chip--active {
+  background: rgba(59, 130, 246, 0.38);
+  border-color: rgba(96, 165, 250, 0.7);
+  color: #f8fafc;
+}
+
+.asset-detail__version-add {
+  border-radius: 999px;
+  border: 1px dashed rgba(148, 163, 184, 0.42);
+  background: transparent;
+  color: rgba(226, 232, 240, 0.85);
+  padding: 0.35rem 0.95rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.asset-detail__version-add:hover,
+.asset-detail__version-add:focus-visible {
+  border-color: rgba(96, 165, 250, 0.6);
+  background: rgba(59, 130, 246, 0.2);
+  color: #f8fafc;
+  outline: none;
+}
+
+.asset-detail__version-add:disabled {
+  cursor: not-allowed;
+  border-color: rgba(148, 163, 184, 0.25);
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.asset-detail__version-feedback {
+  margin: 0.6rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(96, 165, 250, 0.95);
 }
 
 .asset-detail__close {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -19,6 +19,23 @@ export interface User {
   updatedAt?: string;
 }
 
+export interface ModelVersion {
+  id: string;
+  version: string;
+  storagePath: string;
+  storageBucket?: string | null;
+  storageObject?: string | null;
+  previewImage?: string | null;
+  previewImageBucket?: string | null;
+  previewImageObject?: string | null;
+  fileSize?: number | null;
+  checksum?: string | null;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+  isPrimary: boolean;
+}
+
 export interface ModelAsset {
   id: string;
   slug: string;
@@ -40,6 +57,9 @@ export interface ModelAsset {
     email: string;
   };
   tags: Tag[];
+  versions: ModelVersion[];
+  latestVersionId: string;
+  primaryVersionId: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- add Prisma schema and backend routing to manage model versions, including upload validation and cleanup
- enhance the Modelcard UI with version chips, a dedicated upload dialog, and API integration for creating versions
- refresh README highlights and document the change in a dated changelog entry

## Testing
- `cd backend && npm run lint`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cdb4ce246c8333ac75394bc4147c5c