### PR TITLE
Fix AssetExplorer initialization order

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -278,3 +278,8 @@
 - **General**: Empowered curators and admins to rename model versions from the modelcard while giving the metadata section more breathing room.
 - **Technical Changes**: Added `PUT /api/assets/models/:modelId/versions/:versionId`, expanded the frontend API client, introduced an edit dialog with permission checks, refined version chip labelling with edit controls, and stretched the metadata card styling.
 - **Data Changes**: None; operates on existing model/version records without schema updates.
+
+## 2025-09-20 – Asset explorer crash fix (commit TBD)
+- **General**: Restored the model gallery so the Asset Explorer shows tiles instead of failing with a blank screen.
+- **Technical Changes**: Reordered the `activeAsset` memo and its permission guard ahead of dependent effects to remove the temporal dead zone runtime error that crashed the component on load.
+- **Data Changes**: None.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -483,6 +483,22 @@ export const AssetExplorer = ({
   const deferredSearch = useDeferredValue(searchTerm);
   const normalizedQuery = normalize(deferredSearch.trim());
 
+  const activeAsset = useMemo(
+    () => (activeAssetId ? assets.find((asset) => asset.id === activeAssetId) ?? null : null),
+    [activeAssetId, assets],
+  );
+
+  const canManageActiveAsset = useMemo(
+    () =>
+      Boolean(
+        authToken &&
+          activeAsset &&
+          currentUser &&
+          (currentUser.role === 'ADMIN' || currentUser.id === activeAsset.owner.id),
+      ),
+    [activeAsset, authToken, currentUser],
+  );
+
   useEffect(() => {
     if (!externalSearchQuery) {
       return;
@@ -692,21 +708,6 @@ export const AssetExplorer = ({
     return () => observer.disconnect();
   }, [canLoadMore, filteredAssets.length]);
 
-  const activeAsset = useMemo(
-    () => (activeAssetId ? assets.find((asset) => asset.id === activeAssetId) ?? null : null),
-    [activeAssetId, assets],
-  );
-
-  const canManageActiveAsset = useMemo(
-    () =>
-      Boolean(
-        authToken &&
-          activeAsset &&
-          currentUser &&
-          (currentUser.role === 'ADMIN' || currentUser.id === activeAsset.owner.id),
-      ),
-    [activeAsset, authToken, currentUser],
-  );
 
   useEffect(() => {
     if (!activeAsset) {


### PR DESCRIPTION
## Summary
- move the `activeAsset` memoization and permission guard ahead of hooks that consume them to avoid temporal dead zone crashes in the Asset Explorer
- document the fix in the changelog

## Testing
- npx eslint src/components/AssetExplorer.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ce8d6a5cac8333bf2bca57e7ad2625