### PR TITLE
Restructure model card layout

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -257,3 +257,8 @@
 - **General**: Tightened the model card actions by matching button styling and clarifying the surrounding tag and metadata layout.
 - **Technical Changes**: Reduced preview action width stretching, unified the open-collection button palette with downloads, simplified its label, introduced a detail grid for tags versus metadata, and refreshed spacing utilities for both sections.
 - **Data Changes**: None.
+
+## 2025-09-20 – Model card layout restructure
+- **General**: Rebuilt the model card layout into a two-column canvas with more breathing room and stabilized table alignment.
+- **Technical Changes**: Introduced a responsive layout grid for summary and metadata panes, widened the dialog container, enforced fixed table layouts, and added flexible metadata scroll containers.
+- **Data Changes**: None.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -702,6 +702,9 @@ export const AssetExplorer = ({
     return activeAsset.versions.find((version) => version.id === targetId) ?? activeAsset.versions[0] ?? null;
   }, [activeAsset, activeVersionId]);
 
+  const tagsHeadingId = `asset-detail-tags-${activeAssetId ?? 'unknown'}`;
+  const metadataHeadingId = `asset-detail-metadata-${activeAssetId ?? 'unknown'}`;
+
   const handleNavigateFromDetail = useCallback(
     (galleryId: string) => {
       closeDetail();
@@ -1072,185 +1075,191 @@ export const AssetExplorer = ({
                 </button>
               </header>
 
-              <div className="asset-detail__summary">
-                <div className="asset-detail__info">
-                  <table className="asset-detail__info-table">
-                    <tbody>
-                      <tr>
-                        <th scope="row">Name</th>
-                        <td>{activeAsset.title}</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">Version</th>
-                        <td>{activeVersion?.version ?? '–'}</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">Trigger / Activator</th>
-                        <td>
-                          {activeAsset.trigger ? (
-                            <div className="asset-detail__copy-field">
-                              <span className="asset-detail__copy-value">{activeAsset.trigger}</span>
-                              <button
-                                type="button"
-                                className={`asset-detail__copy-button${
-                                  triggerCopyStatus === 'copied' ? ' asset-detail__copy-button--success' : ''
-                                }${triggerCopyStatus === 'error' ? ' asset-detail__copy-button--error' : ''}`}
-                                onClick={() => handleCopyTrigger(activeAsset.trigger ?? '')}
-                              >
-                                {triggerCopyStatus === 'copied'
-                                  ? 'Copied!'
-                                  : triggerCopyStatus === 'error'
-                                    ? 'Copy failed'
-                                    : 'Click to copy'}
-                              </button>
-                            </div>
-                          ) : (
-                            <span className="asset-detail__copy-placeholder">Not provided</span>
-                          )}
-                        </td>
-                      </tr>
-                      <tr>
-                        <th scope="row">Curator</th>
-                        <td>{activeAsset.owner.displayName}</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">Uploaded on</th>
-                        <td>{activeVersion ? formatDate(activeVersion.createdAt) : '–'}</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">File size</th>
-                        <td>{formatFileSize(activeVersion?.fileSize)}</td>
-                      </tr>
-                      <tr>
-                        <th scope="row">Checksum</th>
-                        <td>{activeVersion?.checksum ?? '–'}</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-                <div className="asset-detail__preview-card">
-                  {activeVersion?.previewImage ? (
-                    <div className="asset-detail__preview">
-                      <img
-                        src={
-                          resolveStorageUrl(
-                            activeVersion.previewImage,
-                            activeVersion.previewImageBucket,
-                            activeVersion.previewImageObject,
-                          ) ?? activeVersion.previewImage
-                        }
-                        alt={`Preview von ${activeAsset.title} – Version ${activeVersion?.version ?? ''}`}
-                      />
-                    </div>
-                  ) : (
-                    <div className="asset-detail__preview asset-detail__preview--empty">
-                      <span>No preview available.</span>
-                    </div>
-                  )}
-                  <div className="asset-detail__preview-actions">
-                    {modelDownloadUrl ? (
-                      <a
-                        className="asset-detail__download asset-detail__action"
-                        href={modelDownloadUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        download
-                      >
-                        Download model
-                      </a>
-                    ) : (
-                      <span className="asset-detail__download asset-detail__download--disabled asset-detail__action">
-                        Download not available
-                      </span>
-                    )}
-                    {relatedGalleries.length > 0 ? (
-                      relatedGalleries.map((gallery) => {
-                        const label = 'Open Collection';
-                        const ariaLabel = `Open collection: ${gallery.title}`;
 
-                        if (onNavigateToGallery) {
-                          return (
-                            <button
-                              key={gallery.id}
-                              type="button"
-                              onClick={() => handleNavigateFromDetail(gallery.id)}
-                              className="asset-detail__gallery-link asset-detail__action"
-                              aria-label={ariaLabel}
-                            >
-                              {label}
-                            </button>
-                          );
-                        }
+              <div className="asset-detail__layout">
+                <div className="asset-detail__main">
+                  <div className="asset-detail__summary">
+                    <div className="asset-detail__info">
+                      <table className="asset-detail__info-table">
+                        <tbody>
+                          <tr>
+                            <th scope="row">Name</th>
+                            <td>{activeAsset.title}</td>
+                          </tr>
+                          <tr>
+                            <th scope="row">Version</th>
+                            <td>{activeVersion?.version ?? '–'}</td>
+                          </tr>
+                          <tr>
+                            <th scope="row">Trigger / Activator</th>
+                            <td>
+                              {activeAsset.trigger ? (
+                                <div className="asset-detail__copy-field">
+                                  <span className="asset-detail__copy-value">{activeAsset.trigger}</span>
+                                  <button
+                                    type="button"
+                                    className={`asset-detail__copy-button${
+                                      triggerCopyStatus === 'copied' ? ' asset-detail__copy-button--success' : ''
+                                    }${triggerCopyStatus === 'error' ? ' asset-detail__copy-button--error' : ''}`}
+                                    onClick={() => handleCopyTrigger(activeAsset.trigger ?? '')}
+                                  >
+                                    {triggerCopyStatus === 'copied'
+                                      ? 'Copied!'
+                                      : triggerCopyStatus === 'error'
+                                        ? 'Copy failed'
+                                        : 'Click to copy'}
+                                  </button>
+                                </div>
+                              ) : (
+                                <span className="asset-detail__copy-placeholder">Not provided</span>
+                              )}
+                            </td>
+                          </tr>
+                          <tr>
+                            <th scope="row">Curator</th>
+                            <td>{activeAsset.owner.displayName}</td>
+                          </tr>
+                          <tr>
+                            <th scope="row">Uploaded on</th>
+                            <td>{activeVersion ? formatDate(activeVersion.createdAt) : '–'}</td>
+                          </tr>
+                          <tr>
+                            <th scope="row">File size</th>
+                            <td>{formatFileSize(activeVersion?.fileSize)}</td>
+                          </tr>
+                          <tr>
+                            <th scope="row">Checksum</th>
+                            <td>{activeVersion?.checksum ?? '–'}</td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
 
-                        return (
-                          <span
-                            key={gallery.id}
-                            className="asset-detail__gallery-link asset-detail__gallery-link--disabled asset-detail__action"
-                            aria-label={ariaLabel}
+                    <div className="asset-detail__preview-card">
+                      {activeVersion?.previewImage ? (
+                        <div className="asset-detail__preview">
+                          <img
+                            src={
+                              resolveStorageUrl(
+                                activeVersion.previewImage,
+                                activeVersion.previewImageBucket,
+                                activeVersion.previewImageObject,
+                              ) ?? activeVersion.previewImage
+                            }
+                            alt={`Preview von ${activeAsset.title} – Version ${activeVersion?.version ?? ''}`}
+                          />
+                        </div>
+                      ) : (
+                        <div className="asset-detail__preview asset-detail__preview--empty">
+                          <span>No preview available.</span>
+                        </div>
+                      )}
+                      <div className="asset-detail__preview-actions">
+                        {modelDownloadUrl ? (
+                          <a
+                            className="asset-detail__download asset-detail__action"
+                            href={modelDownloadUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            download
                           >
-                            {label}
+                            Download model
+                          </a>
+                        ) : (
+                          <span className="asset-detail__download asset-detail__download--disabled asset-detail__action">
+                            Download not available
                           </span>
-                        );
-                      })
-                    ) : (
-                      <span className="asset-detail__gallery-link asset-detail__gallery-link--disabled asset-detail__action">
-                        No linked image collections
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
+                        )}
+                        {relatedGalleries.length > 0 ? (
+                          relatedGalleries.map((gallery) => {
+                            const label = 'Open Collection';
+                            const ariaLabel = `Open collection: ${gallery.title}`;
 
-              <div className="asset-detail__details">
-                <section className="asset-detail__section asset-detail__section--tags">
-                  <h4>Tags</h4>
-                  {activeAsset.tags.length > 0 ? (
-                    <div className="asset-detail__tags">
-                      {activeAsset.tags.map((tag) => (
-                        <span key={tag.id}>{tag.label}</span>
-                      ))}
-                    </div>
-                  ) : (
-                    <p className="asset-detail__description asset-detail__description--muted">No tags available.</p>
-                  )}
-                </section>
+                            if (onNavigateToGallery) {
+                              return (
+                                <button
+                                  key={gallery.id}
+                                  type="button"
+                                  onClick={() => handleNavigateFromDetail(gallery.id)}
+                                  className="asset-detail__gallery-link asset-detail__action"
+                                  aria-label={ariaLabel}
+                                >
+                                  {label}
+                                </button>
+                              );
+                            }
 
-                <section className="asset-detail__section asset-detail__section--metadata">
-                  <div className="asset-detail__section-heading">
-                    <h4>Metadata</h4>
-                    {tagFrequencyGroups.length > 0 ? (
-                      <button type="button" className="asset-detail__tag-button" onClick={openTagDialog}>
-                        Show dataset tags
-                      </button>
-                    ) : null}
-                  </div>
-                  {metadataEntries.length > 0 ? (
-                    <div className="asset-detail__metadata">
-                      <div className="asset-detail__metadata-scroll">
-                        <table className="asset-detail__metadata-table">
-                          <thead>
-                            <tr>
-                              <th scope="col">Key</th>
-                              <th scope="col">Value</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {metadataEntries.map((row) => (
-                              <tr key={row.key}>
-                                <th scope="row">{row.key}</th>
-                                <td>
-                                  <span className="asset-detail__metadata-value">{row.value}</span>
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
+                            return (
+                              <span
+                                key={gallery.id}
+                                className="asset-detail__gallery-link asset-detail__gallery-link--disabled asset-detail__action"
+                                aria-label={ariaLabel}
+                              >
+                                {label}
+                              </span>
+                            );
+                          })
+                        ) : (
+                          <span className="asset-detail__gallery-link asset-detail__gallery-link--disabled asset-detail__action">
+                            No linked image collections
+                          </span>
+                        )}
                       </div>
                     </div>
-                  ) : (
-                    <p className="asset-detail__description asset-detail__description--muted">No metadata available.</p>
-                  )}
-                </section>
+                  </div>
+
+                  <section className="asset-detail__section asset-detail__section--tags" aria-labelledby={tagsHeadingId}>
+                    <h4 id={tagsHeadingId}>Tags</h4>
+                    {activeAsset.tags.length > 0 ? (
+                      <div className="asset-detail__tags">
+                        {activeAsset.tags.map((tag) => (
+                          <span key={tag.id}>{tag.label}</span>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="asset-detail__description asset-detail__description--muted">No tags available.</p>
+                    )}
+                  </section>
+                </div>
+
+                <aside className="asset-detail__sidebar" aria-labelledby={metadataHeadingId}>
+                  <section className="asset-detail__section asset-detail__section--metadata">
+                    <div className="asset-detail__section-heading">
+                      <h4 id={metadataHeadingId}>Metadata</h4>
+                      {tagFrequencyGroups.length > 0 ? (
+                        <button type="button" className="asset-detail__tag-button" onClick={openTagDialog}>
+                          Show dataset tags
+                        </button>
+                      ) : null}
+                    </div>
+                    {metadataEntries.length > 0 ? (
+                      <div className="asset-detail__metadata">
+                        <div className="asset-detail__metadata-scroll">
+                          <table className="asset-detail__metadata-table">
+                            <thead>
+                              <tr>
+                                <th scope="col">Key</th>
+                                <th scope="col">Value</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {metadataEntries.map((row) => (
+                                <tr key={row.key}>
+                                  <th scope="row">{row.key}</th>
+                                  <td>
+                                    <span className="asset-detail__metadata-value">{row.value}</span>
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="asset-detail__description asset-detail__description--muted">No metadata available.</p>
+                    )}
+                  </section>
+                </aside>
               </div>
 
             </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1682,7 +1682,7 @@ main {
 
 .asset-detail-dialog__container {
   position: relative;
-  width: min(960px, 94vw);
+  width: min(1180px, 96vw);
   max-height: 88vh;
   display: flex;
   justify-content: center;
@@ -2168,15 +2168,50 @@ main {
   color: rgba(148, 163, 184, 0.75);
 }
 
-.asset-detail__summary {
-  display: grid;
-  gap: 1.5rem;
+.asset-detail__layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
 }
 
 @media (min-width: 960px) {
+  .asset-detail__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1.75fr) minmax(0, 1.25fr);
+    gap: 1.85rem;
+    align-items: start;
+  }
+}
+
+.asset-detail__main,
+.asset-detail__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-width: 0;
+}
+
+.asset-detail__summary {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+@media (min-width: 720px) {
   .asset-detail__summary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: stretch;
+  }
+}
+
+@media (min-width: 1120px) {
+  .asset-detail__summary {
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  }
+}
+
+@media (min-width: 1320px) {
+  .asset-detail__summary {
+    grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr);
   }
 }
 
@@ -2187,6 +2222,7 @@ main {
   border: 1px solid rgba(148, 163, 184, 0.28);
   background: rgba(15, 23, 42, 0.55);
   box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+  min-width: 0;
 }
 
 @media (min-width: 960px) {
@@ -2205,6 +2241,7 @@ main {
 .asset-detail__info-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 .asset-detail__info-table th,
@@ -2417,19 +2454,6 @@ main {
   color: rgba(148, 163, 184, 0.7);
 }
 
-.asset-detail__details {
-  display: grid;
-  gap: 1.5rem;
-}
-
-@media (min-width: 960px) {
-  .asset-detail__details {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
-    align-items: start;
-  }
-}
-
-
 .asset-detail__section--tags {
   display: flex;
   flex-direction: column;
@@ -2442,6 +2466,7 @@ main {
   flex-direction: column;
   gap: 0.9rem;
   min-width: 0;
+  flex: 1;
 }
 
 .asset-detail__section--metadata .asset-detail__section-heading {
@@ -2536,18 +2561,22 @@ main {
   border-radius: 18px;
   border: 1px solid rgba(59, 130, 246, 0.18);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .asset-detail__metadata-scroll {
   max-height: 26rem;
   overflow: auto;
-  padding: 1rem 1.2rem;
+  padding: 1.1rem 1.35rem;
+  flex: 1;
 }
 
 .asset-detail__metadata-table {
   width: 100%;
   border-collapse: collapse;
   min-width: 100%;
+  table-layout: fixed;
 }
 
 .asset-detail__metadata-table thead th {


### PR DESCRIPTION
## Summary
- restructure the model card detail view into a two-column layout with accessible heading anchors for tags and metadata
- widen the detail dialog and refresh supporting styles so summary and metadata tables stay aligned and readable
- log the layout refresh in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6a76cb388333b6e96f3b9cb3c9c6