### PR TITLE
Add model version editing controls and metadata layout polish

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -198,6 +198,7 @@
 - **Technical Changes**: Adopted a named `:objectPath(*)` parameter, retained legacy fallback, and updated README endpoint documentation.
 - **Data Changes**: None.
 
+
 ## 2025-09-19 – Model card layout polish (commit TBD)
 - **General**: Smoothed the model card experience by aligning primary actions and tightening the dataset tags table.
 - **Technical Changes**: Converted the preview action stack to a full-width flex column, equalized button typography, and padded the tag frequency table with a fixed layout so headers and rows stay inside the dialog.
@@ -272,3 +273,8 @@
 - **General**: Realigned the model card so the metadata panel sits beneath the preview and regains breathing room.
 - **Technical Changes**: Repositioned the metadata section inside the summary grid, removed the squeezing flex growth, and added styling to center the metadata card below the preview.
 - **Data Changes**: None.
+
+## 2025-09-20 – Model version management enhancements (commit TBD)
+- **General**: Empowered curators and admins to rename model versions from the modelcard while giving the metadata section more breathing room.
+- **Technical Changes**: Added `PUT /api/assets/models/:modelId/versions/:versionId`, expanded the frontend API client, introduced an edit dialog with permission checks, refined version chip labelling with edit controls, and stretched the metadata card styling.
+- **Data Changes**: None; operates on existing model/version records without schema updates.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - **Role-aware access control** – JWT-based authentication with session persistence, an admin workspace for user/model/gallery management, and protected upload flows.
 - **Guided three-step upload wizard** – Collects metadata, files, and review feedback with validation, drag & drop, and live responses from the production-ready `POST /api/uploads` endpoint.
 - **Data-driven explorers** – Fast filters and full-text search across LoRA assets and galleries, complete with tag badges, five-column tiles, and seamless infinite scrolling with active filter indicators.
-- **Versioned modelcards** – Dedicated model dialogs with inline descriptions, quick switches between safetensor versions, and an integrated flow for uploading new revisions including preview handling.
+- **Versioned modelcards** – Dedicated model dialogs with inline descriptions, quick switches between safetensor versions, in-place editing for curators/admins, and an integrated flow for uploading new revisions including preview handling.
 - **Governed storage pipeline** – Direct MinIO ingestion with automatic tagging, secure download proxying via the backend, audit trails, and guardrails for file size (≤ 2 GB) and batch limits (≤ 12 files).
 
 ## Good to Know
@@ -17,7 +17,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - Gallery uploads support multi-select (up to 12 files/2 GB), role-aware gallery selection, and on-the-fly gallery creation.
 - Model uploads enforce exactly one safetensor/ZIP archive plus a cover image; additional renders can be attached afterwards from the gallery explorer.
 - Gallery explorer offers a five-column grid with random cover art, consistent tile sizing, and a detail dialog per collection with an EXIF lightbox for every image.
-- Interface remains resilient even when the backend delivers entries without populated metadata.
+- Interface remains resilient even when the backend delivers entries without populated metadata, and the metadata card now stretches across the dialog for easier scanning.
 - Automatic extraction of EXIF, Stable Diffusion prompt data, and safetensor headers populates searchable base-model references and frequency tables for tags.
 - Modelcards include a dedicated Trigger/Activator field that is required during uploads or edits and ships with a click-to-copy shortcut for quick prompting.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -433,6 +433,7 @@ export const App = () => {
           onExternalSearchApplied={() => setModelTagQuery(null)}
           onAssetUpdated={handleAssetUpdated}
           authToken={token}
+          currentUser={authUser}
         />
       );
     }

