### PR TITLE
Refine administration styling

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -288,3 +288,8 @@
 - **General**: Extended the gallery detail view to surface six thumbnails per row on wide screens without distorting the layout.
 - **Technical Changes**: Updated `.gallery-detail__grid` breakpoints and thumbnail sizing in `frontend/src/index.css` to provide a six-column base with responsive fallbacks and square previews.
 - **Data Changes**: None; visual styling only.
+
+## 2025-09-20 – Administration workspace restyle
+- **General**: Modernized the admin console with a lighter visual rhythm and clearer hierarchy for moderation workflows.
+- **Technical Changes**: Reworked administration CSS with glassmorphism cards, pill navigation, refined forms/tables, enhanced focus states, and refreshed README guidance.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 ## Good to Know
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
+- Administration workspace now uses glassmorphism-inspired cards, pill-based filters, and softer status chips for faster scanning during moderation.
 - Gallery uploads support multi-select (up to 12 files/2 GB), role-aware gallery selection, and on-the-fly gallery creation.
 - Model uploads enforce exactly one safetensor/ZIP archive plus a cover image; additional renders can be attached afterwards from the gallery explorer.
 - Gallery explorer offers a five-column grid with random cover art, consistent tile sizing, and a detail dialog per collection with an EXIF lightbox for every image.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -725,10 +725,11 @@ body {
   color: #f8fafc;
 }
 
+
 .admin {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .admin__header {
@@ -737,81 +738,166 @@ body {
   justify-content: space-between;
   gap: 1rem;
   flex-wrap: wrap;
+  padding: 1.5rem 1.75rem;
+  border-radius: 22px;
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.62));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.35);
+  backdrop-filter: blur(16px);
 }
 
 .admin__tabs {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  align-items: center;
+  padding: 0.4rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(14px);
 }
 
 .admin__tab {
-  padding: 0.55rem 1rem;
-  border-radius: 10px;
-  border: 1px solid rgba(59, 130, 246, 0.25);
-  background: rgba(15, 23, 42, 0.85);
-  color: rgba(226, 232, 240, 0.85);
-  font-weight: 500;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.86);
+  font-weight: 600;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  transition: background 0.18s ease, transform 0.18s ease;
+  transition: color 0.18s ease, background 0.18s ease, box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.admin__tab:hover,
+.admin__tab:focus-visible {
+  border-color: rgba(125, 211, 252, 0.45);
+  background: rgba(59, 130, 246, 0.12);
+  color: #f8fafc;
+  transform: translateY(-1px);
+  outline: none;
 }
 
 .admin__tab--active {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.55), rgba(14, 165, 233, 0.4));
-  border-color: transparent;
-  color: #0f172a;
-  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.3);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.28), rgba(14, 165, 233, 0.3));
+  border-color: rgba(125, 211, 252, 0.55);
+  color: #f8fafc;
+  box-shadow: 0 16px 28px rgba(14, 165, 233, 0.28);
 }
 
 .admin__status {
   margin: 0;
+  padding: 0.55rem 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1.2;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.14);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  color: rgba(226, 232, 240, 0.86);
+  backdrop-filter: blur(12px);
 }
 
 .admin__status--success {
-  color: rgba(134, 239, 172, 0.9);
+  background: rgba(34, 197, 94, 0.16);
+  border-color: rgba(34, 197, 94, 0.35);
+  color: rgba(187, 247, 208, 0.94);
 }
 
 .admin__status--error {
-  color: rgba(248, 113, 113, 0.9);
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(248, 113, 113, 0.35);
+  color: rgba(254, 226, 226, 0.95);
 }
 
 .admin__panel {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .admin__section {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  border-radius: 24px;
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.74), rgba(30, 41, 59, 0.58));
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 26px 48px rgba(2, 6, 23, 0.32);
+  backdrop-filter: blur(18px);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.admin__section:hover {
+  border-color: rgba(125, 211, 252, 0.35);
+  box-shadow: 0 30px 52px rgba(14, 165, 233, 0.18);
+  transform: translateY(-1px);
+}
+
+.admin__section:focus-within {
+  border-color: rgba(125, 211, 252, 0.45);
+  box-shadow: 0 32px 56px rgba(14, 165, 233, 0.22);
+  transform: translateY(-1px);
+}
+
+.admin__section > h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #f8fafc;
 }
 
 .admin__form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.5rem;
