### PR TITLE
Translate frontend UI to English

### DIFF
--- a/ChangeLog/2025-09-19-commit-tbd-asset-explorer-copy.md
+++ b/ChangeLog/2025-09-19-commit-tbd-asset-explorer-copy.md
@@ -1,0 +1,11 @@
+# Changelog – 2025-09-19
+
+## Kontext
+Im Asset-Explorer befanden sich noch einzelne deutschsprachige Texte in Filterlabels und Debug-Ausgaben. Für eine vollständig englische Oberfläche sollten auch diese letzten Stellen bereinigt werden.
+
+## Umsetzung
+- Dateigrößen-Label `Unbekannt` zu `Unknown` geändert, damit alle Filteroptionen englisch erscheinen.
+- Entwicklungs-Logmeldung bei fehlgeschlagenem Metadaten-Parsing ins Englische übertragen.
+
+## Tests & Validierung
+- `npm run lint`

--- a/ChangeLog/2025-09-19-commit-tbd-upload-wizard-translation.md
+++ b/ChangeLog/2025-09-19-commit-tbd-upload-wizard-translation.md
@@ -1,0 +1,14 @@
+# Changelog – 2025-09-19
+
+## Kontext
+Der Upload-Assistent enthielt noch zahlreiche deutschsprachige Texte, Platzhalter und Statusmeldungen. Für eine konsistente englische Nutzeroberfläche sollten sämtliche verbleibenden Strings überprüft, übersetzt und auf Lesbarkeit hin optimiert werden. Zusätzlich musste die README den Fortschritt der Frontend-Übersetzung widerspiegeln.
+
+## Umsetzung
+- Alle Nutzer:innen sichtbaren Texte im `UploadWizard` wurden ins Englische übertragen, inklusive Validierungsfehlern, Hilfetexten, Fortschrittsanzeige und Footer-Aktionen.
+- Neue Mapping-Konstante `CATEGORY_LABELS` ergänzt, damit Zusammenfassungen die englischen Kategorienamen anzeigen.
+- Erfolgs- und Reviewmeldungen neu formuliert, damit Beschreibungen, Upload-Limits sowie Benachrichtigungen natürliche englische Formulierungen verwenden.
+- Bereits angepasste Komponenten (`App`, `AdminPanel`, `AssetExplorer`, `GalleryExplorer`, `LoginDialog`, `ModelVersionDialog`, `AssetCard`) liegen in dieser Änderung konsolidiert in englischer Sprache vor.
+- README-Highlights um einen Hinweis auf das nun englischsprachige UI ergänzt.
+
+## Tests & Validierung
+- `npm run lint`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ den Upload- und Kuration-Workflow.
 - **Dashboard-Navigation** – Linke Seitenleiste mit direkter Umschaltung zwischen Home, Models und Images sowie Live-Service-Status für Frontend, Backend und MinIO.
 - **Rollenbasierte Authentifizierung** – Login-Dialog mit JWT-Token, persistiertem Zustand und Admin-Dashboard für Benutzer-, Modell- und Bildverwaltung.
 - **Upload-Wizard** – dreistufiger Assistent für Basisdaten, Dateiupload & Review inklusive Validierungen, Drag & Drop sowie Rückmeldung aus dem produktiven Upload-Endpunkt (`POST /api/uploads`).
