### PR TITLE
feat: move linked galleries under model preview

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -242,3 +242,8 @@
 - **General**: Consolidated all legacy changelog entries into the unified format and cleaned up redundant files.
 - **Technical Changes**: Transcribed prior per-commit notes into the new changelog layout and removed superseded markdown entries.
 - **Data Changes**: None.
+
+## 2025-09-20 – Preview gallery quick actions
+- **General**: Moved linked image collection access directly beneath the model preview with action-style buttons.
+- **Technical Changes**: Updated the asset detail preview card to render gallery navigation buttons alongside downloads and refreshed the associated styling while removing the old section list.
+- **Data Changes**: None.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -1147,21 +1147,54 @@ export const AssetExplorer = ({
                       <span>No preview available.</span>
                     </div>
                   )}
-                  {modelDownloadUrl ? (
-                    <a
-                      className="asset-detail__download"
-                      href={modelDownloadUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      download
-                    >
-                      Download model
-                    </a>
-                  ) : (
-                    <span className="asset-detail__download asset-detail__download--disabled">
-                      Download not available
-                    </span>
-                  )}
+                  <div className="asset-detail__preview-actions">
+                    {modelDownloadUrl ? (
+                      <a
+                        className="asset-detail__download asset-detail__action"
+                        href={modelDownloadUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        download
+                      >
+                        Download model
+                      </a>
+                    ) : (
+                      <span className="asset-detail__download asset-detail__download--disabled asset-detail__action">
+                        Download not available
+                      </span>
+                    )}
+                    {relatedGalleries.length > 0 ? (
+                      relatedGalleries.map((gallery) => {
+                        const label = `Open collection: ${gallery.title}`;
+
+                        if (onNavigateToGallery) {
+                          return (
+                            <button
+                              key={gallery.id}
+                              type="button"
+                              onClick={() => handleNavigateFromDetail(gallery.id)}
+                              className="asset-detail__gallery-link asset-detail__action"
+                            >
+                              {label}
+                            </button>
+                          );
+                        }
+
+                        return (
+                          <span
+                            key={gallery.id}
+                            className="asset-detail__gallery-link asset-detail__gallery-link--disabled asset-detail__action"
+                          >
+                            {label}
+                          </span>
+                        );
+                      })
+                    ) : (
+                      <span className="asset-detail__gallery-link asset-detail__gallery-link--disabled asset-detail__action">
+                        No linked image collections
+                      </span>
+                    )}
+                  </div>
                 </div>
               </div>
 
@@ -1215,32 +1248,6 @@ export const AssetExplorer = ({
                 )}
               </section>
 
-              <section className="asset-detail__section">
-                <h4>Linked image collections</h4>
-                {relatedGalleries.length > 0 ? (
-                  <ul className="asset-detail__gallery-links">
-                    {relatedGalleries.map((gallery) => (
-                      <li key={gallery.id}>
-                        {onNavigateToGallery ? (
-                          <button
-                            type="button"
-                            onClick={() => handleNavigateFromDetail(gallery.id)}
-                            className="asset-detail__gallery-button"
-                          >
-                            {gallery.title}
-                          </button>
-                        ) : (
-                          <span>{gallery.title}</span>
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="asset-detail__description asset-detail__description--muted">
-                    This LoRA is not linked to any image collection yet.
-                  </p>
-                )}
-              </section>
             </div>
             {isTagDialogOpen && tagFrequencyGroups.length > 0 ? (
               <div className="tag-frequency-dialog" role="dialog" aria-modal="true" aria-labelledby="tag-frequency-title">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2323,6 +2323,12 @@ main {
   transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 }
 
+.asset-detail__preview-actions {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
 .asset-detail__download:hover,
 .asset-detail__download:focus-visible {
   background: rgba(59, 130, 246, 0.35);
@@ -2332,7 +2338,6 @@ main {
 }
 
 .asset-detail__download--disabled {
-  display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0.6rem 1rem;
@@ -2343,6 +2348,66 @@ main {
   font-size: 0.8rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+.asset-detail__action {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.asset-detail__action.asset-detail__download,
+.asset-detail__action.asset-detail__download--disabled {
+  display: flex;
+}
+
+.asset-detail__gallery-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: rgba(22, 101, 52, 0.32);
+  color: rgba(187, 247, 208, 0.95);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+  text-decoration: none;
+}
+
+.asset-detail__preview-actions button.asset-detail__gallery-link {
+  appearance: none;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.asset-detail__gallery-link:hover,
+.asset-detail__gallery-link:focus-visible {
+  background: rgba(34, 197, 94, 0.45);
+  border-color: rgba(34, 197, 94, 0.55);
+  color: #0f172a;
+  outline: none;
+}
+
+.asset-detail__gallery-link--disabled {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: rgba(148, 163, 184, 0.7);
+  cursor: default;
+}
+
+.asset-detail__gallery-link--disabled:hover,
+.asset-detail__gallery-link--disabled:focus-visible {
+  background: rgba(15, 23, 42, 0.55);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(148, 163, 184, 0.7);
 }
 
 .asset-detail__section h4 {
@@ -2507,34 +2572,6 @@ main {
 .asset-detail__metadata-scroll::-webkit-scrollbar-thumb {
   background: rgba(59, 130, 246, 0.35);
   border-radius: 999px;
-}
-
-.asset-detail__gallery-links {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.asset-detail__gallery-button {
-  width: 100%;
-  text-align: left;
-  border: 1px solid rgba(34, 197, 94, 0.35);
-  background: rgba(22, 101, 52, 0.32);
-  color: rgba(187, 247, 208, 0.95);
-  padding: 0.6rem 0.9rem;
-  border-radius: 12px;
-  cursor: pointer;
-  font-weight: 500;
-}
-
-.asset-detail__gallery-button:hover,
-.asset-detail__gallery-button:focus-visible {
-  background: rgba(34, 197, 94, 0.45);
-  color: #0f172a;
-  outline: none;
 }
 
 .asset-explorer__sentinel {


### PR DESCRIPTION
## Summary
- reposition linked image collections under the model preview with action-style buttons
- align preview action styling and remove the previous linked gallery section layout
- record the UI update in the changelog

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce60e4421c83339ede5c4ad59ee4f2