### PR TITLE
docs: add severity-based community update plans

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -313,3 +313,7 @@
 - **General**: Captured the community roadmap feasibility assessment in dedicated documentation and linked it from the main README.
 - **Technical Changes**: Added `docs/community-features-plan-analysis.md` mirroring the prior review tables and refreshed the README community roadmap section with a reference to the new analysis.
 - **Data Changes**: None; documentation-only addition for planning purposes.
+## 2025-09-19 – Severity-based community update plans
+- **General**: Published severity-grouped content update roadmaps to steer community feature rollout communications.
+- **Technical Changes**: Added dedicated plan documents for Projects Silverleaf, Ironquill, and Novashield plus updated the README to reference them.
+- **Data Changes**: None; documentation-only planning assets.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 
 ## Community Roadmap
 
-VisionSuit is evolving toward a richer community layer featuring reactions, threaded discussions, collaborative collections, and creator recognition systems. The [Community Features Plan](docs/community-features-plan.md) outlines the phased rollout, technical architecture, and moderation safeguards that will guide this expansion while preserving the curated gallery experience. A complementary [feasibility analysis](docs/community-features-plan-analysis.md) captures the current engineering effort required for each capability.
+VisionSuit is evolving toward a richer community layer featuring reactions, threaded discussions, collaborative collections, and creator recognition systems. The [Community Features Plan](docs/community-features-plan.md) outlines the phased rollout, technical architecture, and moderation safeguards that will guide this expansion while preserving the curated gallery experience. A complementary [feasibility analysis](docs/community-features-plan-analysis.md) captures the current engineering effort required for each capability. Severity-bucketed content programs are captured in the companion plans for [Project Silverleaf](docs/community-update-plans/project-silverleaf-low-severity.md), [Project Ironquill](docs/community-update-plans/project-ironquill-medium-severity.md), and [Project Novashield](docs/community-update-plans/project-novashield-high-severity.md).
 
 ## Architecture Overview
 

--- a/docs/community-update-plans/project-ironquill-medium-severity.md
+++ b/docs/community-update-plans/project-ironquill-medium-severity.md
@@ -1,0 +1,39 @@
+# Project Ironquill – Medium-Severity Engagement Systems
+
+Project Ironquill assembles the roadmap initiatives rated at severity 6–7. These efforts expand community interaction loops and supporting infrastructure without yet demanding the deepest architectural rework.
+
+## Scope of Updates
+- **Reactions & counters** – Ship per-item likes for models, images, and galleries plus aggregated counters on tiles and dashboards (Severity 6–7).
+- **Follow graph foundations** – Introduce follow relationships for creators, galleries, or models to prepare personalized discovery (Severity 7).
+- **Collection collaboration** – Enable shared editing and generate short, shareable links with previews (Severity 6–7).
+- **Badge administration** – Provide admin tooling to grant or revoke reputation badges once scoring exists (Severity 7).
+- **Profile activity surfacing** – Add an activity timeline to profile pages (Severity 7).
+- **Core schema extensions** – Create `Reaction`, `Follow`, `Subscription`, and collection-centric tables (`Collection`, `CollectionEntry`, `CollectionCollaborator`) (Severity 6–7).
+- **Community API layer** – Launch `/api/community/*` endpoints guarded by JWTs and basic rate limiting (Severity 7).
+- **Cursor pagination rollout** – Refactor list endpoints to support cursor-based pagination (Severity 6).
+- **Frontend enhancements** – Implement reaction bars across tiles and deliver a profile revamp exposing badges, follower counts, and collections (Severity 7).
+- **Operational guardrails** – Stand up an audit logging pipeline to capture community events (Severity 7).
+- **Engagement metric tracking** – Target 30% weekly reaction participation with supporting analytics (Severity 7).
+- **Policy alignment** – Finalize storage/privacy guidelines for comment media and evaluate third-party API exposure (Severity 6–7).
+
+## Content Update Strategy
+1. **Interaction-first storytelling**
+   - Produce release notes and in-product highlights that celebrate the new reaction and follow mechanics.
+   - Refresh creator documentation to explain how activity timelines and badge administration influence visibility.
+2. **Navigation & discovery refresh**
+   - Update profile layouts and gallery tiles to visually integrate reaction controls, follower counts, and collaboration indicators.
+   - Introduce onboarding tooltips or spotlight tours that teach the follow graph and collaborative collections.
+3. **Trust & policy communication**
+   - Publish clear privacy/storage guidelines for media contributions, ensuring contributors know how assets are processed.
+   - Document API exposure policies and rate limits tied to the new `/api/community` namespace.
+
+## Technical Considerations
+- Schema migrations must be sequenced to avoid blocking existing gallery workflows; start with new tables that can sit idle until endpoints are ready.
+- Rate limiting can begin with in-process tracking before moving to distributed stores, keeping early implementation manageable.
+- Cursor pagination will require coordinated frontend updates to handle `nextCursor` responses across explorers and dashboards.
+- Audit logging should piggyback on the new reaction/follow events to avoid duplicative instrumentation work later.
+
+## Dependencies & Sequencing
+- Complete Project Silverleaf before enabling collaborative collections to guarantee guideline acknowledgements are in place.
+- Align backend and frontend delivery for reactions/follows so the user experience is cohesive on launch day.
+- Reserve discovery marketing pushes until engagement analytics dashboards can accurately report the 30% weekly participation target.

