### PR TITLE
Expand gallery detail grid to six columns

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -283,3 +283,8 @@
 - **General**: Restored the model gallery so the Asset Explorer shows tiles instead of failing with a blank screen.
 - **Technical Changes**: Reordered the `activeAsset` memo and its permission guard ahead of dependent effects to remove the temporal dead zone runtime error that crashed the component on load.
 - **Data Changes**: None.
+
+## 2025-09-20 – Gallery detail grid expansion (commit TBD)
+- **General**: Extended the gallery detail view to surface six thumbnails per row on wide screens without distorting the layout.
+- **Technical Changes**: Updated `.gallery-detail__grid` breakpoints and thumbnail sizing in `frontend/src/index.css` to provide a six-column base with responsive fallbacks and square previews.
+- **Data Changes**: None; visual styling only.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4707,7 +4707,7 @@ button {
 .gallery-detail__grid {
   display: grid;
   gap: 1.1rem;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
 }
 
 .gallery-detail__thumb {
@@ -4716,7 +4716,7 @@ button {
   overflow: hidden;
   border: 1px solid rgba(59, 130, 246, 0.35);
   background: rgba(15, 23, 42, 0.7);
-  height: 140px;
+  aspect-ratio: 1 / 1;
   padding: 0;
   cursor: pointer;
 }
@@ -4897,10 +4897,20 @@ button {
   }
 }
 
+@media (max-width: 1200px) {
+  .gallery-detail__grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 860px) {
   .gallery-explorer__grid,
   .asset-explorer__grid {
     grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+
+  .gallery-detail__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .gallery-image-modal__body {


### PR DESCRIPTION
## Summary
- expand the gallery detail grid to six columns on large screens and add responsive fallbacks with square thumbnail cards to keep the layout intact.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce8feee92c8333b4db6e4ed162fd1e