-  border-radius: 14px;
-  background: rgba(15, 23, 42, 0.85);
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  gap: 1.25rem;
 }
 
 .admin__form-grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.1rem;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.admin__form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.admin__form label span {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: rgba(191, 219, 254, 0.92);
 }
 
 .admin__empty {
   margin: 0;
-  color: rgba(148, 163, 184, 0.75);
+  padding: 1.25rem 1.5rem;
+  border-radius: 18px;
+  border: 1px dashed rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(148, 163, 184, 0.85);
+  text-align: center;
+  font-size: 0.95rem;
 }
 
 .admin__section-header {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
 }
 
 @media (min-width: 900px) {
@@ -822,29 +908,102 @@ body {
   }
 }
 
+.admin__section-header > h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #f8fafc;
+}
+
 .admin__filters {
   display: grid;
-  gap: 0.85rem;
+  gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   align-items: end;
+  padding: 0.85rem 1rem;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .admin__filters label {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.9rem;
-  color: rgba(203, 213, 225, 0.85);
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.78);
 }
 
+.admin__form input,
+.admin__form textarea,
+.admin__form select,
 .admin__filters input,
-.admin__filters select {
-  padding: 0.55rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid rgba(59, 130, 246, 0.22);
-  background: rgba(15, 23, 42, 0.9);
+.admin__filters select,
+.admin-row__cell--form input,
+.admin-row__cell--form textarea,
+.admin-row__cell--form select,
+.admin-gallery-entry input,
+.admin-gallery-entry textarea,
+.admin-gallery-entry select {
+  padding: 0.65rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.68), rgba(30, 41, 59, 0.64));
   color: #f8fafc;
   font-size: 0.9rem;
+  line-height: 1.45;
+  box-shadow: 0 1px 0 rgba(148, 163, 184, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.admin__form input::placeholder,
+.admin__form textarea::placeholder,
+.admin__filters input::placeholder,
+.admin-row__cell--form input::placeholder,
+.admin-row__cell--form textarea::placeholder,
+.admin-gallery-entry input::placeholder,
+.admin-gallery-entry textarea::placeholder {
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.admin__form input:focus-visible,
+.admin__form textarea:focus-visible,
+.admin__form select:focus-visible,
+.admin__filters input:focus-visible,
+.admin__filters select:focus-visible,
+.admin-row__cell--form input:focus-visible,
+.admin-row__cell--form textarea:focus-visible,
+.admin-row__cell--form select:focus-visible,
+.admin-gallery-entry input:focus-visible,
+.admin-gallery-entry textarea:focus-visible,
+.admin-gallery-entry select:focus-visible {
+  outline: none;
+  border-color: rgba(125, 211, 252, 0.55);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  transform: translateY(-1px);
+}
+
+.admin__form input:disabled,
+.admin__form textarea:disabled,
+.admin__form select:disabled,
+.admin__filters input:disabled,
+.admin__filters select:disabled,
+.admin-row__cell--form input:disabled,
+.admin-row__cell--form textarea:disabled,
+.admin-row__cell--form select:disabled,
+.admin-gallery-entry input:disabled,
+.admin-gallery-entry textarea:disabled,
+.admin-gallery-entry select:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  background: rgba(15, 23, 42, 0.5);
+  box-shadow: none;
 }
 
 .admin__toolbar {
@@ -852,57 +1011,103 @@ body {
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.52);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(14px);
 }
 
 .admin__selection {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: 14px;
-  background: rgba(15, 23, 42, 0.85);
-  border: 1px solid rgba(59, 130, 246, 0.2);
+  gap: 0.65rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.2);
+  backdrop-filter: blur(12px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin__selection:focus-within {
+  border-color: rgba(125, 211, 252, 0.45);
+  box-shadow: 0 14px 26px rgba(14, 165, 233, 0.18);
 }
 
 .admin__checkbox {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 12px;
   font-size: 0.9rem;
-  color: rgba(203, 213, 225, 0.85);
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.82);
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  backdrop-filter: blur(10px);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.admin__checkbox:hover,
+.admin__checkbox:focus-within {
+  border-color: rgba(125, 211, 252, 0.45);
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.admin__checkbox input,
+.admin-row__cell--checkbox input {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: rgba(56, 189, 248, 0.85);
 }
 
 .admin__selection-count {
   font-size: 0.85rem;
-  color: rgba(148, 163, 184, 0.8);
+  color: rgba(148, 163, 184, 0.85);
 }
 
 .admin__table {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1.25rem;
 }
 
 .admin__table-header,
 .admin-row {
   display: grid;
-  gap: 1rem;
+  gap: 1.25rem;
   align-items: flex-start;
-  padding: 1.25rem 1.5rem;
-  border-radius: 16px;
-  background: rgba(15, 23, 42, 0.92);
-  border: 1px solid rgba(59, 130, 246, 0.2);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+  padding: 1.35rem 1.65rem;
+  border-radius: 22px;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.7), rgba(30, 41, 59, 0.56));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.28);
+  backdrop-filter: blur(16px);
   grid-template-columns: minmax(48px, 64px) minmax(220px, 2fr) minmax(320px, 3fr) minmax(160px, auto);
 }
 
