### PR TITLE
Fix admin search filters event handling

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -298,3 +298,8 @@
 - **General**: Reimagined the admin image moderation space as a dense grid with inline previews and quick actions to keep hundreds of thousands of assets scannable.
 - **Technical Changes**: Introduced thumbnail resolution helpers, expandable edit sections, condensed metadata badges, subtle action buttons, and refreshed README guidance to describe the new workflow.
 - **Data Changes**: None; presentation-only adjustments.
+
+## 2025-09-20 – Admin search event pooling fix
+- **General**: Restored admin panel filters so typing in search fields no longer crashes the interface.
+- **Technical Changes**: Captured input and select values before enqueuing state updates throughout `AdminPanel.tsx` to avoid React's SyntheticEvent pooling from clearing `currentTarget`.
+- **Data Changes**: None; UI state handling only.

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -675,7 +675,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <input
                     type="search"
                     value={userFilter.query}
-                    onChange={(event) => setUserFilter((previous) => ({ ...previous, query: event.currentTarget.value }))}
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setUserFilter((previous) => ({ ...previous, query: value }));
+                    }}
                     placeholder="Name, email, or bio"
                     disabled={isBusy}
                   />
@@ -684,9 +687,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <span>Role</span>
                   <select
                     value={userFilter.role}
-                    onChange={(event) =>
-                      setUserFilter((previous) => ({ ...previous, role: event.currentTarget.value as FilterValue<User['role']> }))
-                    }
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setUserFilter((previous) => ({ ...previous, role: value as FilterValue<User['role']> }));
+                    }}
                     disabled={isBusy}
                   >
                     <option value="all">All</option>
@@ -698,12 +702,13 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <span>Status</span>
                   <select
                     value={userFilter.status}
-                    onChange={(event) =>
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
                       setUserFilter((previous) => ({
                         ...previous,
-                        status: event.currentTarget.value as FilterValue<UserStatusFilter>,
-                      }))
-                    }
+                        status: value as FilterValue<UserStatusFilter>,
+                      }));
+                    }}
                     disabled={isBusy}
                   >
                     <option value="all">All</option>
@@ -825,7 +830,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <input
                     type="search"
                     value={modelFilter.query}
-                    onChange={(event) => setModelFilter((previous) => ({ ...previous, query: event.currentTarget.value }))}
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setModelFilter((previous) => ({ ...previous, query: value }));
+                    }}
                     placeholder="Title, description, or owner"
                     disabled={isBusy}
                   />
@@ -834,9 +842,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <span>Owner</span>
                   <select
                     value={modelFilter.owner}
-                    onChange={(event) =>
-                      setModelFilter((previous) => ({ ...previous, owner: event.currentTarget.value as FilterValue<string> }))
-                    }
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setModelFilter((previous) => ({ ...previous, owner: value as FilterValue<string> }));
+                    }}
                     disabled={isBusy}
                   >
                     <option value="all">All</option>
@@ -852,7 +861,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <input
                     type="search"
                     value={modelFilter.tag}
-                    onChange={(event) => setModelFilter((previous) => ({ ...previous, tag: event.currentTarget.value }))}
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setModelFilter((previous) => ({ ...previous, tag: value }));
+                    }}
                     placeholder="Tag filter"
                     disabled={isBusy}
                   />
@@ -987,7 +999,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <input
                     type="search"
                     value={imageFilter.query}
-                    onChange={(event) => setImageFilter((previous) => ({ ...previous, query: event.currentTarget.value }))}
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setImageFilter((previous) => ({ ...previous, query: value }));
+                    }}
                     placeholder="Title, prompt, or tags"
                     disabled={isBusy}
                   />
@@ -996,9 +1011,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <span>Owner</span>
                   <select
                     value={imageFilter.owner}
-                    onChange={(event) =>
-                      setImageFilter((previous) => ({ ...previous, owner: event.currentTarget.value as FilterValue<string> }))
-                    }
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setImageFilter((previous) => ({ ...previous, owner: value as FilterValue<string> }));
+                    }}
                     disabled={isBusy}
                   >
                     <option value="all">All</option>
@@ -1254,7 +1270,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <input
                     type="search"
                     value={galleryFilter.query}
-                    onChange={(event) => setGalleryFilter((previous) => ({ ...previous, query: event.currentTarget.value }))}
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setGalleryFilter((previous) => ({ ...previous, query: value }));
+                    }}
                     placeholder="Title or slug"
                     disabled={isBusy}
                   />
@@ -1263,9 +1282,10 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <span>Owner</span>
                   <select
                     value={galleryFilter.owner}
-                    onChange={(event) =>
-                      setGalleryFilter((previous) => ({ ...previous, owner: event.currentTarget.value as FilterValue<string> }))
-                    }
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
+                      setGalleryFilter((previous) => ({ ...previous, owner: value as FilterValue<string> }));
+                    }}
                     disabled={isBusy}
                   >
                     <option value="all">All</option>
@@ -1280,12 +1300,13 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                   <span>Visibility</span>
                   <select
                     value={galleryFilter.visibility}
-                    onChange={(event) =>
+                    onChange={(event) => {
+                      const { value } = event.currentTarget;
                       setGalleryFilter((previous) => ({
                         ...previous,
-                        visibility: event.currentTarget.value as FilterValue<VisibilityFilter>,
-                      }))
-                    }
+                        visibility: value as FilterValue<VisibilityFilter>,
+                      }));
+                    }}
                     disabled={isBusy}
                   >
                     <option value="all">All</option>


### PR DESCRIPTION
## Summary
- prevent admin filter inputs from crashing by copying values before scheduling state updates
- align all admin select filters with the same pattern so React synthetic events are not reused after pooling
- document the fix in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce9983dcac8333a843b665b9b83880