+- **Englischsprachiges UI** – Navigation, Explorer, Dialoge und der Upload-Assistent wurden konsequent ins Englische übertragen und bieten eine durchgängige Nutzererfahrung.
 - **Model-Uploads mit Fokus** – Beim Modell-Assistenten sind exakt eine Safetensor-/ZIP-Datei plus ein Vorschaubild erlaubt; zusätzliche Render lassen sich später in der Galerie ergänzen.
 - **Galerie-Entwürfe** – separater Bild-Upload aus dem Galerie-Explorer, Multi-Upload (bis 12 Dateien/2 GB) mit rollenbasiertem Galerie-Dropdown oder direkter Neuanlage.
 - **Produktionsreifes Frontend** – Sticky-Navigation, Live-Status-Badge, Trust-Metriken und CTA-Panels transportieren einen fertigen Produktlook inklusive Toast-Benachrichtigungen für Upload-Events.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,34 +24,34 @@ interface ServiceIndicator {
 const viewMeta: Record<ViewKey, { title: string; description: string }> = {
   home: {
     title: 'Home',
-    description: 'Überblick über neue Modelle und Bild-Uploads – direkt aus Backend und Storage gespeist.',
+    description: 'Overview of recent models and image uploads—synchronized with the backend and storage.',
   },
   models: {
     title: 'Models',
-    description: 'LoRA-Explorer mit Volltextsuche, Typfiltern und Kurator:innen-Ansicht.',
+    description: 'LoRA explorer with full-text search, type filters, and curator tooling.',
   },
   images: {
     title: 'Images',
-    description: 'Bildgalerie mit Prompt-Details und kuratierten Sets für Präsentationen.',
+    description: 'Image gallery with prompt details and curated sets for presentations.',
   },
   admin: {
     title: 'Administration',
     description:
-      'Geführte Steuerzentrale mit Filter- und Bulk-Werkzeugen für Accounts, Modelle, Bilder und Galerien.',
+      'Guided control center with filters and bulk tools for accounts, models, images, and galleries.',
   },
 };
 
 const statusLabels: Record<ServiceState, string> = {
   online: 'Online',
   offline: 'Offline',
-  degraded: 'Eingeschränkt',
-  unknown: 'Unbekannt',
+  degraded: 'Degraded',
+  unknown: 'Unknown',
 };
 
 const createInitialStatus = (): Record<ServiceStatusKey, ServiceIndicator> => ({
-  frontend: { label: 'Frontend', status: 'online', message: 'UI aktiv.' },
-  backend: { label: 'Backend', status: 'unknown', message: 'Status wird geprüft …' },
-  minio: { label: 'MinIO', status: 'unknown', message: 'Status wird geprüft …' },
+  frontend: { label: 'Frontend', status: 'online', message: 'UI active.' },
+  backend: { label: 'Backend', status: 'unknown', message: 'Status check in progress…' },
+  minio: { label: 'MinIO', status: 'unknown', message: 'Status check in progress…' },
 });
 
 export const App = () => {
@@ -86,24 +86,24 @@ export const App = () => {
     try {
       const status = await api.getServiceStatus();
       setServiceStatus({
-        frontend: { label: 'Frontend', status: 'online', message: 'UI aktiv.' },
+        frontend: { label: 'Frontend', status: 'online', message: 'UI active.' },
         backend: {
           label: 'Backend',
           status: status.services.backend.status ?? 'online',
-          message: status.services.backend.message ?? 'API erreichbar.',
+          message: status.services.backend.message ?? 'API available.',
         },
         minio: {
           label: 'MinIO',
           status: status.services.minio.status ?? 'online',
-          message: status.services.minio.message ?? 'Storage verfügbar.',
+          message: status.services.minio.message ?? 'Storage available.',
         },
       });
     } catch (error) {
       console.error('Service status fetch failed', error);
       setServiceStatus({
-        frontend: { label: 'Frontend', status: 'online', message: 'UI aktiv.' },
-        backend: { label: 'Backend', status: 'offline', message: 'Backend nicht erreichbar.' },
-        minio: { label: 'MinIO', status: 'offline', message: 'Storage nicht erreichbar.' },
+        frontend: { label: 'Frontend', status: 'online', message: 'UI active.' },
+        backend: { label: 'Backend', status: 'offline', message: 'Backend unavailable.' },
+        minio: { label: 'MinIO', status: 'offline', message: 'Storage unavailable.' },
       });
     }
   }, []);
@@ -134,7 +134,7 @@ export const App = () => {
       setErrorMessage(null);
     } catch (error) {
       console.error(error);
-      setErrorMessage('Backend noch nicht erreichbar. Bitte Server prüfen oder später erneut versuchen.');
+      setErrorMessage('Backend not reachable yet. Please check the server or try again later.');
       setUsers([]);
     } finally {
       setIsLoading(false);
@@ -178,7 +178,7 @@ export const App = () => {
         type: 'success',
         message:
           result.message ??
-          'Upload-Session wurde erstellt. Die Inhalte erscheinen nach Abschluss der Hintergrundanalyse.',
+          'Upload session created. Content will appear after the background analysis finishes.',
       });
       refreshData().catch((error) => console.error('Failed to refresh after upload', error));
     } else {
@@ -247,7 +247,7 @@ export const App = () => {
       setLoginError(null);
       await refreshData();
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Anmeldung fehlgeschlagen.';
+      const message = error instanceof Error ? error.message : 'Sign in failed.';
       setLoginError(message);
       throw error;
     } finally {
@@ -279,7 +279,7 @@ export const App = () => {
           {previewUrl ? (
             <img src={previewUrl} alt={asset.title} loading="lazy" />
           ) : (
-            <span className="home-card__placeholder">Kein Vorschaubild verfügbar</span>
+            <span className="home-card__placeholder">No preview available</span>
           )}
         </div>
         <div className="home-card__body">
@@ -290,7 +290,7 @@ export const App = () => {
               <dd>{modelType?.label ?? 'LoRA-Asset'}</dd>
             </div>
             <div>
-              <dt>Kurator:in</dt>
+              <dt>Curator</dt>
               <dd>{asset.owner.displayName}</dd>
             </div>
           </dl>
@@ -310,7 +310,7 @@ export const App = () => {
               {remainingTagCount > 0 ? <li className="home-card__tags-more">+{remainingTagCount}</li> : null}
             </ul>
           ) : (
-            <p className="home-card__tags-empty">Noch keine Tags vergeben.</p>
+            <p className="home-card__tags-empty">No tags assigned yet.</p>
           )}
         </div>
       </article>
@@ -329,7 +329,7 @@ export const App = () => {
           {imageUrl ? (
             <img src={imageUrl} alt={image.title} loading="lazy" />
           ) : (
-            <span className="home-card__placeholder">Kein Bild verfügbar</span>
+            <span className="home-card__placeholder">No image available</span>
           )}
         </div>
         <div className="home-card__body">
@@ -337,10 +337,10 @@ export const App = () => {
           <dl className="home-card__meta">
             <div>
               <dt>Model</dt>
-              <dd>{image.metadata?.model ?? 'Unbekannt'}</dd>
+              <dd>{image.metadata?.model ?? 'Unknown'}</dd>
             </div>
             <div>
-              <dt>Kurator:in</dt>
+              <dt>Curator</dt>
               <dd>{image.owner.displayName}</dd>
             </div>
           </dl>
@@ -360,7 +360,7 @@ export const App = () => {
               {remainingTagCount > 0 ? <li className="home-card__tags-more">+{remainingTagCount}</li> : null}
             </ul>
           ) : (
-            <p className="home-card__tags-empty">Noch keine Tags vergeben.</p>
+            <p className="home-card__tags-empty">No tags assigned yet.</p>
           )}
         </div>
       </article>
@@ -371,8 +371,8 @@ export const App = () => {
     <div className="home-grid">
       <section className="home-section">
         <header className="home-section__header">
-          <h2>Neueste Modelle</h2>
-          <p>Die jüngsten Uploads aus dem Model-Explorer als kompakte Kacheln.</p>
+          <h2>Latest models</h2>
+          <p>The most recent uploads from the model explorer presented as compact tiles.</p>
         </header>
         <div className="home-section__grid">
           {isLoading && assets.length === 0
@@ -380,14 +380,14 @@ export const App = () => {
             : modelTiles}
         </div>
         {!isLoading && modelTiles.length === 0 ? (
-          <p className="empty-state">Noch keine Modelle verfügbar.</p>
+          <p className="empty-state">No models available yet.</p>
         ) : null}
       </section>
 
       <section className="home-section">
         <header className="home-section__header">
-          <h2>Neueste Bilder</h2>
-          <p>Frisch gerenderte Referenzen inklusive Prompt-Auszügen.</p>
+          <h2>Latest images</h2>
+          <p>Freshly rendered references including prompt excerpts.</p>
         </header>
         <div className="home-section__grid">
           {isLoading && images.length === 0
@@ -395,7 +395,7 @@ export const App = () => {
             : imageTiles}
         </div>
         {!isLoading && imageTiles.length === 0 ? (
-          <p className="empty-state">Noch keine Bilder vorhanden.</p>
+          <p className="empty-state">No images available yet.</p>
         ) : null}
       </section>
     </div>
@@ -404,7 +404,7 @@ export const App = () => {
   const renderContent = () => {
     if (activeView === 'admin') {
       if (!authUser || authUser.role !== 'ADMIN' || !token) {
-        return <div className="content__alert">Administrationsbereich erfordert ein angemeldetes Admin-Konto.</div>;
+        return <div className="content__alert">The admin area requires a signed-in admin account.</div>;
       }
 
       return (
@@ -463,7 +463,7 @@ export const App = () => {
             <span className="sidebar__logo">VisionSuit</span>
             <span className="sidebar__tagline">AI Asset Control</span>
           </div>
-          <nav className="sidebar__nav" aria-label="Hauptnavigation">
+          <nav className="sidebar__nav" aria-label="Main navigation">
             {availableViews.map((view) => (
               <button
                 key={view}
@@ -480,9 +480,9 @@ export const App = () => {
             {isAuthenticated ? (
               <>
                 <p className="sidebar__auth-name">{authUser?.displayName}</p>
-                <p className="sidebar__auth-role">{authUser?.role === 'ADMIN' ? 'Administrator:in' : 'Kurator:in'}</p>
+                <p className="sidebar__auth-role">{authUser?.role === 'ADMIN' ? 'Administrator' : 'Curator'}</p>
                 <button type="button" className="sidebar__auth-button" onClick={handleLogout} disabled={isLoggingIn}>
-                  Abmelden
+                  Sign out
                 </button>
               </>
             ) : (
@@ -492,7 +492,7 @@ export const App = () => {
                 onClick={() => setIsLoginOpen(true)}
                 disabled={isLoggingIn}
               >
-                Anmelden
+                Sign in
               </button>
             )}
           </div>

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -123,7 +123,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
       setStatus({ type: 'success', message: successMessage });
       await onRefresh();
     } catch (error) {
-      setStatus({ type: 'error', message: error instanceof Error ? error.message : 'Aktion fehlgeschlagen.' });
+      setStatus({ type: 'error', message: error instanceof Error ? error.message : 'Action failed.' });
     } finally {
       setIsBusy(false);
     }
@@ -286,7 +286,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
     const bio = (formData.get('bio') as string | null)?.trim();
 
     if (!email || !displayName || !password) {
-      setStatus({ type: 'error', message: 'Alle Pflichtfelder müssen ausgefüllt sein.' });
+      setStatus({ type: 'error', message: 'All required fields must be filled in.' });
       return;
     }
 
@@ -303,7 +303,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
           .then(() => {
             event.currentTarget.reset();
           }),
-      'Benutzer:in wurde angelegt.',
+      'User account created.',
     );
   };
 
@@ -335,16 +335,16 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
             passwordField.value = '';
           }
         }),
-      'Benutzerdaten wurden aktualisiert.',
+      'User details updated.',
     );
   };
 
   const handleDeleteUser = async (userId: string) => {
-    if (!window.confirm('Soll dieser Account wirklich gelöscht werden?')) {
+    if (!window.confirm('Are you sure you want to delete this account?')) {
       return;
     }
 
-    await withStatus(() => api.deleteUser(token, userId), 'Benutzer:in wurde gelöscht.');
+    await withStatus(() => api.deleteUser(token, userId), 'User account deleted.');
     setSelectedUsers((previous) => {
       const next = new Set(previous);
       next.delete(userId);
@@ -357,7 +357,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
     if (ids.length === 0) {
       return;
     }
-    if (!window.confirm(`${ids.length} Accounts wirklich löschen?`)) {
+    if (!window.confirm(`Delete ${ids.length} accounts?`)) {
       return;
     }
 
@@ -366,7 +366,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
         api.bulkDeleteUsers(token, ids).then(() => {
           setSelectedUsers(new Set());
         }),
-      `${ids.length} Accounts entfernt.`,
+      `${ids.length} accounts removed.`,
     );
   };
 
@@ -387,15 +387,15 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
       ownerId,
     };
 
-    await withStatus(() => api.updateModelAsset(token, model.id, payload), 'Modell wurde aktualisiert.');
+    await withStatus(() => api.updateModelAsset(token, model.id, payload), 'Model updated.');
   };
 
   const handleDeleteModel = async (model: ModelAsset) => {
-    if (!window.confirm(`Modell "${model.title}" wirklich löschen?`)) {
+    if (!window.confirm(`Delete model "${model.title}"?`)) {
       return;
     }
 
-    await withStatus(() => api.deleteModelAsset(token, model.id), 'Modell wurde gelöscht.');
+    await withStatus(() => api.deleteModelAsset(token, model.id), 'Model deleted.');
     setSelectedModels((previous) => {
       const next = new Set(previous);
       next.delete(model.id);
@@ -409,7 +409,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
       return;
     }
 
-    if (!window.confirm(`${ids.length} Modelle wirklich löschen?`)) {
+    if (!window.confirm(`Delete ${ids.length} models?`)) {
       return;
     }
 
@@ -418,7 +418,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
         api.bulkDeleteModelAssets(token, ids).then(() => {
           setSelectedModels(new Set());
         }),
-      `${ids.length} Modelle entfernt.`,
+      `${ids.length} models removed.`,
     );
   };
 
@@ -455,15 +455,15 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
       },
     };
 
-    await withStatus(() => api.updateImageAsset(token, image.id, payload), 'Bild wurde aktualisiert.');
+    await withStatus(() => api.updateImageAsset(token, image.id, payload), 'Image updated.');
   };
 
   const handleDeleteImage = async (image: ImageAsset) => {
-    if (!window.confirm(`Bild "${image.title}" wirklich löschen?`)) {
+    if (!window.confirm(`Delete image "${image.title}"?`)) {
       return;
     }
 
-    await withStatus(() => api.deleteImageAsset(token, image.id), 'Bild wurde gelöscht.');
+    await withStatus(() => api.deleteImageAsset(token, image.id), 'Image deleted.');
     setSelectedImages((previous) => {
       const next = new Set(previous);
       next.delete(image.id);
@@ -477,7 +477,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
       return;
     }
 
-    if (!window.confirm(`${ids.length} Bilder wirklich löschen?`)) {
+    if (!window.confirm(`Delete ${ids.length} images?`)) {
       return;
     }
 
@@ -486,7 +486,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
         api.bulkDeleteImageAssets(token, ids).then(() => {
           setSelectedImages(new Set());
         }),
-      `${ids.length} Bilder entfernt.`,
+      `${ids.length} images removed.`,
     );
   };
 
@@ -530,15 +530,15 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
       removeEntryIds: removeEntryIds.length > 0 ? removeEntryIds : undefined,
     };
 
-    await withStatus(() => api.updateGallery(token, gallery.id, payload), 'Galerie wurde aktualisiert.');
+    await withStatus(() => api.updateGallery(token, gallery.id, payload), 'Gallery updated.');
   };
 
   const handleDeleteGallery = async (gallery: Gallery) => {
-    if (!window.confirm(`Galerie "${gallery.title}" wirklich löschen?`)) {
+    if (!window.confirm(`Delete gallery "${gallery.title}"?`)) {
       return;
     }
 
-    await withStatus(() => api.deleteGallery(token, gallery.id), 'Galerie wurde gelöscht.');
+    await withStatus(() => api.deleteGallery(token, gallery.id), 'Gallery deleted.');
   };
 
   const renderSelectionToolbar = (
@@ -550,18 +550,18 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
   ) => (
     <div className="admin__toolbar">
       <div className="admin__selection">
-        <label className="admin__checkbox" aria-label="Alles auswählen">
+        <label className="admin__checkbox" aria-label="Select all">
           <input
             type="checkbox"
             checked={selected > 0 && selected === total && total > 0}
             onChange={(event) => onSelectAll(event.currentTarget.checked)}
             disabled={total === 0 || isBusy}
           />
-          <span>Alles</span>
+          <span>All</span>
         </label>
-        <span className="admin__selection-count">{selected} ausgewählt</span>
+        <span className="admin__selection-count">{selected} selected</span>
         <button type="button" className="button" onClick={onClear} disabled={selected === 0 || isBusy}>
-          Auswahl leeren
+          Clear selection
         </button>
         <button
           type="button"
@@ -569,7 +569,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
           onClick={onBulkDelete}
           disabled={selected === 0 || isBusy}
         >
-          Ausgewählte löschen
+          Delete selected
         </button>
       </div>
     </div>
@@ -582,9 +582,9 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
           {(
             [
               { id: 'users', label: 'User' },
-              { id: 'models', label: 'Modelle' },
-              { id: 'images', label: 'Bilder' },
-              { id: 'galleries', label: 'Galerien' },
+              { id: 'models', label: 'Models' },
+              { id: 'images', label: 'Images' },
+              { id: 'galleries', label: 'Galleries' },
             ] as { id: AdminTab; label: string }[]
           ).map((tab) => (
             <button
@@ -606,25 +606,25 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
       {activeTab === 'users' ? (
         <div className="admin__panel">
           <section className="admin__section">
-            <h3>Neuen Account anlegen</h3>
+            <h3>Create new account</h3>
             <form className="admin__form" onSubmit={handleCreateUser}>
               <div className="admin__form-grid">
                 <label>
-                  <span>E-Mail</span>
+                  <span>Email</span>
                   <input name="email" type="email" required disabled={isBusy} />
                 </label>
                 <label>
-                  <span>Anzeigename</span>
+                  <span>Display name</span>
                   <input name="displayName" required disabled={isBusy} />
                 </label>
                 <label>
-                  <span>Passwort</span>
+                  <span>Password</span>
                   <input name="password" type="password" required disabled={isBusy} />
                 </label>
                 <label>
-                  <span>Rolle</span>
+                  <span>Role</span>
                   <select name="role" defaultValue="CURATOR" disabled={isBusy}>
-                    <option value="CURATOR">Kurator:in</option>
+                    <option value="CURATOR">Curator</option>
                     <option value="ADMIN">Admin</option>
                   </select>
                 </label>
@@ -634,27 +634,27 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                 <textarea name="bio" rows={2} disabled={isBusy} />
               </label>
               <button type="submit" className="button button--primary" disabled={isBusy}>
-                Account erstellen
+                Create account
               </button>
             </form>
           </section>
 
           <section className="admin__section">
             <div className="admin__section-header">
-              <h3>Benutzer:innen verwalten</h3>
+              <h3>Manage users</h3>
               <div className="admin__filters">
                 <label>
-                  <span>Suche</span>
+                  <span>Search</span>
                   <input
                     type="search"
                     value={userFilter.query}
                     onChange={(event) => setUserFilter((previous) => ({ ...previous, query: event.currentTarget.value }))}
-                    placeholder="Name, Mail oder Bio"
+                    placeholder="Name, email, or bio"
                     disabled={isBusy}
                   />
                 </label>
                 <label>
-                  <span>Rolle</span>
+                  <span>Role</span>
                   <select
                     value={userFilter.role}
                     onChange={(event) =>
@@ -662,8 +662,8 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                     }
                     disabled={isBusy}
                   >
-                    <option value="all">Alle</option>
-                    <option value="CURATOR">Kurator:innen</option>
+                    <option value="all">All</option>
+                    <option value="CURATOR">Curators</option>
                     <option value="ADMIN">Admin</option>
                   </select>
                 </label>
@@ -679,9 +679,9 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                     }
                     disabled={isBusy}
                   >
-                    <option value="all">Alle</option>
-                    <option value="active">Aktive</option>
-                    <option value="inactive">Inaktive</option>
+                    <option value="all">All</option>
+                    <option value="active">Active</option>
+                    <option value="inactive">Inactive</option>
                   </select>
                 </label>
               </div>
@@ -697,27 +697,27 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
 
             <div className="admin__table" role="grid">
               <div className="admin__table-header admin__table-header--wide" role="row">
-                <span className="admin__table-cell admin__table-cell--checkbox" role="columnheader" aria-label="Auswahl" />
+                <span className="admin__table-cell admin__table-cell--checkbox" role="columnheader" aria-label="Selection" />
                 <span className="admin__table-cell" role="columnheader">
                   Account
                 </span>
                 <span className="admin__table-cell" role="columnheader">
-                  Profil &amp; Berechtigungen
+                  Profile &amp; permissions
                 </span>
                 <span className="admin__table-cell admin__table-cell--actions" role="columnheader">
-                  Aktionen
+                  Actions
                 </span>
               </div>
               <div className="admin__table-body">
                 {filteredUsers.length === 0 ? (
-                  <p className="admin__empty">Keine Benutzer:innen vorhanden.</p>
+                  <p className="admin__empty">No users available.</p>
                 ) : (
                   filteredUsers.map((user) => (
                     <form
                       key={user.id}
                       className="admin-row"
                       onSubmit={(event) => handleUpdateUser(event, user.id)}
-                      aria-label={`Einstellungen für ${user.displayName}`}
+                      aria-label={`Settings for ${user.displayName}`}
                     >
                       <div className="admin-row__cell admin-row__cell--checkbox">
                         <input
@@ -725,7 +725,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           checked={selectedUsers.has(user.id)}
                           onChange={(event) => toggleSelection(setSelectedUsers, user.id, event.currentTarget.checked)}
                           disabled={isBusy}
-                          aria-label={`${user.displayName} auswählen`}
+                          aria-label={`Select ${user.displayName}`}
                         />
                       </div>
                       <div className="admin-row__cell admin-row__cell--meta">
@@ -736,19 +736,19 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           <span
                             className={`admin-badge ${user.isActive === false ? 'admin-badge--muted' : 'admin-badge--success'}`}
                           >
-                            {user.isActive === false ? 'inaktiv' : 'aktiv'}
+                            {user.isActive === false ? 'inactive' : 'active'}
                           </span>
                         </div>
                       </div>
                       <div className="admin-row__cell admin-row__cell--form">
                         <label>
-                          <span>Anzeigename</span>
+                          <span>Display name</span>
                           <input name="displayName" defaultValue={user.displayName} disabled={isBusy} />
                         </label>
                         <label>
-                          <span>Rolle</span>
+                          <span>Role</span>
                           <select name="role" defaultValue={user.role} disabled={isBusy}>
-                            <option value="CURATOR">Kurator:in</option>
+                            <option value="CURATOR">Curator</option>
                             <option value="ADMIN">Admin</option>
                           </select>
                         </label>
@@ -757,17 +757,17 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           <textarea name="bio" rows={2} defaultValue={user.bio ?? ''} disabled={isBusy} />
                         </label>
                         <label>
-                          <span>Neues Passwort</span>
+                          <span>New password</span>
                           <input name="password" type="password" placeholder="Optional" disabled={isBusy} />
                         </label>
                         <label className="admin__checkbox">
                           <input type="checkbox" name="isActive" defaultChecked={user.isActive !== false} disabled={isBusy} />
-                          <span>Konto aktiv</span>
+                          <span>Account active</span>
                         </label>
                       </div>
                       <div className="admin-row__cell admin-row__cell--actions">
                         <button type="submit" className="button" disabled={isBusy}>
-                          Speichern
+                          Save
                         </button>
                         <button
                           type="button"
@@ -775,7 +775,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           onClick={() => handleDeleteUser(user.id)}
                           disabled={isBusy}
                         >
-                          Löschen
+                          Delete
                         </button>
                       </div>
                     </form>
@@ -791,20 +791,20 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
         <div className="admin__panel">
           <section className="admin__section">
             <div className="admin__section-header">
-              <h3>Modelle verwalten</h3>
+              <h3>Manage models</h3>
               <div className="admin__filters">
                 <label>
-                  <span>Suche</span>
+                  <span>Search</span>
                   <input
                     type="search"
                     value={modelFilter.query}
                     onChange={(event) => setModelFilter((previous) => ({ ...previous, query: event.currentTarget.value }))}
-                    placeholder="Titel, Beschreibung oder Besitzer"
+                    placeholder="Title, description, or owner"
                     disabled={isBusy}
                   />
                 </label>
                 <label>
-                  <span>Besitzer:in</span>
+                  <span>Owner</span>
                   <select
                     value={modelFilter.owner}
                     onChange={(event) =>
@@ -812,7 +812,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                     }
                     disabled={isBusy}
                   >
-                    <option value="all">Alle</option>
+                    <option value="all">All</option>
                     {userOptions.map((option) => (
                       <option key={option.id} value={option.id}>
                         {option.label}
@@ -821,12 +821,12 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   </select>
                 </label>
                 <label>
-                  <span>Tag-Suche</span>
+                  <span>Tag search</span>
                   <input
                     type="search"
                     value={modelFilter.tag}
                     onChange={(event) => setModelFilter((previous) => ({ ...previous, tag: event.currentTarget.value }))}
-                    placeholder="Tag-Filter"
+                    placeholder="Tag filter"
                     disabled={isBusy}
                   />
                 </label>
@@ -843,27 +843,27 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
 
             <div className="admin__table" role="grid">
               <div className="admin__table-header" role="row">
-                <span className="admin__table-cell admin__table-cell--checkbox" role="columnheader" aria-label="Auswahl" />
+                <span className="admin__table-cell admin__table-cell--checkbox" role="columnheader" aria-label="Selection" />
                 <span className="admin__table-cell" role="columnheader">
-                  Modell
+                  Model
                 </span>
                 <span className="admin__table-cell" role="columnheader">
                   Details
                 </span>
                 <span className="admin__table-cell admin__table-cell--actions" role="columnheader">
-                  Aktionen
+                  Actions
                 </span>
               </div>
               <div className="admin__table-body">
                 {filteredModels.length === 0 ? (
-                  <p className="admin__empty">Keine Modelle vorhanden.</p>
+                  <p className="admin__empty">No models available.</p>
                 ) : (
                   filteredModels.map((model) => (
                     <form
                       key={model.id}
                       className="admin-row"
                       onSubmit={(event) => handleUpdateModel(event, model)}
-                      aria-label={`Einstellungen für ${model.title}`}
+                      aria-label={`Settings for ${model.title}`}
                     >
                       <div className="admin-row__cell admin-row__cell--checkbox">
                         <input
@@ -871,22 +871,22 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           checked={selectedModels.has(model.id)}
                           onChange={(event) => toggleSelection(setSelectedModels, model.id, event.currentTarget.checked)}
                           disabled={isBusy}
-                          aria-label={`${model.title} auswählen`}
+                          aria-label={`Select ${model.title}`}
                         />
                       </div>
                       <div className="admin-row__cell admin-row__cell--meta">
                         <h4>{model.title}</h4>
-                        <span className="admin-row__subtitle">von {model.owner.displayName}</span>
+                        <span className="admin-row__subtitle">by {model.owner.displayName}</span>
                         <div className="admin-row__badges">
                           <span className="admin-badge">{model.version}</span>
                           <span className="admin-badge admin-badge--muted">
-                            {new Date(model.updatedAt).toLocaleDateString('de-DE')}
+                            {new Date(model.updatedAt).toLocaleDateString('en-US')}
                           </span>
                         </div>
                       </div>
                       <div className="admin-row__cell admin-row__cell--form">
                         <label>
-                          <span>Titel</span>
+                          <span>Title</span>
                           <input name="title" defaultValue={model.title} disabled={isBusy} />
                         </label>
                         <label>
@@ -894,7 +894,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           <input name="version" defaultValue={model.version} disabled={isBusy} />
                         </label>
                         <label>
-                          <span>Beschreibung</span>
+                          <span>Description</span>
                           <textarea name="description" rows={3} defaultValue={model.description ?? ''} disabled={isBusy} />
                         </label>
                         <label>
@@ -902,12 +902,12 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           <input
                             name="tags"
                             defaultValue={model.tags.map((tag) => tag.label).join(', ')}
-                            placeholder="Kommagetrennt"
+                            placeholder="Comma separated"
                             disabled={isBusy}
                           />
                         </label>
                         <label>
-                          <span>Besitzer:in</span>
+                          <span>Owner</span>
                           <select name="ownerId" defaultValue={model.owner.id} disabled={isBusy}>
                             {userOptions.map((option) => (
                               <option key={option.id} value={option.id}>
@@ -919,7 +919,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                       </div>
                       <div className="admin-row__cell admin-row__cell--actions">
                         <button type="submit" className="button" disabled={isBusy}>
-                          Speichern
+                          Save
                         </button>
                         <button
                           type="button"
@@ -927,7 +927,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           onClick={() => handleDeleteModel(model)}
                           disabled={isBusy}
                         >
-                          Löschen
+                          Delete
                         </button>
                       </div>
                     </form>
@@ -943,20 +943,20 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
         <div className="admin__panel">
           <section className="admin__section">
             <div className="admin__section-header">
-              <h3>Bilder verwalten</h3>
+              <h3>Manage images</h3>
               <div className="admin__filters">
                 <label>
-                  <span>Suche</span>
+                  <span>Search</span>
                   <input
                     type="search"
                     value={imageFilter.query}
                     onChange={(event) => setImageFilter((previous) => ({ ...previous, query: event.currentTarget.value }))}
-                    placeholder="Titel, Prompt oder Tags"
+                    placeholder="Title, prompt, or tags"
                     disabled={isBusy}
                   />
                 </label>
                 <label>
-                  <span>Besitzer:in</span>
+                  <span>Owner</span>
                   <select
                     value={imageFilter.owner}
                     onChange={(event) =>
@@ -964,7 +964,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                     }
                     disabled={isBusy}
                   >
-                    <option value="all">Alle</option>
+                    <option value="all">All</option>
                     {userOptions.map((option) => (
                       <option key={option.id} value={option.id}>
                         {option.label}
@@ -985,27 +985,27 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
 
             <div className="admin__table" role="grid">
               <div className="admin__table-header" role="row">
-                <span className="admin__table-cell admin__table-cell--checkbox" role="columnheader" aria-label="Auswahl" />
+                <span className="admin__table-cell admin__table-cell--checkbox" role="columnheader" aria-label="Selection" />
                 <span className="admin__table-cell" role="columnheader">
-                  Bild
+                  Image
                 </span>
                 <span className="admin__table-cell" role="columnheader">
-                  Metadaten
+                  Metadata
                 </span>
                 <span className="admin__table-cell admin__table-cell--actions" role="columnheader">
-                  Aktionen
+                  Actions
                 </span>
               </div>
               <div className="admin__table-body">
                 {filteredImages.length === 0 ? (
-                  <p className="admin__empty">Keine Bilder vorhanden.</p>
+                  <p className="admin__empty">No images available.</p>
                 ) : (
                   filteredImages.map((image) => (
                     <form
                       key={image.id}
                       className="admin-row"
                       onSubmit={(event) => handleUpdateImage(event, image)}
-                      aria-label={`Einstellungen für ${image.title}`}
+                      aria-label={`Settings for ${image.title}`}
                     >
                       <div className="admin-row__cell admin-row__cell--checkbox">
                         <input
@@ -1013,26 +1013,26 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           checked={selectedImages.has(image.id)}
                           onChange={(event) => toggleSelection(setSelectedImages, image.id, event.currentTarget.checked)}
                           disabled={isBusy}
-                          aria-label={`${image.title} auswählen`}
+                          aria-label={`Select ${image.title}`}
                         />
                       </div>
                       <div className="admin-row__cell admin-row__cell--meta">
                         <h4>{image.title}</h4>
-                        <span className="admin-row__subtitle">von {image.owner.displayName}</span>
+                        <span className="admin-row__subtitle">by {image.owner.displayName}</span>
                         <div className="admin-row__badges">
                           <span className="admin-badge admin-badge--muted">
-                            {new Date(image.updatedAt).toLocaleDateString('de-DE')}
+                            {new Date(image.updatedAt).toLocaleDateString('en-US')}
                           </span>
                           <span className="admin-badge">{image.tags.map((tag) => tag.label).slice(0, 3).join(', ')}</span>
                         </div>
                       </div>
                       <div className="admin-row__cell admin-row__cell--form">
                         <label>
-                          <span>Titel</span>
+                          <span>Title</span>
                           <input name="title" defaultValue={image.title} disabled={isBusy} />
                         </label>
                         <label>
-                          <span>Beschreibung</span>
+                          <span>Description</span>
                           <textarea name="description" rows={2} defaultValue={image.description ?? ''} disabled={isBusy} />
                         </label>
                         <label>
@@ -1040,7 +1040,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           <textarea name="prompt" rows={2} defaultValue={image.prompt ?? ''} disabled={isBusy} />
                         </label>
                         <label>
-                          <span>Negativer Prompt</span>
+                          <span>Negative prompt</span>
                           <textarea name="negativePrompt" rows={2} defaultValue={image.negativePrompt ?? ''} disabled={isBusy} />
                         </label>
                         <label>
@@ -1048,12 +1048,12 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           <input
                             name="tags"
                             defaultValue={image.tags.map((tag) => tag.label).join(', ')}
-                            placeholder="Kommagetrennt"
+                            placeholder="Comma separated"
                             disabled={isBusy}
                           />
                         </label>
                         <label>
-                          <span>Besitzer:in</span>
+                          <span>Owner</span>
                           <select name="ownerId" defaultValue={image.owner.id} disabled={isBusy}>
                             {userOptions.map((option) => (
                               <option key={option.id} value={option.id}>
@@ -1087,7 +1087,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                       </div>
                       <div className="admin-row__cell admin-row__cell--actions">
                         <button type="submit" className="button" disabled={isBusy}>
-                          Speichern
+                          Save
                         </button>
                         <button
                           type="button"
@@ -1095,7 +1095,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           onClick={() => handleDeleteImage(image)}
                           disabled={isBusy}
                         >
-                          Löschen
+                          Delete
                         </button>
                       </div>
                     </form>
@@ -1111,20 +1111,20 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
         <div className="admin__panel">
           <section className="admin__section">
             <div className="admin__section-header">
-              <h3>Galerien &amp; Alben</h3>
+              <h3>Galleries &amp; albums</h3>
               <div className="admin__filters">
                 <label>
-                  <span>Suche</span>
+                  <span>Search</span>
                   <input
                     type="search"
                     value={galleryFilter.query}
                     onChange={(event) => setGalleryFilter((previous) => ({ ...previous, query: event.currentTarget.value }))}
-                    placeholder="Titel oder Slug"
+                    placeholder="Title or slug"
                     disabled={isBusy}
                   />
                 </label>
                 <label>
-                  <span>Besitzer:in</span>
+                  <span>Owner</span>
                   <select
                     value={galleryFilter.owner}
                     onChange={(event) =>
@@ -1132,7 +1132,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                     }
                     disabled={isBusy}
                   >
-                    <option value="all">Alle</option>
+                    <option value="all">All</option>
                     {userOptions.map((option) => (
                       <option key={option.id} value={option.id}>
                         {option.label}
@@ -1141,7 +1141,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   </select>
                 </label>
                 <label>
-                  <span>Sichtbarkeit</span>
+                  <span>Visibility</span>
                   <select
                     value={galleryFilter.visibility}
                     onChange={(event) =>
@@ -1152,9 +1152,9 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                     }
                     disabled={isBusy}
                   >
-                    <option value="all">Alle</option>
-                    <option value="public">Öffentlich</option>
-                    <option value="private">Privat</option>
+                    <option value="all">All</option>
+                    <option value="public">Public</option>
+                    <option value="private">Private</option>
                   </select>
                 </label>
               </div>
@@ -1163,55 +1163,55 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
             <div className="admin__table" role="grid">
               <div className="admin__table-header" role="row">
                 <span className="admin__table-cell" role="columnheader">
-                  Galerie
+                  Gallery
                 </span>
                 <span className="admin__table-cell" role="columnheader">
-                  Metadaten &amp; Einträge
+                  Metadata &amp; entries
                 </span>
                 <span className="admin__table-cell admin__table-cell--actions" role="columnheader">
-                  Aktionen
+                  Actions
                 </span>
               </div>
               <div className="admin__table-body">
                 {filteredGalleries.length === 0 ? (
-                  <p className="admin__empty">Keine Galerien vorhanden.</p>
+                  <p className="admin__empty">No galleries available.</p>
                 ) : (
                   filteredGalleries.map((gallery) => (
                     <form
                       key={gallery.id}
                       className="admin-row admin-row--wide"
                       onSubmit={(event) => handleUpdateGallery(event, gallery)}
-                      aria-label={`Einstellungen für ${gallery.title}`}
+                      aria-label={`Settings for ${gallery.title}`}
                     >
                       <div className="admin-row__cell admin-row__cell--meta">
                         <h4>{gallery.title}</h4>
                         <span className="admin-row__subtitle">Slug: {gallery.slug}</span>
                         <div className="admin-row__badges">
-                          <span className="admin-badge">{gallery.isPublic ? 'öffentlich' : 'privat'}</span>
+                          <span className="admin-badge">{gallery.isPublic ? 'public' : 'private'}</span>
                           <span className="admin-badge admin-badge--muted">
-                            {new Date(gallery.updatedAt).toLocaleDateString('de-DE')}
+                            {new Date(gallery.updatedAt).toLocaleDateString('en-US')}
                           </span>
-                          <span className="admin-badge">{gallery.entries.length} Einträge</span>
+                          <span className="admin-badge">{gallery.entries.length} entries</span>
                         </div>
                       </div>
                       <div className="admin-row__cell admin-row__cell--form">
                         <label>
-                          <span>Titel</span>
+                          <span>Title</span>
                           <input name="title" defaultValue={gallery.title} disabled={isBusy} />
                         </label>
                         <label>
-                          <span>Beschreibung</span>
+                          <span>Description</span>
                           <textarea name="description" rows={2} defaultValue={gallery.description ?? ''} disabled={isBusy} />
                         </label>
                         <label>
-                          <span>Sichtbarkeit</span>
+                          <span>Visibility</span>
                           <select name="visibility" defaultValue={gallery.isPublic ? 'public' : 'private'} disabled={isBusy}>
-                            <option value="public">Öffentlich</option>
-                            <option value="private">Privat</option>
+                            <option value="public">Public</option>
+                            <option value="private">Private</option>
                           </select>
                         </label>
                         <label>
-                          <span>Besitzer:in</span>
+                          <span>Owner</span>
                           <select name="ownerId" defaultValue={gallery.owner.id} disabled={isBusy}>
                             {userOptions.map((option) => (
                               <option key={option.id} value={option.id}>
@@ -1221,24 +1221,24 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           </select>
                         </label>
                         <label>
-                          <span>Cover-Storage-Pfad</span>
+                          <span>Cover storage path</span>
                           <input
                             name="coverImage"
                             defaultValue={gallery.coverImage ?? ''}
-                            placeholder="leer lassen, um zu entfernen"
+                            placeholder="leave empty to remove"
                             disabled={isBusy}
                           />
                         </label>
                         <div className="admin-gallery-entries">
-                          <h5>Einträge</h5>
+                          <h5>Entries</h5>
                           {gallery.entries.length === 0 ? (
-                            <p className="admin__empty admin__empty--sub">Noch keine Inhalte verknüpft.</p>
+                            <p className="admin__empty admin__empty--sub">No items linked yet.</p>
                           ) : (
                             gallery.entries.map((entry) => (
                               <fieldset key={entry.id} className="admin-gallery-entry">
                                 <legend>
                                   {entry.position + 1}.{' '}
-                                  {entry.modelAsset ? `Model: ${entry.modelAsset.title}` : entry.imageAsset ? `Bild: ${entry.imageAsset.title}` : 'Unverknüpft'}
+                                  {entry.modelAsset ? `Model: ${entry.modelAsset.title}` : entry.imageAsset ? `Image: ${entry.imageAsset.title}` : 'Unlinked'}
                                 </legend>
                                 <div className="admin-gallery-entry__grid">
                                   <label>
@@ -1253,11 +1253,11 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                                   </label>
                                   <label className="admin__checkbox admin-gallery-entry__remove">
                                     <input name={`entry-${entry.id}-remove`} type="checkbox" disabled={isBusy} />
-                                    <span>Entfernen</span>
+                                    <span>Remove</span>
                                   </label>
                                 </div>
                                 <label>
-                                  <span>Notiz</span>
+                                  <span>Note</span>
                                   <textarea
                                     name={`entry-${entry.id}-note`}
                                     rows={2}
@@ -1272,7 +1272,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                       </div>
                       <div className="admin-row__cell admin-row__cell--actions admin-row__cell--stacked">
                         <button type="submit" className="button" disabled={isBusy}>
-                          Speichern
+                          Save
                         </button>
                         <button
                           type="button"
@@ -1280,7 +1280,7 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                           onClick={() => handleDeleteGallery(gallery)}
                           disabled={isBusy}
                         >
-                          Löschen
+                          Delete
                         </button>
                       </div>
                     </form>

--- a/frontend/src/components/AssetCard.tsx
+++ b/frontend/src/components/AssetCard.tsx
@@ -13,7 +13,7 @@ const formatFileSize = (bytes?: number | null) => {
 };
 
 const formatDate = (value: string) =>
-  new Date(value).toLocaleDateString('de-DE', {
+  new Date(value).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -29,7 +29,7 @@ export const AssetCard = ({ asset }: AssetCardProps) => {
     <article className="asset-card">
       {previewUrl ? (
         <div className="asset-card__media">
-          <img src={previewUrl} alt={`Preview von ${asset.title}`} loading="lazy" />
+          <img src={previewUrl} alt={`Preview of ${asset.title}`} loading="lazy" />
         </div>
       ) : null}
       <header className="asset-card__header">
@@ -39,7 +39,7 @@ export const AssetCard = ({ asset }: AssetCardProps) => {
         </div>
         <span className="asset-card__badge">{modelType}</span>
       </header>
-      <p className="asset-card__description">{asset.description ?? 'Noch keine Beschreibung hinterlegt.'}</p>
+      <p className="asset-card__description">{asset.description ?? 'No description provided yet.'}</p>
       <dl className="asset-card__meta">
         <div>
           <dt>Storage</dt>
@@ -56,19 +56,19 @@ export const AssetCard = ({ asset }: AssetCardProps) => {
           </div>
         ) : null}
         <div>
-          <dt>Dateigröße</dt>
+          <dt>File size</dt>
           <dd>{formatFileSize(asset.fileSize)}</dd>
         </div>
         <div>
-          <dt>Checksumme</dt>
+          <dt>Checksum</dt>
           <dd className="asset-card__mono">{asset.checksum ?? '–'}</dd>
         </div>
         <div>
-          <dt>Kurator</dt>
+          <dt>Curator</dt>
           <dd>{asset.owner.displayName}</dd>
         </div>
         <div>
-          <dt>Aktualisiert</dt>
+          <dt>Updated</dt>
           <dd>{formatDate(asset.updatedAt)}</dd>
         </div>
       </dl>

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -37,7 +37,7 @@ const fileSizeLabels: Record<Exclude<FileSizeFilter, 'all'>, string> = {
   small: '≤ 50 MB',
   medium: '50 – 200 MB',
   large: '≥ 200 MB',
-  unknown: 'Unbekannt',
+  unknown: 'Unknown',
 };
 
 const categorizeFileSize = (value?: number | null): FileSizeFilter => {
@@ -72,9 +72,9 @@ const tryParseStructuredValue = (value: string): unknown => {
     try {
       return JSON.parse(trimmed);
     } catch (error) {
-      if (import.meta.env.DEV) {
-        console.warn('Konnte Metadatenwert nicht parsen:', error);
-      }
+        if (import.meta.env.DEV) {
+          console.warn('Failed to parse metadata value:', error);
+        }
     }
   }
 
@@ -207,7 +207,7 @@ const buildMetadataRows = (metadata?: Record<string, unknown> | null) => {
     return rows;
   }
 
-  rows.push({ key: 'Wert', value: formatPrimitiveMetadataValue(normalized) });
+  rows.push({ key: 'Value', value: formatPrimitiveMetadataValue(normalized) });
   return rows;
 };
 
@@ -352,13 +352,13 @@ const toTagFrequencyGroups = (value: unknown): TagFrequencyGroup[] => {
         if (b.count !== a.count) {
           return b.count - a.count;
         }
-        return a.label.localeCompare(b.label, 'de');
+        return a.label.localeCompare(b.label, 'en');
       });
       groups.push({ scope, tags });
     }
   });
 
-  return groups.sort((a, b) => a.scope.localeCompare(b.scope, 'de'));
+  return groups.sort((a, b) => a.scope.localeCompare(b.scope, 'en'));
 };
 
 const extractTagFrequency = (metadata?: Record<string, unknown> | null): TagFrequencyGroup[] => {
@@ -422,7 +422,7 @@ const formatFileSize = (bytes?: number | null) => {
 };
 
 const formatDate = (value: string) =>
-  new Date(value).toLocaleDateString('de-DE', {
+  new Date(value).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -493,7 +493,7 @@ export const AssetExplorer = ({
     const sortByCount = (first: TagOption, second: TagOption) => second.count - first.count;
 
     return {
-      ownerOptions: Array.from(ownersMap.values()).sort((a, b) => a.label.localeCompare(b.label, 'de')),
+      ownerOptions: Array.from(ownersMap.values()).sort((a, b) => a.label.localeCompare(b.label, 'en')),
       tagOptions: Array.from(tagsMap.values()).sort(sortByCount).slice(0, 18),
       typeOptions: Array.from(typesMap.values()).sort(sortByCount),
     };
@@ -528,7 +528,7 @@ export const AssetExplorer = ({
 
     const sorters: Record<SortOption, (a: ModelAsset, b: ModelAsset) => number> = {
       recent: (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-      alpha: (a, b) => a.title.localeCompare(b.title, 'de'),
+      alpha: (a, b) => a.title.localeCompare(b.title, 'en'),
       'size-desc': (a, b) => (b.fileSize ?? 0) - (a.fileSize ?? 0),
       'size-asc': (a, b) => (a.fileSize ?? Infinity) - (b.fileSize ?? Infinity),
     };
@@ -745,27 +745,27 @@ export const AssetExplorer = ({
     const filters: { id: string; label: string; onClear: () => void }[] = [];
 
     if (normalizedQuery) {
-      filters.push({ id: 'search', label: `Suche: “${deferredSearch.trim()}”`, onClear: () => setSearchTerm('') });
+      filters.push({ id: 'search', label: `Search: “${deferredSearch.trim()}”`, onClear: () => setSearchTerm('') });
     }
 
     if (selectedOwner !== 'all') {
       const owner = ownerOptions.find((option) => option.id === selectedOwner);
       if (owner) {
-        filters.push({ id: `owner-${owner.id}`, label: `Kurator:in · ${owner.label}`, onClear: () => setSelectedOwner('all') });
+        filters.push({ id: `owner-${owner.id}`, label: `Curator · ${owner.label}`, onClear: () => setSelectedOwner('all') });
       }
     }
 
     if (selectedType !== 'all') {
       const type = typeOptions.find((option) => option.id === selectedType);
       if (type) {
-        filters.push({ id: `type-${type.id}`, label: `Typ · ${type.label}`, onClear: () => setSelectedType('all') });
+        filters.push({ id: `type-${type.id}`, label: `Type · ${type.label}`, onClear: () => setSelectedType('all') });
       }
     }
 
     if (fileSizeFilter !== 'all') {
       filters.push({
         id: `size-${fileSizeFilter}`,
-        label: `Größe · ${fileSizeLabels[fileSizeFilter]}`,
+        label: `Size · ${fileSizeLabels[fileSizeFilter]}`,
         onClear: () => setFileSizeFilter('all'),
       });
     }
@@ -797,52 +797,51 @@ export const AssetExplorer = ({
     <section className="panel">
       <header className="panel__header">
         <div>
-          <h2 className="panel__title">LoRA-Datenbank</h2>
+          <h2 className="panel__title">LoRA library</h2>
           <p className="panel__subtitle">
-            Produktionsreife LoRA-Bibliothek mit Volltext, Tagging und Kurator:innen-Filtern. Alle Einträge spiegeln den
-            aktuellen Analyse-Status und lassen sich ohne Performanceeinbruch über große Bestände hinweg sortieren.
+            Production-grade LoRA library with full-text search, tagging, and curator filters. Every entry mirrors the current analysis status and can be sorted across large collections without performance loss.
           </p>
         </div>
         <button type="button" className="panel__action panel__action--primary" onClick={() => onStartUpload?.()}>
-          LoRA-Upload öffnen
+          Open LoRA upload
         </button>
       </header>
 
-      <div className="filter-toolbar" aria-label="Filter für LoRA-Datenbank">
+      <div className="filter-toolbar" aria-label="Filters for the LoRA library">
         <div className="filter-toolbar__row">
           <label className="filter-toolbar__search">
-            <span className="sr-only">Suche in LoRA-Assets</span>
+            <span className="sr-only">Search in LoRA assets</span>
             <input
               type="search"
               value={searchTerm}
               onChange={(event) => setSearchTerm(event.target.value)}
-              placeholder="Titel, Tags oder Personen durchsuchen"
+              placeholder="Search titles, tags, or people"
               disabled={isLoading && assets.length === 0}
             />
           </label>
 
           <label className="filter-toolbar__control">
-            <span>Sortierung</span>
+            <span>Sort order</span>
             <select
               value={sortOption}
               onChange={(event) => setSortOption(event.target.value as SortOption)}
               className="filter-select"
             >
-              <option value="recent">Aktualisiert · Neueste zuerst</option>
-              <option value="alpha">Titel · A → Z</option>
-              <option value="size-desc">Dateigröße · Groß → Klein</option>
-              <option value="size-asc">Dateigröße · Klein → Groß</option>
+              <option value="recent">Updated · Newest first</option>
+              <option value="alpha">Title · A → Z</option>
+              <option value="size-desc">File size · Large → Small</option>
+              <option value="size-asc">File size · Small → Large</option>
             </select>
           </label>
 
           <label className="filter-toolbar__control">
-            <span>Kurator:in</span>
+            <span>Curator</span>
             <select
               value={selectedOwner}
               onChange={(event) => setSelectedOwner(event.target.value)}
               className="filter-select"
             >
-              <option value="all">Alle Personen</option>
+              <option value="all">All people</option>
               {ownerOptions.map((owner) => (
                 <option key={owner.id} value={owner.id}>
                   {owner.label}
@@ -852,13 +851,13 @@ export const AssetExplorer = ({
           </label>
 
           <label className="filter-toolbar__control">
-            <span>Model-Typ</span>
+            <span>Model type</span>
             <select
               value={selectedType}
               onChange={(event) => setSelectedType(event.target.value)}
               className="filter-select"
             >
-              <option value="all">Alle Typen</option>
+              <option value="all">All types</option>
               {typeOptions.map((type) => (
                 <option key={type.id} value={type.id}>
                   {type.label}
@@ -867,9 +866,9 @@ export const AssetExplorer = ({
             </select>
           </label>
 
-          <div className="filter-toolbar__chips" role="group" aria-label="Dateigröße filtern">
+          <div className="filter-toolbar__chips" role="group" aria-label="Filter by file size">
             <FilterChip
-              label="Alle Größen"
+              label="All sizes"
               isActive={fileSizeFilter === 'all'}
               onClick={() => setFileSizeFilter('all')}
             />
@@ -885,8 +884,8 @@ export const AssetExplorer = ({
         </div>
 
         {tagOptions.length > 0 ? (
-          <div className="filter-toolbar__tag-row" role="group" aria-label="Tags filtern">
-            <span className="filter-toolbar__tag-label">Beliebte Tags</span>
+          <div className="filter-toolbar__tag-row" role="group" aria-label="Filter by tags">
+            <span className="filter-toolbar__tag-label">Popular tags</span>
             <div className="filter-toolbar__tag-chips">
               {tagOptions.map((tag) => (
                 <FilterChip
@@ -909,7 +908,7 @@ export const AssetExplorer = ({
 
         {activeFilters.length > 0 ? (
           <div className="filter-toolbar__active">
-            <span className="filter-toolbar__active-label">Aktive Filter:</span>
+            <span className="filter-toolbar__active-label">Active filters:</span>
             <div className="filter-toolbar__active-chips">
               {activeFilters.map((filter) => (
                 <button key={filter.id} type="button" className="active-filter" onClick={filter.onClear}>
@@ -919,17 +918,17 @@ export const AssetExplorer = ({
               ))}
             </div>
             <button type="button" className="filter-toolbar__reset" onClick={resetFilters}>
-              Alle Filter zurücksetzen
+              Reset all filters
             </button>
           </div>
         ) : null}
       </div>
 
       <div className="result-info" role="status">
-        {isLoading && assets.length === 0 ? 'Lade LoRA-Assets …' : `Zeigt ${visibleAssets.length} von ${filteredAssets.length} Assets`}
+        {isLoading && assets.length === 0 ? 'Loading LoRA assets…' : `Showing ${visibleAssets.length} of ${filteredAssets.length} assets`}
       </div>
 
-      <div className="asset-explorer__grid" role="list" aria-label="LoRA-Assets">
+      <div className="asset-explorer__grid" role="list" aria-label="LoRA assets">
         {isLoading && assets.length === 0
           ? Array.from({ length: 10 }).map((_, index) => <div key={index} className="skeleton skeleton--card" />)
           : visibleAssets.map((asset) => {
@@ -951,9 +950,9 @@ export const AssetExplorer = ({
                 >
                   <div className={`asset-tile__preview${previewUrl ? '' : ' asset-tile__preview--empty'}`}>
                     {previewUrl ? (
-                      <img src={previewUrl} alt={`Preview von ${asset.title}`} loading="lazy" />
+                      <img src={previewUrl} alt={`Preview of ${asset.title}`} loading="lazy" />
                     ) : (
-                      <span>Kein Preview</span>
+                      <span>No preview</span>
                     )}
                   </div>
                   <div className="asset-tile__body">
@@ -982,10 +981,10 @@ export const AssetExplorer = ({
                     <p className="asset-detail__subtitle">{activeAsset.description}</p>
                   ) : (
                     <p className="asset-detail__subtitle asset-detail__subtitle--muted">
-                      Noch keine Beschreibung hinterlegt.
+                      No description provided yet.
                     </p>
                   )}
-                  <div className="asset-detail__version-switcher" role="group" aria-label="Modelversionen">
+                  <div className="asset-detail__version-switcher" role="group" aria-label="Model versions">
                     {activeAsset.versions.map((version) => {
                       const isCurrent = activeVersion?.id === version.id;
                       return (
@@ -1006,10 +1005,10 @@ export const AssetExplorer = ({
                       onClick={openVersionDialog}
                       disabled={!authToken}
                       title={
-                        !authToken ? 'Nur angemeldete Kurator:innen können neue Versionen hochladen.' : undefined
+                        !authToken ? 'Only signed-in curators can upload new versions.' : undefined
                       }
                     >
-                      Neue Version hinzufügen
+                      Add new version
                     </button>
                   </div>
                   {versionFeedback ? (
@@ -1017,7 +1016,7 @@ export const AssetExplorer = ({
                   ) : null}
                 </div>
                 <button type="button" className="asset-detail__close" onClick={closeDetail}>
-                  Zurück zur Modellliste
+                  Back to model list
                 </button>
               </header>
 
@@ -1034,19 +1033,19 @@ export const AssetExplorer = ({
                         <td>{activeVersion?.version ?? '–'}</td>
                       </tr>
                       <tr>
-                        <th scope="row">Kurator</th>
+                        <th scope="row">Curator</th>
                         <td>{activeAsset.owner.displayName}</td>
                       </tr>
                       <tr>
-                        <th scope="row">Upload am</th>
+                        <th scope="row">Uploaded on</th>
                         <td>{activeVersion ? formatDate(activeVersion.createdAt) : '–'}</td>
                       </tr>
                       <tr>
-                        <th scope="row">Dateigröße</th>
+                        <th scope="row">File size</th>
                         <td>{formatFileSize(activeVersion?.fileSize)}</td>
                       </tr>
                       <tr>
-                        <th scope="row">Checksumme</th>
+                        <th scope="row">Checksum</th>
                         <td>{activeVersion?.checksum ?? '–'}</td>
                       </tr>
                     </tbody>
@@ -1068,7 +1067,7 @@ export const AssetExplorer = ({
                     </div>
                   ) : (
                     <div className="asset-detail__preview asset-detail__preview--empty">
-                      <span>Kein Vorschaubild vorhanden.</span>
+                      <span>No preview available.</span>
                     </div>
                   )}
                   {modelDownloadUrl ? (
@@ -1079,11 +1078,11 @@ export const AssetExplorer = ({
                       rel="noopener noreferrer"
                       download
                     >
-                      Modell herunterladen
+                      Download model
                     </a>
                   ) : (
                     <span className="asset-detail__download asset-detail__download--disabled">
-                      Download nicht verfügbar
+                      Download not available
                     </span>
                   )}
                 </div>
@@ -1098,16 +1097,16 @@ export const AssetExplorer = ({
                     ))}
                   </div>
                 ) : (
-                  <p className="asset-detail__description asset-detail__description--muted">Keine Tags hinterlegt.</p>
+                  <p className="asset-detail__description asset-detail__description--muted">No tags available.</p>
                 )}
               </section>
 
               <section className="asset-detail__section">
                 <div className="asset-detail__section-heading">
-                  <h4>Metadaten</h4>
+                  <h4>Metadata</h4>
                   {tagFrequencyGroups.length > 0 ? (
                     <button type="button" className="asset-detail__tag-button" onClick={openTagDialog}>
-                      Datensatz-Tags anzeigen
+                      Show dataset tags
                     </button>
                   ) : null}
                 </div>
@@ -1117,8 +1116,8 @@ export const AssetExplorer = ({
                       <table className="asset-detail__metadata-table">
                         <thead>
                           <tr>
-                            <th scope="col">Schlüssel</th>
-                            <th scope="col">Wert</th>
+                            <th scope="col">Key</th>
+                            <th scope="col">Value</th>
                           </tr>
                         </thead>
                         <tbody>
@@ -1135,12 +1134,12 @@ export const AssetExplorer = ({
                     </div>
                   </div>
                 ) : (
-                  <p className="asset-detail__description asset-detail__description--muted">Keine Metadaten verfügbar.</p>
+                  <p className="asset-detail__description asset-detail__description--muted">No metadata available.</p>
                 )}
               </section>
 
               <section className="asset-detail__section">
-                <h4>Verknüpfte Bild-Sammlungen</h4>
+                <h4>Linked image collections</h4>
                 {relatedGalleries.length > 0 ? (
                   <ul className="asset-detail__gallery-links">
                     {relatedGalleries.map((gallery) => (
@@ -1161,7 +1160,7 @@ export const AssetExplorer = ({
                   </ul>
                 ) : (
                   <p className="asset-detail__description asset-detail__description--muted">
-                    Dieses LoRA ist noch keiner Bildsammlung zugeordnet.
+                    This LoRA is not linked to any image collection yet.
                   </p>
                 )}
               </section>
@@ -1173,17 +1172,17 @@ export const AssetExplorer = ({
                   <div className="tag-frequency">
                     <header className="tag-frequency__header">
                       <div>
-                        <h4 id="tag-frequency-title">Datensatz-Tags</h4>
-                        <p>Häufigkeiten der Trainings-Tags, die das Modell beim Fine-Tuning gesehen hat.</p>
+                        <h4 id="tag-frequency-title">Dataset tags</h4>
+                        <p>Frequency of training tags the model saw during fine-tuning.</p>
                       </div>
                       <button type="button" className="tag-frequency__close" onClick={closeTagDialog}>
-                        Schließen
+                        Close
                       </button>
                     </header>
                     <div className="tag-frequency__body">
                       {tagFrequencyGroups.map((group) => {
                         const groupId = `tag-frequency-${
-                          group.scope.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase() || 'gruppe'
+                          group.scope.replace(/[^a-zA-Z0-9_-]/g, '-').toLowerCase() || 'group'
                         }`;
                         return (
                           <section key={group.scope} className="tag-frequency__group" aria-labelledby={groupId}>
@@ -1195,7 +1194,7 @@ export const AssetExplorer = ({
                                 <thead>
                                   <tr>
                                     <th scope="col">Tag</th>
-                                    <th scope="col">Vorkommen</th>
+                                    <th scope="col">Occurrences</th>
                                   </tr>
                                 </thead>
                                 <tbody>
@@ -1233,15 +1232,15 @@ export const AssetExplorer = ({
             );
             setVersionFeedback(
               createdVersion
-                ? `Version ${createdVersion.version} wurde hinzugefügt.`
-                : 'Modell wurde aktualisiert.',
+                ? `Version ${createdVersion.version} was added.`
+                : 'Model updated.',
             );
           }}
         />
       ) : null}
 
       {!isLoading && filteredAssets.length === 0 ? (
-        <p className="panel__empty">Keine Assets entsprechen den aktuellen Filtern.</p>
+        <p className="panel__empty">No assets match the current filters.</p>
       ) : null}
 
       <div ref={sentinelRef} className="asset-explorer__sentinel" aria-hidden="true" />

--- a/frontend/src/components/GalleryExplorer.tsx
+++ b/frontend/src/components/GalleryExplorer.tsx
@@ -120,18 +120,18 @@ const getImageEntries = (gallery: Gallery): GalleryImageEntry[] =>
     .map((entry) => ({ entryId: entry.id, image: entry.imageAsset, note: entry.note ?? null }));
 
 const formatDate = (value: string) =>
-  new Date(value).toLocaleDateString('de-DE', {
+  new Date(value).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
   });
 
 const formatDimensions = (image: ImageAsset) =>
-  image.dimensions ? `${image.dimensions.width} × ${image.dimensions.height}px` : 'Unbekannt';
+  image.dimensions ? `${image.dimensions.width} × ${image.dimensions.height}px` : 'Unknown';
 
 const formatFileSize = (size?: number | null) => {
   if (!size || Number.isNaN(size)) {
-    return 'Unbekannt';
+    return 'Unknown';
   }
   if (size < 1024 * 1024) {
     return `${Math.round(size / 1024)} KB`;
@@ -160,15 +160,15 @@ const selectPreviewImage = (gallery: Gallery) => {
 const buildMetadataRows = (image: ImageAsset) => {
   const exif = image.metadata ?? {};
   return [
-    { label: 'Prompt', value: image.prompt ?? 'Kein Prompt hinterlegt.' },
-    { label: 'Negativer Prompt', value: image.negativePrompt ?? '–' },
-    { label: 'Model', value: exif.model ?? 'Unbekannt' },
-    { label: 'Sampler', value: exif.sampler ?? 'Unbekannt' },
+    { label: 'Prompt', value: image.prompt ?? 'No prompt provided.' },
+    { label: 'Negative prompt', value: image.negativePrompt ?? '–' },
+    { label: 'Model', value: exif.model ?? 'Unknown' },
+    { label: 'Sampler', value: exif.sampler ?? 'Unknown' },
     { label: 'Seed', value: exif.seed ?? '–' },
     { label: 'CFG Scale', value: exif.cfgScale != null ? exif.cfgScale.toString() : '–' },
     { label: 'Steps', value: exif.steps != null ? exif.steps.toString() : '–' },
-    { label: 'Dimensionen', value: formatDimensions(image) },
-    { label: 'Dateigröße', value: formatFileSize(image.fileSize) },
+    { label: 'Dimensions', value: formatDimensions(image) },
+    { label: 'File size', value: formatFileSize(image.fileSize) },
   ];
 };
 
@@ -210,7 +210,7 @@ export const GalleryExplorer = ({
         ownersMap.set(gallery.owner.id, { id: gallery.owner.id, label: gallery.owner.displayName });
       }
     });
-    return Array.from(ownersMap.values()).sort((a, b) => a.label.localeCompare(b.label, 'de'));
+    return Array.from(ownersMap.values()).sort((a, b) => a.label.localeCompare(b.label, 'en'));
   }, [galleries]);
 
   const filteredGalleries = useMemo(() => {
@@ -230,7 +230,7 @@ export const GalleryExplorer = ({
 
     const sorters: Record<SortOption, (a: Gallery, b: Gallery) => number> = {
       recent: (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-      alpha: (a, b) => a.title.localeCompare(b.title, 'de'),
+      alpha: (a, b) => a.title.localeCompare(b.title, 'en'),
       'entries-desc': (a, b) => b.entries.length - a.entries.length,
       'entries-asc': (a, b) => a.entries.length - b.entries.length,
     };
@@ -286,13 +286,13 @@ export const GalleryExplorer = ({
     const filters: { id: string; label: string; onClear: () => void }[] = [];
 
     if (normalizedQuery) {
-      filters.push({ id: 'search', label: `Suche: “${deferredSearch.trim()}”`, onClear: () => setSearchTerm('') });
+      filters.push({ id: 'search', label: `Search: “${deferredSearch.trim()}”`, onClear: () => setSearchTerm('') });
     }
 
     if (visibility !== 'all') {
       filters.push({
         id: `visibility-${visibility}`,
-        label: visibility === 'public' ? 'Status · Öffentlich' : 'Status · Privat',
+        label: visibility === 'public' ? 'Status · Public' : 'Status · Private',
         onClear: () => setVisibility('all'),
       });
     }
@@ -300,9 +300,9 @@ export const GalleryExplorer = ({
     if (entryFilter !== 'all') {
       const labels: Record<EntryFilter, string> = {
         all: '',
-        'with-image': 'Inhalte · Mit Bildern',
-        'with-model': 'Inhalte · Mit LoRAs',
-        empty: 'Inhalte · Ohne Einträge',
+        'with-image': 'Content · With images',
+        'with-model': 'Content · With LoRAs',
+        empty: 'Content · No entries',
       };
       filters.push({
         id: `entries-${entryFilter}`,
@@ -314,7 +314,7 @@ export const GalleryExplorer = ({
     if (ownerId !== 'all') {
       const owner = ownerOptions.find((option) => option.id === ownerId);
       if (owner) {
-        filters.push({ id: `owner-${owner.id}`, label: `Kurator:in · ${owner.label}`, onClear: () => setOwnerId('all') });
+        filters.push({ id: `owner-${owner.id}`, label: `Curator · ${owner.label}`, onClear: () => setOwnerId('all') });
       }
     }
 
@@ -373,50 +373,49 @@ export const GalleryExplorer = ({
     <section className="panel">
       <header className="panel__header">
         <div>
-          <h2 className="panel__title">Galerie-Explorer</h2>
+          <h2 className="panel__title">Gallery explorer</h2>
           <p className="panel__subtitle">
-            Kuratierte Sammlungen mit zufälligen Vorschaubildern, festen Kachelbreiten und detailreichen Bildansichten inklusive
-            EXIF-Daten.
+            Curated collections with random preview tiles, fixed column widths, and detailed image views including EXIF data.
           </p>
         </div>
         <button type="button" className="panel__action" onClick={onStartGalleryDraft}>
-          Galerie-Upload öffnen
+          Open gallery upload
         </button>
       </header>
 
-      <div className="filter-toolbar" aria-label="Filter für Galerien">
+      <div className="filter-toolbar" aria-label="Filters for galleries">
         <div className="filter-toolbar__row">
           <label className="filter-toolbar__search">
-            <span className="sr-only">Suche in Galerien</span>
+            <span className="sr-only">Search in galleries</span>
             <input
               type="search"
               value={searchTerm}
               onChange={(event) => setSearchTerm(event.target.value)}
-              placeholder="Titel, Kurator:in oder Slug durchsuchen"
+              placeholder="Search title, curator, or slug"
               disabled={isLoading && galleries.length === 0}
             />
           </label>
 
           <label className="filter-toolbar__control">
-            <span>Sortierung</span>
+            <span>Sort order</span>
             <select value={sortOption} onChange={(event) => setSortOption(event.target.value as SortOption)} className="filter-select">
-              <option value="recent">Aktualisiert · Neueste zuerst</option>
-              <option value="alpha">Titel · A → Z</option>
-              <option value="entries-desc">Einträge · Viele → Wenige</option>
-              <option value="entries-asc">Einträge · Wenige → Viele</option>
+              <option value="recent">Updated · Newest first</option>
+              <option value="alpha">Title · A → Z</option>
+              <option value="entries-desc">Entries · Many → Few</option>
+              <option value="entries-asc">Entries · Few → Many</option>
             </select>
           </label>
 
-          <div className="filter-toolbar__chips" role="group" aria-label="Sichtbarkeit filtern">
-            <FilterChip label="Alle" isActive={visibility === 'all'} onClick={() => setVisibility('all')} />
-            <FilterChip label="Öffentlich" isActive={visibility === 'public'} onClick={() => setVisibility('public')} />
-            <FilterChip label="Privat" isActive={visibility === 'private'} onClick={() => setVisibility('private')} />
+          <div className="filter-toolbar__chips" role="group" aria-label="Filter visibility">
+            <FilterChip label="All" isActive={visibility === 'all'} onClick={() => setVisibility('all')} />
+            <FilterChip label="Public" isActive={visibility === 'public'} onClick={() => setVisibility('public')} />
+            <FilterChip label="Private" isActive={visibility === 'private'} onClick={() => setVisibility('private')} />
           </div>
 
           <label className="filter-toolbar__control">
-            <span>Kurator:in</span>
+            <span>Curator</span>
             <select value={ownerId} onChange={(event) => setOwnerId(event.target.value)} className="filter-select">
-              <option value="all">Alle Personen</option>
+              <option value="all">All people</option>
               {ownerOptions.map((owner) => (
                 <option key={owner.id} value={owner.id}>
                   {owner.label}
@@ -426,16 +425,16 @@ export const GalleryExplorer = ({
           </label>
         </div>
 
-        <div className="filter-toolbar__chips" role="group" aria-label="Inhaltstyp filtern">
-          <FilterChip label="Alle Inhalte" isActive={entryFilter === 'all'} onClick={() => setEntryFilter('all')} />
-          <FilterChip label="Mit Bildern" isActive={entryFilter === 'with-image'} onClick={() => setEntryFilter('with-image')} />
-          <FilterChip label="Mit LoRAs" isActive={entryFilter === 'with-model'} onClick={() => setEntryFilter('with-model')} />
-          <FilterChip label="Ohne Einträge" isActive={entryFilter === 'empty'} onClick={() => setEntryFilter('empty')} />
+        <div className="filter-toolbar__chips" role="group" aria-label="Filter content type">
+          <FilterChip label="All content" isActive={entryFilter === 'all'} onClick={() => setEntryFilter('all')} />
+          <FilterChip label="With images" isActive={entryFilter === 'with-image'} onClick={() => setEntryFilter('with-image')} />
+          <FilterChip label="With LoRAs" isActive={entryFilter === 'with-model'} onClick={() => setEntryFilter('with-model')} />
+          <FilterChip label="No entries" isActive={entryFilter === 'empty'} onClick={() => setEntryFilter('empty')} />
         </div>
 
         {activeFilters.length > 0 ? (
           <div className="filter-toolbar__active">
-            <span className="filter-toolbar__active-label">Aktive Filter:</span>
+            <span className="filter-toolbar__active-label">Active filters:</span>
             <div className="filter-toolbar__active-chips">
               {activeFilters.map((filter) => (
                 <button key={filter.id} type="button" className="active-filter" onClick={filter.onClear}>
@@ -445,7 +444,7 @@ export const GalleryExplorer = ({
               ))}
             </div>
             <button type="button" className="filter-toolbar__reset" onClick={resetFilters}>
-              Alle Filter zurücksetzen
+              Reset all filters
             </button>
           </div>
         ) : null}
@@ -453,8 +452,8 @@ export const GalleryExplorer = ({
 
       <div className="result-info" role="status">
         {isLoading && galleries.length === 0
-          ? 'Lade Galerien …'
-          : `Zeigt ${visibleGalleries.length} von ${filteredGalleries.length} Sammlungen`}
+          ? 'Loading galleries…'
+          : `Showing ${visibleGalleries.length} of ${filteredGalleries.length} collections`}
       </div>
 
       <div className="gallery-explorer__grid" role="list" aria-label="Galerien">
@@ -486,19 +485,19 @@ export const GalleryExplorer = ({
                         loading="lazy"
                       />
                     ) : (
-                      <span>Kein Vorschaubild</span>
+                      <span>No preview available</span>
                     )}
                   </div>
                   <div className="gallery-card__body">
                     <h3 className="gallery-card__title">{gallery.title}</h3>
-                    <p className="gallery-card__meta">Kuratiert von {gallery.owner.displayName}</p>
+                    <p className="gallery-card__meta">Curated by {gallery.owner.displayName}</p>
                     <dl className="gallery-card__stats">
                       <div>
-                        <dt>Einträge</dt>
+                        <dt>Entries</dt>
                         <dd>{gallery.entries.length}</dd>
                       </div>
                       <div>
-                        <dt>Bilder</dt>
+                        <dt>Images</dt>
                         <dd>{totalImages}</dd>
                       </div>
                       <div>
@@ -506,7 +505,7 @@ export const GalleryExplorer = ({
                         <dd>{totalModels}</dd>
                       </div>
                     </dl>
-                    <p className="gallery-card__timestamp">Zuletzt aktualisiert am {formatDate(gallery.updatedAt)}</p>
+                    <p className="gallery-card__timestamp">Last updated on {formatDate(gallery.updatedAt)}</p>
                   </div>
                 </button>
               );
@@ -516,7 +515,7 @@ export const GalleryExplorer = ({
       {!isLoading && visibleGalleries.length < filteredGalleries.length ? (
         <div className="panel__footer">
           <button type="button" className="panel__action panel__action--ghost" onClick={loadMore}>
-            Weitere {Math.min(GALLERY_BATCH_SIZE, filteredGalleries.length - visibleGalleries.length)} Galerien laden
+            Load {Math.min(GALLERY_BATCH_SIZE, filteredGalleries.length - visibleGalleries.length)} more galleries
           </button>
         </div>
       ) : null}
@@ -529,15 +528,15 @@ export const GalleryExplorer = ({
               <header className="gallery-detail__header">
                 <div>
                   <span className={`gallery-detail__badge${activeGallery.isPublic ? ' gallery-detail__badge--public' : ''}`}>
-                    {activeGallery.isPublic ? 'Öffentliche Sammlung' : 'Private Sammlung'}
+                    {activeGallery.isPublic ? 'Public collection' : 'Private collection'}
                   </span>
                   <h3 id="gallery-detail-title">{activeGallery.title}</h3>
                   <p>
-                    Kuratiert von {activeGallery.owner.displayName} · Aktualisiert am {formatDate(activeGallery.updatedAt)}
+                    Curated by {activeGallery.owner.displayName} · Updated on {formatDate(activeGallery.updatedAt)}
                   </p>
                 </div>
                 <button type="button" className="gallery-detail__close" onClick={closeDetail}>
-                  Zurück zur Galerie
+                  Back to galleries
                 </button>
               </header>
 
@@ -545,13 +544,13 @@ export const GalleryExplorer = ({
                 <p className="gallery-detail__description">{activeGallery.description}</p>
               ) : (
                 <p className="gallery-detail__description gallery-detail__description--muted">
-                  Noch keine Galerie-Beschreibung hinterlegt.
+                  No gallery description provided yet.
                 </p>
               )}
 
               {activeGalleryModels.length > 0 ? (
                 <section className="gallery-detail__models">
-                  <h4>Verknüpfte LoRAs</h4>
+                  <h4>Linked LoRAs</h4>
                   <ul>
                     {activeGalleryModels.map((model) => (
                       <li key={model.id}>
@@ -592,7 +591,7 @@ export const GalleryExplorer = ({
                     );
                   })
                 ) : (
-                  <div className="gallery-detail__empty">Diese Sammlung enthält noch keine Bilder.</div>
+                  <div className="gallery-detail__empty">This collection does not contain any images yet.</div>
                 )}
               </div>
             </div>
@@ -601,15 +600,15 @@ export const GalleryExplorer = ({
       ) : null}
 
       {activeImage ? (
-        <div className="gallery-image-modal" role="dialog" aria-modal="true" aria-label={`${activeImage.image.title} vergrößern`}>
+        <div className="gallery-image-modal" role="dialog" aria-modal="true" aria-label={`Enlarge ${activeImage.image.title}`}>
           <div className="gallery-image-modal__backdrop" onClick={() => setActiveImage(null)} aria-hidden="true" />
           <div className="gallery-image-modal__content">
             <header className="gallery-image-modal__header">
               <div>
                 <h3>{activeImage.image.title}</h3>
-                <p>Kuratiert von {activeGallery?.owner.displayName ?? 'Unbekannt'}</p>
+                <p>Curated by {activeGallery?.owner.displayName ?? 'Unknown'}</p>
               </div>
-              <button type="button" className="gallery-image-modal__close" onClick={() => setActiveImage(null)} aria-label="Bildansicht schließen">
+              <button type="button" className="gallery-image-modal__close" onClick={() => setActiveImage(null)} aria-label="Close image view">
                 ×
               </button>
             </header>
@@ -627,7 +626,7 @@ export const GalleryExplorer = ({
                 />
               </div>
               <div className="gallery-image-modal__meta">
-                {activeImage.note ? <p className="gallery-image-modal__note">Notiz: {activeImage.note}</p> : null}
+                {activeImage.note ? <p className="gallery-image-modal__note">Note: {activeImage.note}</p> : null}
                 <dl>
                   {buildMetadataRows(activeImage.image).map((row) => (
                     <div key={row.label}>

--- a/frontend/src/components/LoginDialog.tsx
+++ b/frontend/src/components/LoginDialog.tsx
@@ -30,14 +30,14 @@ export const LoginDialog = ({ isOpen, onClose, onSubmit, isSubmitting = false, e
     setLocalError(null);
 
     if (!email.trim() || !password) {
-      setLocalError('Bitte E-Mail und Passwort eingeben.');
+      setLocalError('Please enter your email and password.');
       return;
     }
 
     try {
       await onSubmit(email.trim(), password);
     } catch (error) {
-      setLocalError(error instanceof Error ? error.message : 'Anmeldung fehlgeschlagen.');
+      setLocalError(error instanceof Error ? error.message : 'Sign in failed.');
     }
   };
 
@@ -48,14 +48,14 @@ export const LoginDialog = ({ isOpen, onClose, onSubmit, isSubmitting = false, e
       <div className="modal__backdrop" onClick={onClose} aria-hidden="true" />
       <div className="modal__content modal__content--compact">
         <header className="modal__header">
-          <h2 id="login-dialog-title">Anmeldung</h2>
-          <button type="button" className="modal__close" onClick={onClose} aria-label="Dialog schließen">
+          <h2 id="login-dialog-title">Sign in</h2>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Close dialog">
             ×
           </button>
         </header>
         <form className="modal__body" onSubmit={handleSubmit}>
           <label className="form-field">
-            <span>E-Mail</span>
+            <span>Email</span>
             <input
               type="email"
               value={email}
@@ -65,7 +65,7 @@ export const LoginDialog = ({ isOpen, onClose, onSubmit, isSubmitting = false, e
             />
           </label>
           <label className="form-field">
-            <span>Passwort</span>
+            <span>Password</span>
             <input
               type="password"
               value={password}
@@ -77,10 +77,10 @@ export const LoginDialog = ({ isOpen, onClose, onSubmit, isSubmitting = false, e
           {displayError ? <p className="form-error">{displayError}</p> : null}
           <div className="modal__actions">
             <button type="button" className="button" onClick={onClose} disabled={isSubmitting}>
-              Abbrechen
+              Cancel
             </button>
             <button type="submit" className="button button--primary" disabled={isSubmitting}>
-              {isSubmitting ? 'Anmeldung…' : 'Anmelden'}
+              {isSubmitting ? 'Signing in…' : 'Sign in'}
             </button>
           </div>
         </form>

--- a/frontend/src/components/ModelVersionDialog.tsx
+++ b/frontend/src/components/ModelVersionDialog.tsx
@@ -68,31 +68,31 @@ export const ModelVersionDialog = ({ isOpen, onClose, model, token, onSuccess }:
 
     const trimmedVersion = version.trim();
     if (!token) {
-      setError('Bitte melde dich an, um eine neue Modellversion hochzuladen.');
+      setError('Please sign in to upload a new model version.');
       setDetails([]);
       return;
     }
 
     if (trimmedVersion.length === 0) {
-      setError('Bitte gib eine Versionsnummer an.');
+      setError('Please enter a version number.');
       setDetails([]);
       return;
     }
 
     if (!modelFile) {
-      setError('Bitte wähle die Safetensors-Datei aus.');
+      setError('Please select the safetensors file.');
       setDetails([]);
       return;
     }
 
     if (!modelFile.name.toLowerCase().endsWith('.safetensors')) {
-      setError('Die Modelldatei muss im Safetensors-Format vorliegen.');
+      setError('The model file must use the safetensors format.');
       setDetails([]);
       return;
     }
 
     if (!previewFile) {
-      setError('Bitte wähle ein Vorschaubild aus.');
+      setError('Please select a preview image.');
       setDetails([]);
       return;
     }
@@ -123,7 +123,7 @@ export const ModelVersionDialog = ({ isOpen, onClose, model, token, onSuccess }:
         setError(uploadError.message);
         setDetails([]);
       } else {
-        setError('Unbekannter Fehler beim Hochladen der Modellversion.');
+        setError('Unknown error while uploading the model version.');
         setDetails([]);
       }
     } finally {
@@ -139,30 +139,30 @@ export const ModelVersionDialog = ({ isOpen, onClose, model, token, onSuccess }:
     <div className="model-version-dialog" role="dialog" aria-modal="true" aria-labelledby="model-version-title" onClick={handleBackdropClick}>
       <div className="model-version-dialog__content">
         <header className="model-version-dialog__header">
-          <h3 id="model-version-title">Neue Version für {model.title}</h3>
+          <h3 id="model-version-title">New version for {model.title}</h3>
           <button
             type="button"
             className="model-version-dialog__close"
             onClick={onClose}
             disabled={isSubmitting}
           >
-            Schließen
+            Close
           </button>
         </header>
         <form className="model-version-dialog__form" onSubmit={handleSubmit}>
           <label className="model-version-dialog__field">
-            <span>Versionsnummer</span>
+            <span>Version number</span>
             <input
               type="text"
               value={version}
               onChange={(event) => setVersion(event.target.value)}
-              placeholder="z. B. 1.2.0"
+              placeholder="e.g. 1.2.0"
               disabled={isSubmitting}
               required
             />
           </label>
           <label className="model-version-dialog__field">
-            <span>Safetensors-Datei</span>
+            <span>Safetensors file</span>
             <input
               type="file"
               accept=".safetensors"
@@ -173,7 +173,7 @@ export const ModelVersionDialog = ({ isOpen, onClose, model, token, onSuccess }:
             {modelFile ? <small className="model-version-dialog__hint">{modelFile.name}</small> : null}
           </label>
           <label className="model-version-dialog__field">
-            <span>Vorschaubild</span>
+            <span>Preview image</span>
             <input
               type="file"
               accept="image/*"
@@ -199,10 +199,10 @@ export const ModelVersionDialog = ({ isOpen, onClose, model, token, onSuccess }:
 
           <footer className="model-version-dialog__actions">
             <button type="button" onClick={onClose} className="model-version-dialog__secondary" disabled={isSubmitting}>
-              Abbrechen
+              Cancel
             </button>
             <button type="submit" className="model-version-dialog__primary" disabled={isSubmitting || !token}>
-              {isSubmitting ? 'Lädt …' : 'Version hochladen'}
+              {isSubmitting ? 'Uploading…' : 'Upload version'}
             </button>
           </footer>
         </form>

--- a/frontend/src/components/UploadWizard.tsx
+++ b/frontend/src/components/UploadWizard.tsx
@@ -22,40 +22,40 @@ interface UploadWizardProps {
 const stepDefinitions = [
   {
     id: 'details' as const,
-    label: { asset: 'Basisdaten', gallery: 'Galerie-Einstellungen' },
+    label: { asset: 'Basic information', gallery: 'Gallery settings' },
     helper: {
-      asset: 'Titel, Typ und Sichtbarkeit festlegen',
-      gallery: 'Ziel-Galerie, Sichtbarkeit und Tags wählen',
+      asset: 'Set title, type, and visibility',
+      gallery: 'Choose target gallery, visibility, and tags',
     },
   },
   {
     id: 'files' as const,
-    label: { asset: 'Dateien', gallery: 'Bilddateien' },
+    label: { asset: 'Files', gallery: 'Image files' },
     helper: {
-      asset: 'LoRA- oder Bilddateien hinzufügen',
-      gallery: 'Mehrere Bilder hinzufügen und Limits beachten',
+      asset: 'Add LoRA or image files',
+      gallery: 'Add multiple images and respect limits',
     },
   },
   {
     id: 'review' as const,
     label: { asset: 'Review', gallery: 'Review' },
     helper: {
-      asset: 'Zusammenfassung prüfen & absenden',
-      gallery: 'Zusammenfassung prüfen & absenden',
+      asset: 'Review summary & submit',
+      gallery: 'Review summary & submit',
     },
   },
 ] as const;
 
 type StepId = (typeof stepDefinitions)[number]['id'];
 
-type AssetType = 'lora' | 'image';
+type AssetTypee = 'lora' | 'image';
 
 type Visibility = 'private' | 'public';
 
 type GalleryMode = 'existing' | 'new';
 
 interface UploadFormState {
-  assetType: AssetType;
+  assetTypee: AssetTypee;
   title: string;
   description: string;
   visibility: Visibility;
@@ -66,7 +66,7 @@ interface UploadFormState {
 }
 
 const buildInitialState = (mode: UploadWizardMode): UploadFormState => ({
-  assetType: mode === 'gallery' ? 'image' : 'lora',
+  assetTypee: mode === 'gallery' ? 'image' : 'lora',
   title: '',
   description: '',
   visibility: 'private',
@@ -76,6 +76,13 @@ const buildInitialState = (mode: UploadWizardMode): UploadFormState => ({
   tags: [],
 });
 
+const CATEGORY_LABELS: Record<string, string> = {
+  style: 'Style & look',
+  character: 'Character / person',
+  environment: 'Environment / setting',
+  workflow: 'Workflow / utility',
+};
+
 const formatFileSize = (size: number) => {
   if (size < 1024) return `${size} B`;
   if (size < 1024 ** 2) return `${(size / 1024).toFixed(1)} KB`;
@@ -84,7 +91,7 @@ const formatFileSize = (size: number) => {
 };
 
 const summarizeTags = (tags: string[]) => {
-  if (tags.length === 0) return 'Keine Tags vergeben';
+  if (tags.length === 0) return 'No tags assigned';
   if (tags.length < 4) return tags.join(', ');
   return `${tags.slice(0, 3).join(', ')} … (+${tags.length - 3})`;
 };
@@ -204,7 +211,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
         if (!isActive) return;
         console.error('Failed to load galleries for upload wizard', error);
         setAvailableGalleries([]);
-        setGalleryError('Galerien konnten nicht geladen werden. Bitte später erneut versuchen.');
+        setGalleryError('Galleries could not be loaded. Please try again later.');
       } finally {
         if (isActive) {
           setIsLoadingGalleries(false);
@@ -279,7 +286,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
         for (const file of normalized) {
           if (isImageFile(file)) {
             if (previewFile && previewFile.name !== file.name) {
-              nextError = 'Es kann maximal ein Vorschaubild pro Modell hochgeladen werden.';
+              nextError = 'Only one preview image can be uploaded per model.';
               continue;
             }
             previewFile = file;
@@ -287,7 +294,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
           }
 
           if (modelFile && modelFile.name !== file.name) {
-            nextError = 'Es kann nur eine Modelldatei pro Upload ausgewählt werden.';
+            nextError = 'Only one model file can be selected per upload.';
             continue;
           }
 
@@ -300,7 +307,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
 
         const total = candidate.reduce((sum, file) => sum + file.size, 0);
         if (total > MAX_TOTAL_SIZE_BYTES) {
-          nextError = `Die Gesamtgröße überschreitet das Limit von ${formatFileSize(MAX_TOTAL_SIZE_BYTES)}.`;
+          nextError = `The total size exceeds the limit of ${formatFileSize(MAX_TOTAL_SIZE_BYTES)}.`;
           return prev;
         }
 
@@ -327,26 +334,26 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
           return true;
         }
         if (!nextError) {
-          nextError = 'Nur Bilddateien (PNG, JPG, WebP, GIF) können in eine Galerie hochgeladen werden.';
+          nextError = 'Only image files (PNG, JPG, WebP, GIF) can be uploaded to a gallery.';
         }
         return false;
       });
 
       const availableSlots = MAX_UPLOAD_FILES - merged.length;
       if (availableSlots <= 0) {
-        nextError = `Es können maximal ${MAX_UPLOAD_FILES} Dateien pro Upload verarbeitet werden.`;
+        nextError = `A maximum of ${MAX_UPLOAD_FILES} files can be processed per upload.`;
         return merged;
       }
 
       const toAdd = filtered.slice(0, availableSlots);
       if (filtered.length > toAdd.length) {
-        nextError = `Es können maximal ${MAX_UPLOAD_FILES} Dateien pro Upload verarbeitet werden.`;
+        nextError = `A maximum of ${MAX_UPLOAD_FILES} files can be processed per upload.`;
       }
 
       const updated = [...merged, ...toAdd];
       const total = updated.reduce((sum, file) => sum + file.size, 0);
       if (total > MAX_TOTAL_SIZE_BYTES) {
-        nextError = `Die Gesamtgröße überschreitet das Limit von ${formatFileSize(MAX_TOTAL_SIZE_BYTES)}.`;
+        nextError = `The total size exceeds the limit of ${formatFileSize(MAX_TOTAL_SIZE_BYTES)}.`;
         return prev;
       }
 
@@ -373,13 +380,13 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
       if (!formState.title.trim()) {
         setStepError(
           isGalleryMode
-            ? 'Bitte vergib einen Upload-Titel für die neuen Bilder.'
-            : 'Bitte vergib einen Titel für das Asset.',
+            ? 'Please provide an upload title for the new images.'
+            : 'Please provide a title for the asset.',
         );
         return false;
       }
       if (formState.galleryMode === 'existing' && !formState.targetGallery.trim()) {
-        setStepError('Bitte gib eine bestehende Galerie an oder wähle "Neue Galerie".');
+        setStepError('Please specify an existing gallery or choose "New gallery".');
         return false;
       }
       setStepError(null);
@@ -389,7 +396,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
     if (step === 'files') {
       if (files.length === 0) {
         setStepError(
-          isGalleryMode ? 'Bitte füge mindestens eine Datei hinzu.' : 'Bitte füge eine Modelldatei hinzu.',
+          isGalleryMode ? 'Please add at least one file.' : 'Please add a model file.',
         );
         return false;
       }
@@ -399,27 +406,27 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
         const previewFiles = files.filter((file) => isImageFile(file));
 
         if (modelFiles.length === 0) {
-          setStepError('Bitte füge eine Modelldatei hinzu.');
+          setStepError('Please add a model file.');
           return false;
         }
 
         if (modelFiles.length > 1) {
-          setStepError('Es kann nur eine Modelldatei pro Upload verarbeitet werden.');
+          setStepError('Only one model file can be processed per upload.');
           return false;
         }
 
         if (previewFiles.length > 1) {
-          setStepError('Es kann maximal ein Vorschaubild pro Upload hinzugefügt werden.');
+          setStepError('Only one preview image can be added per upload.');
           return false;
         }
       } else if (files.length > MAX_UPLOAD_FILES) {
-        setStepError(`Es können maximal ${MAX_UPLOAD_FILES} Dateien pro Upload verarbeitet werden.`);
+        setStepError(`A maximum of ${MAX_UPLOAD_FILES} files can be processed per upload.`);
         return false;
       }
 
       const total = files.reduce((sum, file) => sum + file.size, 0);
       if (total > MAX_TOTAL_SIZE_BYTES) {
-        setStepError(`Die Gesamtgröße überschreitet das Limit von ${formatFileSize(MAX_TOTAL_SIZE_BYTES)}.`);
+        setStepError(`The total size exceeds the limit of ${formatFileSize(MAX_TOTAL_SIZE_BYTES)}.`);
         return false;
       }
       setStepError(null);
@@ -449,59 +456,62 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
 
   const reviewMetadata = useMemo(() => {
     const base = [
-      { label: isGalleryMode ? 'Upload-Titel' : 'Titel', value: formState.title || '–' },
-      { label: isGalleryMode ? 'Beschreibung / Notiz' : 'Beschreibung', value: formState.description || '–' },
+      { label: isGalleryMode ? 'Upload title' : 'Title', value: formState.title || '–' },
+      { label: isGalleryMode ? 'Description / note' : 'Description', value: formState.description || '–' },
       {
-        label: 'Sichtbarkeit',
+        label: 'Visibility',
         value:
           formState.visibility === 'public'
-            ? 'Öffentlich'
+            ? 'Public'
             : formState.galleryMode === 'existing'
-              ? 'Privat (übernimmt Sichtbarkeit der Galerie)'
-              : 'Privat',
+              ? 'Private (inherits gallery visibility)'
+              : 'Private',
       },
       { label: 'Tags', value: summarizeTags(formState.tags) },
       {
-        label: 'Ziel-Galerie',
+        label: 'Target gallery',
         value: isGalleryMode
           ? formState.galleryMode === 'existing'
             ? selectedTargetGallery
               ? `${selectedTargetGallery.title} (${selectedTargetGallery.owner.displayName})`
               : formState.targetGallery
-                ? 'Ausgewählte Galerie nicht mehr verfügbar'
-                : 'Bitte Galerie auswählen'
-            : 'Neue Galerie wird nach Upload angelegt'
-          : 'Neue Galerie wird automatisch erstellt',
+                ? 'Selected gallery no longer available'
+                : 'Select a gallery'
+            : 'New gallery will be created after the upload'
+          : 'New gallery will be created automatically',
       },
-      { label: 'Dateien', value: `${files.length} · ${formatFileSize(totalSize)}` },
+      { label: 'Files', value: `${files.length} · ${formatFileSize(totalSize)}` },
     ];
 
     if (!isGalleryMode) {
       base.splice(2, 0, {
-        label: 'Typ',
-        value: formState.assetType === 'lora' ? 'LoRA / Safetensor' : 'Bild / Render',
+        label: 'Type',
+        value: formState.assetTypee === 'lora' ? 'LoRA / safetensor' : 'Image / render',
       });
-      base.splice(4, 0, { label: 'Kategorie', value: formState.category || 'Allgemein' });
+      base.splice(4, 0, {
+        label: 'Category',
+        value: CATEGORY_LABELS[formState.category] ?? 'General',
+      });
     } else {
-      base.splice(2, 0, { label: 'Upload-Kontext', value: 'Galerie-Entwurf (Bilder)' });
+      base.splice(2, 0, { label: 'Upload context', value: 'Gallery draft (images)' });
       base.push({
-        label: 'Upload-Limits',
-        value: `${MAX_UPLOAD_FILES} Dateien · bis ${formatFileSize(MAX_TOTAL_SIZE_BYTES)}`,
+        label: 'Upload limits',
+        value: `${MAX_UPLOAD_FILES} files · up to ${formatFileSize(MAX_TOTAL_SIZE_BYTES)}`,
       });
     }
 
-    if (files.length > 0 && formState.assetType === 'lora') {
-      base.push({ label: 'Checksum-Vorschau', value: 'Wird nach Upload vom Backend berechnet' });
+    if (files.length > 0 && formState.assetTypee === 'lora') {
+      base.push({ label: 'Checksum preview', value: 'Calculated by backend after upload' });
     }
 
-    if (files.length > 0 && formState.assetType === 'image' && !isGalleryMode) {
-      base.push({ label: 'EXIF/Prompt', value: 'Extraktion nach Upload in Warteschlange' });
+    if (files.length > 0 && formState.assetTypee === 'image' && !isGalleryMode) {
+      base.push({ label: 'EXIF/prompt', value: 'Extraction queued after upload' });
     }
 
     return base;
   }, [
     files.length,
-    formState.assetType,
+    formState.assetTypee,
     formState.category,
     formState.description,
     formState.galleryMode,
@@ -524,7 +534,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
     }
 
     if (!token) {
-      setSubmitResult({ status: 'error', message: 'Anmeldung erforderlich, um Uploads zu starten.' });
+      setSubmitResult({ status: 'error', message: 'Sign-in required to start uploads.' });
       return;
     }
 
@@ -535,14 +545,14 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
     try {
       await simulateProgress((value) => setProgressValue(Math.min(95, Math.round(value))));
 
-      const assetType = isGalleryMode ? 'image' : formState.assetType;
+      const assetTypee = isGalleryMode ? 'image' : formState.assetTypee;
       const title = formState.title.trim();
       const description = formState.description.trim();
       const targetGallery = formState.targetGallery.trim();
 
       const response = await api.createUploadDraft(
         {
-          assetType,
+          assetTypee,
           context: isGalleryMode ? 'gallery' : 'asset',
           title,
           description: description.length > 0 ? description : undefined,
@@ -559,11 +569,11 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
       setProgressValue(100);
       const details = [
         response.assetSlug ? `Asset: ${response.assetSlug}` : null,
-        response.gallerySlug ? `Galerie: ${response.gallerySlug}` : null,
+        response.gallerySlug ? `Gallery: ${response.gallerySlug}` : null,
         response.imageIds && response.imageIds.length > 1
-          ? `${response.imageIds.length} Bilder`
+          ? `${response.imageIds.length} images`
           : response.imageId
-            ? '1 Bild'
+            ? '1 image'
             : null,
       ]
         .filter(Boolean)
@@ -574,10 +584,10 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
         uploadId: response.uploadId,
         message:
           response.message ??
-          `Upload abgeschlossen. ${
+          `Upload complete. ${
             details.length > 0
-              ? `${details} stehen unmittelbar im Explorer bereit.`
-              : 'Dateien stehen unmittelbar im Explorer bereit.'
+              ? `${details} are immediately available in the explorer.`
+              : 'Files are immediately available in the explorer.'
           }`,
       };
       setSubmitResult(result);
@@ -597,7 +607,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
       const message =
         error instanceof Error
           ? error.message
-          : 'Upload konnte nicht gestartet werden. Bitte später erneut versuchen.';
+          : 'Upload could not be started. Please try again later.';
       const result: UploadWizardResult = { status: 'error', message };
       setSubmitResult(result);
       onComplete?.(result);
@@ -616,15 +626,15 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
       <div className="upload-wizard__dialog">
         <header className="upload-wizard__header">
           <div>
-            <h2 id="upload-wizard-title">{isGalleryMode ? 'Galerie-Upload' : 'Upload-Assistent'}</h2>
+            <h2 id="upload-wizard-title">{isGalleryMode ? 'Gallery upload' : 'Upload assistant'}</h2>
             <p>
               {isGalleryMode
-                ? 'Füge neue Bilder strukturiert in bestehende Sammlungen ein oder starte eine frische Galerie.'
-                : 'Führe neue LoRAs oder Renderings strukturiert ein. Nach Abschluss wird automatisch eine Upload-Session im Backend angelegt.'}
+                ? 'Add new images to existing collections or start a new gallery in a structured way.'
+                : 'Introduce new LoRAs or renderings in a structured way. An upload session is created automatically after completion.'}
             </p>
           </div>
           <button type="button" className="upload-wizard__close" onClick={onClose}>
-            Schließen
+            Close
           </button>
         </header>
 
@@ -654,15 +664,15 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
             <div className="upload-wizard__grid">
               <div className="upload-wizard__field">
                 <label>
-                  <span>{isGalleryMode ? 'Upload-Titel*' : 'Titel*'}</span>
+                  <span>Upload title*</span>
                   <input
                     type="text"
                     value={formState.title}
                     onChange={(event) => setFormState((prev) => ({ ...prev, title: event.target.value }))}
                     placeholder={
                       isGalleryMode
-                        ? 'z. B. Spotlight Serie – Nachtaufnahmen'
-                        : 'z. B. Neon Depth Portrait Pack'
+                        ? 'e.g. Spotlight Series – Night Shots'
+                        : 'e.g. Neon Depth Portrait Pack'
                     }
                   />
                 </label>
@@ -670,7 +680,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
 
               <div className="upload-wizard__field upload-wizard__field--inline">
                 <label>
-                  <span>Sichtbarkeit</span>
+                  <span>Visibility</span>
                   <div className="upload-wizard__options">
                     <label>
                       <input
@@ -680,7 +690,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                         checked={formState.visibility === 'private'}
                         onChange={() => setFormState((prev) => ({ ...prev, visibility: 'private' }))}
                       />
-                      <span>Privat</span>
+                      <span>Private</span>
                     </label>
                     <label>
                       <input
@@ -690,7 +700,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                         checked={formState.visibility === 'public'}
                         onChange={() => setFormState((prev) => ({ ...prev, visibility: 'public' }))}
                       />
-                      <span>Öffentlich</span>
+                      <span>Public</span>
                     </label>
                   </div>
                 </label>
@@ -699,15 +709,15 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
               {!isGalleryMode ? (
                 <div className="upload-wizard__field">
                   <label>
-                    <span>Kategorie</span>
+                    <span>Category</span>
                     <select
                       value={formState.category}
                       onChange={(event) => setFormState((prev) => ({ ...prev, category: event.target.value }))}
                     >
-                      <option value="style">Stil & Look</option>
-                      <option value="character">Character / Person</option>
-                      <option value="environment">Environment / Setting</option>
-                      <option value="workflow">Workflow / Utility</option>
+                      <option value="style">Style & look</option>
+                      <option value="character">Character / person</option>
+                      <option value="environment">Environment / setting</option>
+                      <option value="workflow">Workflow / utility</option>
                     </select>
                   </label>
                 </div>
@@ -715,14 +725,14 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
 
               <div className="upload-wizard__field upload-wizard__field--full">
                 <label>
-                  <span>{isGalleryMode ? 'Beschreibung / Notiz' : 'Beschreibung'}</span>
+                  <span>{isGalleryMode ? 'Description / note' : 'Description'}</span>
                   <textarea
                     value={formState.description}
                     onChange={(event) => setFormState((prev) => ({ ...prev, description: event.target.value }))}
                     placeholder={
                       isGalleryMode
-                        ? 'Optionaler Prompt-Kontext oder Hinweise zur Serie …'
-                        : 'Kontext, Besonderheiten, Trigger-Wörter oder Basismodelle …'
+                        ? 'Optional prompt context or notes about the series…'
+                        : 'Context, special considerations, trigger words, or base models…'
                     }
                     rows={3}
                   />
@@ -749,7 +759,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                           handleAddTag();
                         }
                       }}
-                      placeholder="Tag hinzufügen und Enter drücken"
+                      placeholder="Add a tag and press Enter"
                     />
                   </div>
                 </label>
@@ -757,7 +767,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
 
               {isGalleryMode ? (
                 <div className="upload-wizard__field upload-wizard__field--full">
-                  <span>Galerie-Zuordnung</span>
+                  <span>Gallery assignment</span>
                   <div className="upload-wizard__options upload-wizard__options--stacked">
                     <label>
                       <input
@@ -767,7 +777,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                         checked={formState.galleryMode === 'existing'}
                         onChange={() => setFormState((prev) => ({ ...prev, galleryMode: 'existing' }))}
                       />
-                      <span>{isGalleryMode ? 'Zu bestehender Galerie hinzufügen' : 'Zu bestehender Galerie hinzufügen'}</span>
+                      <span>Add to existing gallery</span>
                     </label>
                     <label>
                       <input
@@ -779,15 +789,15 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                       />
                       <span>
                         {isGalleryMode
-                          ? 'Neue Galerie während des Uploads anlegen'
-                          : 'Neue Galerie im Review-Schritt anlegen'}
+                          ? 'Create a new gallery during the upload'
+                          : 'Create a new gallery during the review step'}
                       </span>
                     </label>
                   </div>
                   {formState.galleryMode === 'existing' ? (
                     <div className="upload-wizard__gallery-select">
                       <label>
-                        <span className="sr-only">Bestehende Galerie</span>
+                        <span className="sr-only">Existing gallery</span>
                         <select
                           value={formState.targetGallery}
                           onChange={(event) =>
@@ -797,10 +807,10 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                         >
                           <option value="">
                             {isLoadingGalleries
-                              ? 'Galerien werden geladen …'
+                              ? 'Loading galleries…'
                               : availableGalleries.length === 0
-                                ? 'Keine Galerie verfügbar'
-                                : 'Bitte Galerie auswählen'}
+                                ? 'No gallery available'
+                                : 'Select a gallery'}
                           </option>
                           {availableGalleries.map((gallery) => (
                             <option key={gallery.id} value={gallery.slug}>
@@ -816,7 +826,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                       ) : null}
                       {!galleryError && !isLoadingGalleries && availableGalleries.length === 0 ? (
                         <p className="upload-wizard__helper">
-                          Keine passenden Galerien gefunden. Lege eine neue Galerie an oder ändere die Auswahl.
+                          No matching galleries found. Create a new gallery or adjust the selection.
                         </p>
                       ) : null}
                     </div>
@@ -845,13 +855,13 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                     }
                   }}
                 />
-                <span>Ziehe Dateien hierher oder klicke, um sie auszuwählen.</span>
+                <span>Drag files here or click to choose.</span>
                 <span className="upload-wizard__dropzone-helper">
                   {isGalleryMode
-                    ? `Unterstützt PNG, JPG, WebP und GIF. Mehrfachauswahl bis ${MAX_UPLOAD_FILES} Dateien mit insgesamt ${formatFileSize(
+                    ? `Supports PNG, JPG, WebP, and GIF. Select up to ${MAX_UPLOAD_FILES} files with a combined size of ${formatFileSize(
                         MAX_TOTAL_SIZE_BYTES,
                       )}.`
-                    : `Unterstützt Safetensors oder ZIP-Bundles für das Modell plus ein optionales PNG, JPG, WebP oder GIF als Vorschaubild. Maximal ein Modell und ein Vorschaubild mit insgesamt ${formatFileSize(
+                    : `Supports safetensors or ZIP bundles for the model plus an optional PNG, JPG, WebP, or GIF preview. Upload up to one model and one preview with a combined size of ${formatFileSize(
                         MAX_TOTAL_SIZE_BYTES,
                       )}.`}
                 </span>
@@ -864,20 +874,20 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                       <div>
                         <span className="upload-wizard__file-name">{file.name}</span>
                         <span className="upload-wizard__file-meta">
-                          {formatFileSize(file.size)} · {file.type || 'Dateityp wird beim Upload bestimmt'}
+                          {formatFileSize(file.size)} · {file.type || 'File type determined during upload'}
                         </span>
                       </div>
                       <button type="button" onClick={() => removeFile(file.name)}>
-                        Entfernen
+                        Remove
                       </button>
                     </div>
                   ))}
                   <div className="upload-wizard__file-summary">
-                    Gesamt: {files.length} Datei{files.length === 1 ? '' : 'en'} · {formatFileSize(totalSize)}
+                    Total: {files.length} file{files.length === 1 ? '' : 's'} · {formatFileSize(totalSize)}
                   </div>
                 </div>
               ) : (
-                <p className="upload-wizard__empty">Noch keine Dateien ausgewählt.</p>
+                <p className="upload-wizard__empty">No files selected yet.</p>
               )}
             </div>
           ) : null}
@@ -885,7 +895,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
           {currentStep.id === 'review' ? (
             <div className="upload-wizard__review">
               <div className="upload-wizard__review-card">
-                <h3>Zusammenfassung</h3>
+                <h3>Summary</h3>
                 <dl>
                   {reviewMetadata.map((item) => (
                     <div key={item.label}>
@@ -897,14 +907,11 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
               </div>
 
               <div className="upload-wizard__review-card">
-                <h3>Nächste Schritte</h3>
+                <h3>Next steps</h3>
                 <ul>
-                  <li>Upload-Session wird angelegt und Dateien werden nacheinander übertragen.</li>
-                  <li>Nach Abschluss prüft der Analyse-Worker automatisch Safetensor-Header bzw. EXIF-/Prompt-Daten.</li>
-                  <li>
-                    Du erhältst einen Hinweis im Dashboard, sobald die Zuordnung zu Galerien oder LoRA-Bibliothek abgeschlossen
-                    ist.
-                  </li>
+                  <li>An upload session is created and files are transferred sequentially.</li>
+                  <li>After completion, the analysis worker automatically inspects safetensor headers or EXIF/prompt data.</li>
+                  <li>You will be notified in the dashboard once gallery or LoRA library assignments are complete.</li>
                 </ul>
               </div>
 
@@ -914,7 +921,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                 >
                   {submitResult.status === 'success' ? (
                     <>
-                      <strong>Upload gestartet</strong>
+                      <strong>Upload started</strong>
                       <span>
                         {submitResult.message}
                         {submitResult.uploadId ? ` (ID: ${submitResult.uploadId})` : ''}
@@ -922,7 +929,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                     </>
                   ) : (
                     <>
-                      <strong>Fehler</strong>
+                      <strong>Error</strong>
                       <span>{submitResult.message}</span>
                       {submitResult.details && submitResult.details.length > 0 ? (
                         <ul className="upload-wizard__result-details">
@@ -939,7 +946,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
               {isSubmitting ? (
                 <div className="upload-wizard__progress" aria-live="polite">
                   <div className="upload-wizard__progress-bar" style={{ width: `${progressValue}%` }} />
-                  <span>Übertrage … {progressValue}%</span>
+                  <span>Transferring… {progressValue}%</span>
                 </div>
               ) : null}
             </div>
@@ -951,17 +958,17 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
         <footer className="upload-wizard__footer">
           <div className="upload-wizard__footer-meta">
             <span>
-              Schritt {currentStepIndex + 1} von {steps.length}
+              Step {currentStepIndex + 1} of {steps.length}
             </span>
             <span>{currentStep.helper}</span>
           </div>
           <div className="upload-wizard__footer-actions">
             <button type="button" className="panel__action" onClick={currentStepIndex === 0 ? onClose : handleBack}>
-              {currentStepIndex === 0 ? 'Abbrechen' : 'Zurück'}
+              {currentStepIndex === 0 ? 'Cancel' : 'Back'}
             </button>
             {currentStep.id !== 'review' ? (
               <button type="button" className="panel__action panel__action--primary" onClick={handleNext}>
-                Weiter
+                Next
               </button>
             ) : (
               <button
@@ -970,7 +977,7 @@ export const UploadWizard = ({ isOpen, onClose, onComplete, mode = 'asset' }: Up
                 onClick={handleSubmit}
                 disabled={isSubmitting || submitResult?.status === 'success'}
               >
-                Upload starten
+                Start upload
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary
- translate the main navigation shell, admin tooling, and explorer components to English for consistent wording across the frontend
- finish the Upload Wizard translation, update helper and validation copy, and add category labels for readable summaries
- document the English UI status in the README and changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdc292c0e48333ab331c653fdc59c8