### PR TITLE
Polish model card actions

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -252,3 +252,8 @@
 - **General**: Moved linked image collection access directly beneath the model preview with action-style buttons.
 - **Technical Changes**: Updated the asset detail preview card to render gallery navigation buttons alongside downloads and refreshed the associated styling while removing the old section list.
 - **Data Changes**: None.
+
+## 2025-09-20 – Model card action polish (commit TBD)
+- **General**: Tightened the model card actions by matching button styling and clarifying the surrounding tag and metadata layout.
+- **Technical Changes**: Reduced preview action width stretching, unified the open-collection button palette with downloads, simplified its label, introduced a detail grid for tags versus metadata, and refreshed spacing utilities for both sections.
+- **Data Changes**: None.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -1165,7 +1165,8 @@ export const AssetExplorer = ({
                     )}
                     {relatedGalleries.length > 0 ? (
                       relatedGalleries.map((gallery) => {
-                        const label = `Open collection: ${gallery.title}`;
+                        const label = 'Open Collection';
+                        const ariaLabel = `Open collection: ${gallery.title}`;
 
                         if (onNavigateToGallery) {
                           return (
@@ -1174,6 +1175,7 @@ export const AssetExplorer = ({
                               type="button"
                               onClick={() => handleNavigateFromDetail(gallery.id)}
                               className="asset-detail__gallery-link asset-detail__action"
+                              aria-label={ariaLabel}
                             >
                               {label}
                             </button>
@@ -1184,6 +1186,7 @@ export const AssetExplorer = ({
                           <span
                             key={gallery.id}
                             className="asset-detail__gallery-link asset-detail__gallery-link--disabled asset-detail__action"
+                            aria-label={ariaLabel}
                           >
                             {label}
                           </span>
@@ -1198,55 +1201,57 @@ export const AssetExplorer = ({
                 </div>
               </div>
 
-              <section className="asset-detail__section">
-                <h4>Tags</h4>
-                {activeAsset.tags.length > 0 ? (
-                  <div className="asset-detail__tags">
-                    {activeAsset.tags.map((tag) => (
-                      <span key={tag.id}>{tag.label}</span>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="asset-detail__description asset-detail__description--muted">No tags available.</p>
-                )}
-              </section>
-
-              <section className="asset-detail__section">
-                <div className="asset-detail__section-heading">
-                  <h4>Metadata</h4>
-                  {tagFrequencyGroups.length > 0 ? (
-                    <button type="button" className="asset-detail__tag-button" onClick={openTagDialog}>
-                      Show dataset tags
-                    </button>
-                  ) : null}
-                </div>
-                {metadataEntries.length > 0 ? (
-                  <div className="asset-detail__metadata">
-                    <div className="asset-detail__metadata-scroll">
-                      <table className="asset-detail__metadata-table">
-                        <thead>
-                          <tr>
-                            <th scope="col">Key</th>
-                            <th scope="col">Value</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {metadataEntries.map((row) => (
-                            <tr key={row.key}>
-                              <th scope="row">{row.key}</th>
-                              <td>
-                                <span className="asset-detail__metadata-value">{row.value}</span>
-                              </td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
+              <div className="asset-detail__details">
+                <section className="asset-detail__section asset-detail__section--tags">
+                  <h4>Tags</h4>
+                  {activeAsset.tags.length > 0 ? (
+                    <div className="asset-detail__tags">
+                      {activeAsset.tags.map((tag) => (
+                        <span key={tag.id}>{tag.label}</span>
+                      ))}
                     </div>
+                  ) : (
+                    <p className="asset-detail__description asset-detail__description--muted">No tags available.</p>
+                  )}
+                </section>
+
+                <section className="asset-detail__section asset-detail__section--metadata">
+                  <div className="asset-detail__section-heading">
+                    <h4>Metadata</h4>
+                    {tagFrequencyGroups.length > 0 ? (
+                      <button type="button" className="asset-detail__tag-button" onClick={openTagDialog}>
+                        Show dataset tags
+                      </button>
+                    ) : null}
                   </div>
-                ) : (
-                  <p className="asset-detail__description asset-detail__description--muted">No metadata available.</p>
-                )}
-              </section>
+                  {metadataEntries.length > 0 ? (
+                    <div className="asset-detail__metadata">
+                      <div className="asset-detail__metadata-scroll">
+                        <table className="asset-detail__metadata-table">
+                          <thead>
+                            <tr>
+                              <th scope="col">Key</th>
+                              <th scope="col">Value</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {metadataEntries.map((row) => (
+                              <tr key={row.key}>
+                                <th scope="row">{row.key}</th>
+                                <td>
+                                  <span className="asset-detail__metadata-value">{row.value}</span>
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="asset-detail__description asset-detail__description--muted">No metadata available.</p>
+                  )}
+                </section>
+              </div>
 
             </div>
             {isTagDialogOpen && tagFrequencyGroups.length > 0 ? (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2331,7 +2331,7 @@ main {
   flex-direction: column;
   gap: 0.75rem;
   margin-top: 1rem;
-  align-items: stretch;
+  align-items: flex-start;
 }
 
 .asset-detail__download:hover,
@@ -2357,10 +2357,12 @@ main {
 
 .asset-detail__action {
   display: flex;
-  width: 100%;
+  width: auto;
   align-items: center;
   justify-content: center;
   text-align: center;
+  align-self: flex-start;
+  min-width: 0;
 }
 
 .asset-detail__action.asset-detail__download,
@@ -2375,9 +2377,9 @@ main {
   gap: 0.5rem;
   padding: 0.6rem 1rem;
   border-radius: 999px;
-  border: 1px solid rgba(34, 197, 94, 0.35);
-  background: rgba(22, 101, 52, 0.32);
-  color: rgba(187, 247, 208, 0.95);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.2);
+  color: rgba(191, 219, 254, 0.95);
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.08em;
@@ -2388,16 +2390,16 @@ main {
 
 .asset-detail__preview-actions button.asset-detail__gallery-link {
   appearance: none;
-  border: 1px solid rgba(34, 197, 94, 0.35);
+  border: 1px solid rgba(59, 130, 246, 0.35);
   cursor: pointer;
   font-family: inherit;
 }
 
 .asset-detail__gallery-link:hover,
 .asset-detail__gallery-link:focus-visible {
-  background: rgba(34, 197, 94, 0.45);
-  border-color: rgba(34, 197, 94, 0.55);
-  color: #0f172a;
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #ffffff;
   outline: none;
 }
 
@@ -2413,6 +2415,37 @@ main {
   background: rgba(15, 23, 42, 0.55);
   border-color: rgba(148, 163, 184, 0.35);
   color: rgba(148, 163, 184, 0.7);
+}
+
+.asset-detail__details {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .asset-detail__details {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+    align-items: start;
+  }
+}
+
+
+.asset-detail__section--tags {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.asset-detail__section--metadata {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-width: 0;
+}
+
+.asset-detail__section--metadata .asset-detail__section-heading {
+  margin-bottom: 0;
 }
 
 .asset-detail__section h4 {


### PR DESCRIPTION
## Summary
- align the model card preview actions so downloads and open-collection buttons share sizing and styling
- reorganize the tag and metadata sections into a dedicated grid with clearer spacing and simplified "Open Collection" copy
- record the adjustments in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6517bed483339d07c00a2d34aaf3