+.admin-row {
+  transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease;
+}
+
+.admin-row:hover,
+.admin-row:focus-within {
+  border-color: rgba(125, 211, 252, 0.45);
+  box-shadow: 0 28px 52px rgba(14, 165, 233, 0.2);
+  transform: translateY(-2px);
+}
+
 .admin__table-header {
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.8);
-  background: rgba(30, 41, 59, 0.85);
-  box-shadow: none;
+  color: rgba(148, 163, 184, 0.85);
+  background: rgba(15, 23, 42, 0.52);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .admin__table-header .admin__table-cell--actions {
@@ -927,7 +1132,7 @@ body {
 .admin__table-body {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .admin-row__cell {
@@ -949,7 +1154,7 @@ body {
 
 .admin-row__subtitle {
   font-size: 0.9rem;
-  color: rgba(148, 163, 184, 0.85);
+  color: rgba(165, 180, 203, 0.85);
 }
 
 .admin-row__badges {
@@ -962,45 +1167,42 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.35rem 0.7rem;
+  padding: 0.35rem 0.75rem;
   border-radius: 999px;
   font-size: 0.75rem;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  background: rgba(37, 99, 235, 0.18);
-  color: rgba(191, 219, 254, 0.9);
-  border: 1px solid rgba(37, 99, 235, 0.32);
+  background: rgba(59, 130, 246, 0.16);
+  color: rgba(224, 242, 254, 0.94);
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  box-shadow: 0 8px 16px rgba(59, 130, 246, 0.18);
 }
 
 .admin-badge--success {
   background: rgba(34, 197, 94, 0.18);
-  border-color: rgba(34, 197, 94, 0.35);
-  color: rgba(187, 247, 208, 0.92);
+  border-color: rgba(74, 222, 128, 0.45);
+  color: rgba(209, 250, 229, 0.94);
 }
 
 .admin-badge--muted {
-  background: rgba(148, 163, 184, 0.14);
-  border-color: rgba(148, 163, 184, 0.25);
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.28);
   color: rgba(226, 232, 240, 0.72);
 }
 
 .admin-row__cell--form label {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.45rem;
   font-size: 0.9rem;
-  color: rgba(203, 213, 225, 0.85);
+  color: rgba(226, 232, 240, 0.82);
 }
 
-.admin-row__cell--form input,
-.admin-row__cell--form textarea,
-.admin-row__cell--form select {
-  padding: 0.55rem 0.75rem;
-  border-radius: 10px;
-  border: 1px solid rgba(59, 130, 246, 0.22);
-  background: rgba(15, 23, 42, 0.9);
-  color: #f8fafc;
-  font-size: 0.9rem;
+.admin-row__cell--form label span {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(191, 219, 254, 0.88);
 }
 
 .admin-row__cell--form textarea {
@@ -1024,14 +1226,17 @@ body {
 }
 
 .admin__empty--sub {
-  padding: 0.5rem 0;
+  padding: 0.35rem 0;
   margin: 0;
+  border: none;
+  background: transparent;
+  text-align: left;
 }
 
 .admin-gallery-entries {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
   margin-top: 0.5rem;
 }
 
@@ -1044,17 +1249,21 @@ body {
 .admin-gallery-entry {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.9rem 1rem;
-  border-radius: 12px;
-  border: 1px solid rgba(59, 130, 246, 0.18);
-  background: rgba(15, 23, 42, 0.78);
+  gap: 1rem;
+  padding: 1.15rem 1.25rem;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.68), rgba(30, 41, 59, 0.54));
+  box-shadow: 0 18px 32px rgba(2, 6, 23, 0.24);
+  backdrop-filter: blur(14px);
 }
 
 .admin-gallery-entry legend {
-  padding: 0 0.35rem;
-  font-size: 0.9rem;
-  color: rgba(191, 219, 254, 0.9);
+  padding: 0 0.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.84);
 }
 
 .admin-gallery-entry__grid {


### PR DESCRIPTION
## Summary
- restyled the administration workspace with glassmorphism cards, pill navigation, refined forms, and lighter table treatments
- updated helper text and empty states to match the modernized moderation experience
- documented the visual overhaul in the README and appended a changelog entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce91e5559483338f8f7e15fa97d54b