--- a/docs/community-update-plans/project-novashield-high-severity.md
+++ b/docs/community-update-plans/project-novashield-high-severity.md
@@ -1,0 +1,40 @@
+# Project Novashield – High-Severity Community Platform Overhaul
+
+Project Novashield groups all roadmap elements scored at severity 8–9. These initiatives redefine how the community collaborates, requiring deep schema overhauls, new infrastructure, and sustained operational readiness.
+
+## Scope of Updates
+- **Advanced reactions governance** – Enforce daily like quotas and anti-spam safeguards (Severity 8).
+- **Threaded discussions** – Deliver contextual comment threads, rich-text composition with attachments, and inline moderation/flagging pipelines (Severity 8–9).
+- **Personalized discovery** – Build a personal feed for followed entities and craft weekly email or in-app digests (Severity 8–9).
+- **Reputation systems** – Launch reputation ledgers, tiered badges with unlockable perks, and supporting admin controls (Severity 8).
+- **Moderation & safety enhancements** – Implement flagging queues, shadow bans, and automated throttling (Severity 8–9).
+- **Notification ecosystem** – Stand up an in-app notification center, deliver webhook integrations, and manage unread counts (Severity 8–9).
+- **Data model expansion** – Create `Comment`, `CommentThread`, `CommentReaction`, `ReputationLedger`, and `Notification` entities with full lifecycle tracking (Severity 8).
+- **Real-time & bulk APIs** – Provide WebSocket/SSE channels, bulk moderator endpoints, and event-driven webhook delivery (Severity 8–9).
+- **Frontend deep rebuilds** – Ship a comment composer with moderation controls, a notification drawer plus full-page feed, and expanded profile surfaces (Severity 8).
+- **Infrastructure uplift** – Deploy background workers (BullMQ), Redis caching layers, and search indexing services for comment/collection discovery (Severity 8–9).
+- **Rollout milestones** – Execute milestone waves M1–M4 covering reactions foundation, feed/notifications, collaborative reputation layers, and analytics/digest maturity (Severity 8–9).
+- **Operational targets** – Achieve median flag response under 12 hours and a 20% engagement uplift from follows/digests (Severity 8).
+
+## Content Update Strategy
+1. **Narrative arcs for major launches**
+   - Plan campaign-style announcements for each milestone (M1–M4) to articulate the platform evolution and set user expectations.
+   - Develop long-form documentation that explains moderation protocols, reputation mechanics, and notification management.
+2. **Safety & trust communication**
+   - Publish comprehensive guides for flagging misuse, understanding throttling behavior, and managing shadow bans with transparency.
+   - Offer clear consent and opt-in messaging for digest emails, covering legal compliance and unsubscribe flows.
+3. **Ecosystem enablement**
+   - Prepare integration playbooks for webhook consumers, outlining event schemas, retries, and security signatures.
+   - Curate tutorials that show creators how to leverage comment threads, badges, and feeds to build sustained engagement.
+
+## Technical Considerations
+- Background workers and Redis introduce new deployment topologies; invest in infrastructure-as-code and observability before launch.
+- Real-time channels necessitate authentication hardening and scalability planning to avoid regressions in existing REST traffic.
+- Reputation and moderation systems should share a central rules engine to reduce duplication and support future policy tweaks.
+- Search indexing must balance latency with consistency, potentially favoring managed services to minimize operational burden.
+
+## Dependencies & Sequencing
+- Project Ironquill deliverables (reaction primitives, follow graph, audit logging) must be complete before Novashield work begins.
+- Establish governance councils or moderator cohorts early so tooling can be co-designed with actual operators.
+- Stagger rollouts to beta audiences to validate infrastructure under load prior to general availability campaigns.
+- Align legal, compliance, and data protection reviews with the digest and webhook features to avoid launch delays.

