### PR TITLE
Refine admin image moderation layout

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -293,3 +293,8 @@
 - **General**: Modernized the admin console with a lighter visual rhythm and clearer hierarchy for moderation workflows.
 - **Technical Changes**: Reworked administration CSS with glassmorphism cards, pill navigation, refined forms/tables, enhanced focus states, and refreshed README guidance.
 - **Data Changes**: None.
+
+## 2025-09-21 – Compact moderation grid (commit TBD)
+- **General**: Reimagined the admin image moderation space as a dense grid with inline previews and quick actions to keep hundreds of thousands of assets scannable.
+- **Technical Changes**: Introduced thumbnail resolution helpers, expandable edit sections, condensed metadata badges, subtle action buttons, and refreshed README guidance to describe the new workflow.
+- **Data Changes**: None; presentation-only adjustments.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 ## Good to Know
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
-- Administration workspace now uses glassmorphism-inspired cards, pill-based filters, and softer status chips for faster scanning during moderation.
+- Administration workspace now offers a compact moderation grid with lazy thumbnails, collapsible edit drawers, and persistent bulk tools tuned for six-figure image libraries.
 - Gallery uploads support multi-select (up to 12 files/2 GB), role-aware gallery selection, and on-the-fly gallery creation.
 - Model uploads enforce exactly one safetensor/ZIP archive plus a cover image; additional renders can be attached afterwards from the gallery explorer.
 - Gallery explorer offers a five-column grid with random cover art, consistent tile sizing, and a detail dialog per collection with an EXIF lightbox for every image.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -281,6 +281,19 @@ body {
   color: rgba(254, 226, 226, 0.9);
 }
 
+.button--subtle {
+  background: rgba(15, 23, 42, 0.6);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.button--subtle:hover:not(:disabled),
+.button--subtle:focus-visible:not(:disabled) {
+  border-color: rgba(148, 163, 184, 0.55);
+  background: rgba(30, 41, 59, 0.7);
+  color: #f8fafc;
+}
+
 .content {
   display: flex;
   flex-direction: column;
@@ -1133,6 +1146,221 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
+}
+
+.admin-image-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+
+@media (max-width: 720px) {
+  .admin-image-grid {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  }
+}
+
+@media (max-width: 540px) {
+  .admin-image-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.admin-image-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  padding: 1.15rem;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.78), rgba(30, 41, 59, 0.58));
+  box-shadow: 0 24px 44px rgba(2, 6, 23, 0.32);
+  backdrop-filter: blur(14px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.admin-image-card:hover,
+.admin-image-card:focus-within {
+  border-color: rgba(125, 211, 252, 0.45);
+  box-shadow: 0 28px 52px rgba(14, 165, 233, 0.22);
+  transform: translateY(-2px);
+}
+
+.admin-image-card--expanded {
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 32px 64px rgba(76, 29, 149, 0.25);
+}
+
+.admin-image-card__body {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 1024px) {
+  .admin-image-card__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.admin-image-card__media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(30, 64, 175, 0.16);
+}
+
+.admin-image-card__media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.admin-image-card__placeholder {
+  display: grid;
+  place-items: center;
+  color: rgba(148, 163, 184, 0.82);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.admin-image-card__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-width: 0;
+}
+
+.admin-image-card__summary-header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.admin-image-card__checkbox input {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: rgba(56, 189, 248, 0.85);
+}
+
+.admin-image-card__titles {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.admin-image-card__titles h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.admin-image-card__subtitle {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(165, 180, 203, 0.85);
+}
+
+.admin-image-card__meta {
+  margin-left: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: flex-end;
+}
+
+.admin-image-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.admin-image-card__metadata {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.4rem 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.admin-image-card__metadata li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.admin-image-card__metadata li span {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.admin-image-card__metadata li strong {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.admin-image-card__prompts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: rgba(203, 213, 225, 0.88);
+}
+
+.admin-image-card__prompts p {
+  margin: 0;
+}
+
+.admin-image-card__prompts strong {
+  color: rgba(248, 250, 252, 0.88);
+  font-weight: 600;
+}
+
+.admin-image-card__quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.admin-image-card__form {
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.24);
+  gap: 1.1rem;
+}
+
+.admin-image-card__form-fields {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.admin-image-card__form-item {
+  min-width: 0;
+}
+
+.admin-image-card__form-item--full {
+  grid-column: 1 / -1;
+}
+
+.admin-image-card__form-grid {
+  margin-top: 0.25rem;
+}
+
+.admin-image-card__form-footer {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .admin-row__cell {


### PR DESCRIPTION
## Summary
- restructure the admin image moderation tab into a dense grid with thumbnails, quick actions, and expandable edit drawers for high-volume review
- add supporting styles, a subtle button treatment, and responsive metadata layouts to keep cards compact across breakpoints
- refresh the README highlight and append a changelog entry documenting the moderation grid rollout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce959fac048333a985c0dccd21f777