--- a/frontend/src/components/ModelVersionEditDialog.tsx
+++ b/frontend/src/components/ModelVersionEditDialog.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { FormEvent, MouseEvent } from 'react';
+
+import { api, ApiError } from '../lib/api';
+import type { ModelAsset, ModelVersion } from '../types/api';
+
+interface ModelVersionEditDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  model: ModelAsset;
+  version: ModelVersion | null;
+  token: string | null | undefined;
+  onSuccess?: (updated: ModelAsset, refreshedVersion: ModelVersion | null) => void;
+}
+
+export const ModelVersionEditDialog = ({
+  isOpen,
+  onClose,
+  model,
+  version,
+  token,
+  onSuccess,
+}: ModelVersionEditDialogProps) => {
+  const [versionLabel, setVersionLabel] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [details, setDetails] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const normalizedOriginal = useMemo(() => version?.version.trim() ?? '', [version?.version]);
+
+  useEffect(() => {
+    if (!isOpen || !version) {
+      setVersionLabel('');
+      setError(null);
+      setDetails([]);
+      setIsSubmitting(false);
+      return;
+    }
+
+    setVersionLabel(version.version);
+    setError(null);
+    setDetails([]);
+    setIsSubmitting(false);
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (!isSubmitting) {
+          onClose();
+        }
+      }
+    };
+
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = '';
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, isSubmitting, onClose, version]);
+
+  const handleBackdropClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget && !isSubmitting) {
+        onClose();
+      }
+    },
+    [isSubmitting, onClose],
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!version) {
+      return;
+    }
+
+    if (isSubmitting) {
+      return;
+    }
+
+    const trimmed = versionLabel.trim();
+
+    if (!token) {
+      setError('Please sign in to edit this version.');
+      setDetails([]);
+      return;
+    }
+
+    if (!trimmed) {
+      setError('Please provide a version label.');
+      setDetails([]);
+      return;
+    }
+
+    if (trimmed === normalizedOriginal) {
+      setError('Please change the version label before saving.');
+      setDetails([]);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setDetails([]);
+
+    try {
+      const updatedAsset = await api.updateModelVersion(token, model.id, version.id, { version: trimmed });
+      const refreshedVersion =
+        updatedAsset.versions.find((entry) => entry.id === version.id) ??
+        (version.isPrimary ? updatedAsset.versions.find((entry) => entry.isPrimary) ?? null : null);
+      onSuccess?.(updatedAsset, refreshedVersion ?? null);
+      onClose();
+    } catch (updateError) {
+      if (updateError instanceof ApiError) {
+        setError(updateError.message);
+        setDetails(updateError.details ?? []);
+      } else if (updateError instanceof Error) {
+        setError(updateError.message);
+        setDetails([]);
+      } else {
+        setError('Unknown error while updating the model version.');
+        setDetails([]);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen || !version) {
+    return null;
+  }
+
+  const headingSuffix = version.isPrimary ? 'Primary version' : `Version ${normalizedOriginal || version.version}`;
+
+  return (
+    <div
+      className="model-version-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="model-version-edit-title"
+      onClick={handleBackdropClick}
+    >
+      <div className="model-version-dialog__content">
+        <header className="model-version-dialog__header">
+          <h3 id="model-version-edit-title">Edit {headingSuffix} for {model.title}</h3>
+          <button
+            type="button"
+            className="model-version-dialog__close"
+            onClick={onClose}
+            disabled={isSubmitting}
+          >
+            Close
+          </button>
+        </header>
+        <form className="model-version-dialog__form" onSubmit={handleSubmit}>
+          <label className="model-version-dialog__field">
+            <span>Version label</span>
+            <input
+              type="text"
+              value={versionLabel}
+              onChange={(event) => setVersionLabel(event.target.value)}
+              placeholder="e.g. 1.3.0"
+              disabled={isSubmitting}
+              required
+            />
+          </label>
+
+          {error ? (
+            <div className="model-version-dialog__error" role="alert">
+              <p>{error}</p>
+              {details.length > 0 ? (
+                <ul>
+                  {details.map((entry) => (
+                    <li key={entry}>{entry}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ) : null}
+
+          <footer className="model-version-dialog__actions">
+            <button type="button" onClick={onClose} className="model-version-dialog__secondary" disabled={isSubmitting}>
+              Cancel
+            </button>
+            <button type="submit" className="model-version-dialog__primary" disabled={isSubmitting || !token}>
+              {isSubmitting ? 'Saving…' : 'Save changes'}
+            </button>
+          </footer>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2083,6 +2083,12 @@ main {
   align-items: center;
 }
 
+.asset-detail__version-chip-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 .asset-detail__version-chip {
   border-radius: 999px;
   border: 1px solid rgba(96, 165, 250, 0.35);
@@ -2090,6 +2096,7 @@ main {
   color: rgba(191, 219, 254, 0.92);
   padding: 0.35rem 0.85rem;
   font-size: 0.75rem;
+  white-space: nowrap;
   cursor: pointer;
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
@@ -2106,6 +2113,32 @@ main {
   background: rgba(59, 130, 246, 0.38);
   border-color: rgba(96, 165, 250, 0.7);
   color: #f8fafc;
+}
+
+.asset-detail__version-edit {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(226, 232, 240, 0.85);
+  padding: 0.3rem 0.65rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.asset-detail__version-edit:hover,
+.asset-detail__version-edit:focus-visible {
+  background: rgba(148, 163, 184, 0.24);
+  border-color: rgba(226, 232, 240, 0.45);
+  color: #f8fafc;
+  outline: none;
+}
+
+.asset-detail__version-edit:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .asset-detail__version-add {
@@ -2229,9 +2262,10 @@ main {
 
 .asset-detail__metadata-card {
   grid-column: 1 / -1;
-  width: min(100%, 640px);
-  margin: 0 auto;
-  justify-self: center;
+  width: 100%;
+  margin: 0;
+  margin-top: 0.75rem;
+  justify-self: stretch;
 }
 
 .asset-detail__info-table {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -193,6 +193,32 @@ const postModelVersion = async (
   }
 };
 
+const putModelVersion = async (
+  token: string,
+  modelId: string,
+  versionId: string,
+  payload: { version: string },
+) => {
+  try {
+    return await request<ModelAsset>(
+      `/api/assets/models/${modelId}/versions/${versionId}`,
+      {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      },
+      token,
+    );
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    throw new ApiError(
+      error instanceof Error ? error.message : 'Unbekannter Fehler beim Bearbeiten der Modellversion.',
+    );
+  }
+};
+
 export const api = {
   getStats: () => request<MetaStats>('/api/meta/stats'),
   getModelAssets: () => request<ModelAsset[]>('/api/assets/models'),
@@ -201,6 +227,7 @@ export const api = {
   getServiceStatus: () => request<ServiceStatusResponse>('/api/meta/status'),
   createUploadDraft: postUploadDraft,
   createModelVersion: postModelVersion,
+  updateModelVersion: putModelVersion,
   login: (email: string, password: string) =>
     request<AuthResponse>('/api/auth/login', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- add backend validation and a PUT endpoint so admins/curators can rename model versions
- surface a version edit dialog with permission-aware UI, revised chip labels, and metadata card adjustments
- refresh README highlights and record the changelog entry

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68ce8376eda48333bb8fb3497be2f3fb