### PR TITLE
Fix model card metadata layout

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -267,3 +267,8 @@
 - **General**: Enlarged the model detail dialog so metadata columns remain readable on wide screens.
 - **Technical Changes**: Adjusted the dialog container to span 80% of the viewport (capped at 1400px) and loosened the tablet breakpoint width to retain proportional spacing.
 - **Data Changes**: None.
+
+## 2025-09-20 – Model card metadata centering
+- **General**: Realigned the model card so the metadata panel sits beneath the preview and regains breathing room.
+- **Technical Changes**: Repositioned the metadata section inside the summary grid, removed the squeezing flex growth, and added styling to center the metadata card below the preview.
+- **Data Changes**: None.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -1206,6 +1206,46 @@ export const AssetExplorer = ({
                         )}
                       </div>
                     </div>
+
+                    <section
+                      className="asset-detail__section asset-detail__section--metadata asset-detail__metadata-card"
+                      aria-labelledby={metadataHeadingId}
+                    >
+                      <div className="asset-detail__section-heading">
+                        <h4 id={metadataHeadingId}>Metadata</h4>
+                        {tagFrequencyGroups.length > 0 ? (
+                          <button type="button" className="asset-detail__tag-button" onClick={openTagDialog}>
+                            Show dataset tags
+                          </button>
+                        ) : null}
+                      </div>
+                      {metadataEntries.length > 0 ? (
+                        <div className="asset-detail__metadata">
+                          <div className="asset-detail__metadata-scroll">
+                            <table className="asset-detail__metadata-table">
+                              <thead>
+                                <tr>
+                                  <th scope="col">Key</th>
+                                  <th scope="col">Value</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {metadataEntries.map((row) => (
+                                  <tr key={row.key}>
+                                    <th scope="row">{row.key}</th>
+                                    <td>
+                                      <span className="asset-detail__metadata-value">{row.value}</span>
+                                    </td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="asset-detail__description asset-detail__description--muted">No metadata available.</p>
+                      )}
+                    </section>
                   </div>
 
                   <section className="asset-detail__section asset-detail__section--tags" aria-labelledby={tagsHeadingId}>
@@ -1222,44 +1262,6 @@ export const AssetExplorer = ({
                   </section>
                 </div>
 
-                <aside className="asset-detail__sidebar" aria-labelledby={metadataHeadingId}>
-                  <section className="asset-detail__section asset-detail__section--metadata">
-                    <div className="asset-detail__section-heading">
-                      <h4 id={metadataHeadingId}>Metadata</h4>
-                      {tagFrequencyGroups.length > 0 ? (
-                        <button type="button" className="asset-detail__tag-button" onClick={openTagDialog}>
-                          Show dataset tags
-                        </button>
-                      ) : null}
-                    </div>
-                    {metadataEntries.length > 0 ? (
-                      <div className="asset-detail__metadata">
-                        <div className="asset-detail__metadata-scroll">
-                          <table className="asset-detail__metadata-table">
-                            <thead>
-                              <tr>
-                                <th scope="col">Key</th>
-                                <th scope="col">Value</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {metadataEntries.map((row) => (
-                                <tr key={row.key}>
-                                  <th scope="row">{row.key}</th>
-                                  <td>
-                                    <span className="asset-detail__metadata-value">{row.value}</span>
-                                  </td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </table>
-                        </div>
-                      </div>
-                    ) : (
-                      <p className="asset-detail__description asset-detail__description--muted">No metadata available.</p>
-                    )}
-                  </section>
-                </aside>
               </div>
 
             </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2173,18 +2173,7 @@ main {
   flex-direction: column;
   gap: 1.6rem;
 }
-
-@media (min-width: 960px) {
-  .asset-detail__layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1.75fr) minmax(0, 1.25fr);
-    gap: 1.85rem;
-    align-items: start;
-  }
-}
-
-.asset-detail__main,
-.asset-detail__sidebar {
+.asset-detail__main {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -2236,6 +2225,13 @@ main {
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
+}
+
+.asset-detail__metadata-card {
+  grid-column: 1 / -1;
+  width: min(100%, 640px);
+  margin: 0 auto;
+  justify-self: center;
 }
 
 .asset-detail__info-table {
@@ -2466,7 +2462,6 @@ main {
   flex-direction: column;
   gap: 0.9rem;
   min-width: 0;
-  flex: 1;
 }
 
 .asset-detail__section--metadata .asset-detail__section-heading {


### PR DESCRIPTION
## Summary
- move the model detail metadata panel beneath the preview image and keep the summary grid readable
- adjust the metadata styling so the card centers below the preview without flex compression
- record the interface update in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce6e723b5c8333b4f4785bcb402deb