### PR TITLE
Widen model card dialog width

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -262,3 +262,8 @@
 - **General**: Rebuilt the model card layout into a two-column canvas with more breathing room and stabilized table alignment.
 - **Technical Changes**: Introduced a responsive layout grid for summary and metadata panes, widened the dialog container, enforced fixed table layouts, and added flexible metadata scroll containers.
 - **Data Changes**: None.
+
+## 2025-09-20 – Model card width expansion
+- **General**: Enlarged the model detail dialog so metadata columns remain readable on wide screens.
+- **Technical Changes**: Adjusted the dialog container to span 80% of the viewport (capped at 1400px) and loosened the tablet breakpoint width to retain proportional spacing.
+- **Data Changes**: None.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1682,7 +1682,7 @@ main {
 
 .asset-detail-dialog__container {
   position: relative;
-  width: min(1180px, 96vw);
+  width: min(1400px, 80vw);
   max-height: 88vh;
   display: flex;
   justify-content: center;
@@ -4880,7 +4880,7 @@ button {
 
   .gallery-detail-dialog__container,
   .asset-detail-dialog__container {
-    width: min(720px, 96vw);
+    width: min(720px, 90vw);
   }
 }
 


### PR DESCRIPTION
## Summary
- expand the model detail dialog to span 80% of the viewport (capped at 1400px) so metadata is readable
- tweak the tablet breakpoint width to keep proportions consistent on smaller screens
- log the UI adjustment in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6ce9c9648333a493598b88a5bca2