### PR TITLE
feat: make home previews interactive

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -317,3 +317,8 @@
 - **General**: Published severity-grouped content update roadmaps to steer community feature rollout communications.
 - **Technical Changes**: Added dedicated plan documents for Projects Silverleaf, Ironquill, and Novashield plus updated the README to reference them.
 - **Data Changes**: None; documentation-only planning assets.
+
+## 2025-09-20 – Interactive home spotlights (commit TBD)
+- **General**: Elevated the home dashboard with clickable previews that jump directly into the explorers.
+- **Technical Changes**: Added media buttons on home tiles that focus the respective model or gallery, introduced gallery lookups for image cards, updated hover/focus styling, and refreshed README guidance.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 ## Good to Know
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
+- Home spotlight tiles are fully interactive—click previews to jump straight into the model or gallery explorers, and tap tag chips to filter matching content instantly.
 - Administration workspace now offers a compact moderation grid across models and images with lazy thumbnails, inline version histories, collapsible edit drawers, and persistent bulk tools tuned for six-figure libraries.
 - Gallery uploads support multi-select (up to 12 files/2 GB), role-aware gallery selection, and on-the-fly gallery creation.
 - Model uploads enforce exactly one safetensor/ZIP archive plus a cover image; additional renders can be attached afterwards from the gallery explorer.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -238,6 +238,25 @@ export const App = () => {
     setActiveView('images');
   }, []);
 
+  const handleModelCardClick = useCallback((modelId: string) => {
+    setFocusedGalleryId(null);
+    setFocusedAssetId(modelId);
+    setActiveView('models');
+  }, []);
+
+  const handleImageCardClick = useCallback(
+    (imageId: string) => {
+      setFocusedAssetId(null);
+      const matchedGallery =
+        galleries.find((gallery) =>
+          gallery.entries.some((entry) => entry.imageAsset?.id === imageId),
+        ) ?? null;
+      setFocusedGalleryId(matchedGallery?.id ?? null);
+      setActiveView('images');
+    },
+    [galleries],
+  );
+
   const handleLoginSubmit = async (email: string, password: string) => {
     setIsLoggingIn(true);
     setLoginError(null);
@@ -276,11 +295,18 @@ export const App = () => {
     return (
       <article key={asset.id} className="home-card home-card--model">
         <div className="home-card__media">
-          {previewUrl ? (
-            <img src={previewUrl} alt={asset.title} loading="lazy" />
-          ) : (
-            <span className="home-card__placeholder">No preview available</span>
-          )}
+          <button
+            type="button"
+            className="home-card__media-button"
+            onClick={() => handleModelCardClick(asset.id)}
+            aria-label={`Open ${asset.title} in the model explorer`}
+          >
+            {previewUrl ? (
+              <img src={previewUrl} alt={asset.title} loading="lazy" />
+            ) : (
+              <span className="home-card__placeholder">No preview available</span>
+            )}
+          </button>
         </div>
         <div className="home-card__body">
           <h3 className="home-card__title">{asset.title}</h3>
@@ -322,15 +348,29 @@ export const App = () => {
       resolveStorageUrl(image.storagePath, image.storageBucket, image.storageObject) ?? image.storagePath;
     const visibleTags = image.tags.slice(0, 5);
     const remainingTagCount = image.tags.length - visibleTags.length;
+    const matchedGallery = galleries.find((gallery) =>
+      gallery.entries.some((entry) => entry.imageAsset?.id === image.id),
+    );
 
     return (
       <article key={image.id} className="home-card home-card--image">
         <div className="home-card__media">
-          {imageUrl ? (
-            <img src={imageUrl} alt={image.title} loading="lazy" />
-          ) : (
-            <span className="home-card__placeholder">No image available</span>
-          )}
+          <button
+            type="button"
+            className="home-card__media-button"
+            onClick={() => handleImageCardClick(image.id)}
+            aria-label={
+              matchedGallery
+                ? `Open ${matchedGallery.title} in the gallery explorer`
+                : `Open gallery explorer for ${image.title}`
+            }
+          >
+            {imageUrl ? (
+              <img src={imageUrl} alt={image.title} loading="lazy" />
+            ) : (
+              <span className="home-card__placeholder">No image available</span>
+            )}
+          </button>
         </div>
         <div className="home-card__body">
           <h3 className="home-card__title">{image.title}</h3>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -445,6 +445,39 @@ body {
   background: rgba(15, 23, 42, 0.85);
 }
 
+.home-card__media-button {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  cursor: pointer;
+  border-radius: 0;
+  background: transparent;
+  overflow: hidden;
+}
+
+.home-card__media-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.35) 100%);
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.home-card__media-button:hover::after,
+.home-card__media-button:focus-visible::after {
+  opacity: 1;
+}
+
+.home-card__media-button:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.65);
+  outline-offset: 3px;
+}
+
 .home-card__media img {
   position: absolute;
   inset: 0;
@@ -452,6 +485,12 @@ body {
   height: 100%;
   object-fit: cover;
   filter: saturate(1.1);
+  transition: transform 0.25s ease;
+}
+
+.home-card__media-button:hover img,
+.home-card__media-button:focus-visible img {
+  transform: scale(1.02);
 }
 
 .home-card__placeholder {


### PR DESCRIPTION
## Summary
- add interactive media buttons to home spotlight cards so previews jump into the explorers
- surface gallery context for home image tiles and refresh hover/focus styling
- document the new interactions in the README and changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cea5f7150c833397978aad2cdc9cc6