--- a/docs/community-update-plans/project-silverleaf-low-severity.md
+++ b/docs/community-update-plans/project-silverleaf-low-severity.md
@@ -1,0 +1,30 @@
+# Project Silverleaf – Low-Severity Community Foundations
+
+Project Silverleaf captures the community-facing updates from the feasibility review that carry a severity rating of 4–5. These workstreams offer the fastest path to visible improvements and can be scheduled as early content refreshes while heavier initiatives incubate.
+
+## Scope of Updates
+- **Curated collection curation enhancements** – Allow curators to assemble public or private collections that mix models and galleries (Severity 4).
+- **Community guidelines acknowledgement flow** – Surface a reusable banner and persist acknowledgement state for each account (Severity 5).
+- **Extended auditing on community records** – Add audit columns that align with the existing `createdAt`/`updatedAt` pattern (Severity 4).
+- **Experience tracking through surveys** – Establish a feedback loop to monitor satisfaction >4/5 (Severity 5).
+
+## Content Update Strategy
+1. **Elevate documentation and onboarding copy**
+   - Update help center language to explain new collection flexibility and the guidelines acknowledgement experience.
+   - Provide short-form copy for UI banners and tooltips outlining acknowledgement requirements and privacy expectations.
+2. **UI/UX micro-adjustments**
+   - Extend gallery-related screens with inline cues that highlight mixed collection support without overwhelming existing layouts.
+   - Design a slim banner component that can appear across shell pages and dismiss once acknowledgement is recorded.
+3. **Data visibility improvements**
+   - Document how audit fields surface in admin exports and activity logs so moderators understand accountability touchpoints.
+   - Plan lightweight dashboard tiles or report snippets that visualize satisfaction trends as survey data is collected.
+
+## Technical Considerations
+- Schema updates are limited to augmenting existing tables with acknowledgement and audit metadata, minimizing migration risk.
+- Frontend changes can reuse established layout primitives; no new navigation or deep component hierarchies are required.
+- Survey collection can start with embedded external tools while long-term telemetry is evaluated, keeping engineering effort modest.
+
+## Dependencies & Sequencing
+- Coordinate with legal/compliance stakeholders for the wording of the guidelines acknowledgement prior to rollout.
+- Ensure analytics or survey tooling is available before publicizing satisfaction tracking to avoid empty dashboards.
+- Schedule the work ahead of higher-severity programs to build momentum and gather early community sentiment data.


### PR DESCRIPTION
## Summary
- add three severity-bucketed community content plans covering low, medium, and high effort initiatives
- surface the new plans from the README community roadmap overview
- log the documentation work in the running changelog

## Testing
- no automated tests were run (not applicable for documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cea39f42708333a7348e268f1bfeaa