### PR TITLE
Add dialog-driven user onboarding to admin panel

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -327,3 +327,8 @@
 - **General**: Ensured modelcard version listings surface the primary release before sequential versions for quicker recognition.
 - **Technical Changes**: Updated backend asset mapping to keep the primary version at the top while numerically ordering the remaining versions and retaining latest-version metadata via creation timestamps.
 - **Data Changes**: None; response payload ordering only.
+
+## 2025-09-19 – Dialog-driven user onboarding (pending)
+- **General**: Reimagined account creation with preset-driven dialogs and clearer role guidance for administrators.
+- **Technical Changes**: Added a multi-step `UserCreationDialog` with validation and password generation, introduced role summary popups, revamped the admin onboarding panel styling, extended status handling, and refreshed README highlights.
+- **Data Changes**: None; interface and workflow updates only.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 ## Core Highlights
 
 - **Unified operations dashboard** – Persistent sidebar navigation with instant switching between Home, Models, and Images, plus live health badges for the front end, API, and MinIO services.
-- **Role-aware access control** – JWT-based authentication with session persistence, an admin workspace for user/model/gallery management, and protected upload flows.
+- **Role-aware access control** – JWT-based authentication with session persistence, an admin workspace for user/model/gallery management, a dialog-driven onboarding wizard with role presets, and protected upload flows.
 - **Guided three-step upload wizard** – Collects metadata, files, and review feedback with validation, drag & drop, and live responses from the production-ready `POST /api/uploads` endpoint.
 - **Data-driven explorers** – Fast filters and full-text search across LoRA assets and galleries, complete with tag badges, five-column tiles, and seamless infinite scrolling with active filter indicators.
 - **Versioned modelcards** – Dedicated model dialogs with inline descriptions, quick switches between safetensor versions, in-place editing for curators/admins, and an integrated flow for uploading new revisions including preview handling.
@@ -15,7 +15,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
 - Home spotlight tiles are fully interactive—click previews to jump straight into the model or gallery explorers, and tap tag chips to filter matching content instantly.
-- Administration workspace now offers a compact moderation grid across models and images with lazy thumbnails, inline version histories, collapsible edit drawers, and persistent bulk tools tuned for six-figure libraries.
+- Administration workspace now offers a compact moderation grid across models and images with lazy thumbnails, inline version histories, collapsible edit drawers, persistent bulk tools tuned for six-figure libraries, and a multi-step user onboarding dialog with permission previews.
 - Gallery uploads support multi-select (up to 12 files/2 GB), role-aware gallery selection, and on-the-fly gallery creation.
 - Model uploads enforce exactly one safetensor/ZIP archive plus a cover image; additional renders can be attached afterwards from the gallery explorer.
 - Gallery explorer offers a five-column grid with random cover art, consistent tile sizing, and a detail dialog per collection with an EXIF lightbox for every image.

--- a/frontend/src/components/UserCreationDialog.tsx
+++ b/frontend/src/components/UserCreationDialog.tsx
@@ -1,0 +1,400 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import type { User } from '../types/api';
+
+export type AsyncActionResult = { ok: true } | { ok: false; message: string };
+
+type UserCreationStep = 'account' | 'profile' | 'review';
+
+interface UserCreationDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (payload: {
+    email: string;
+    displayName: string;
+    password: string;
+    role: User['role'];
+    bio?: string;
+  }) => Promise<AsyncActionResult>;
+  isSubmitting: boolean;
+  initialRole?: User['role'];
+}
+
+interface UserCreationState {
+  email: string;
+  displayName: string;
+  role: User['role'];
+  password: string;
+  confirmPassword: string;
+  bio: string;
+}
+
+const passwordFromCrypto = () => {
+  if (typeof window !== 'undefined' && window.crypto?.getRandomValues) {
+    const array = new Uint32Array(4);
+    window.crypto.getRandomValues(array);
+    return Array.from(array)
+      .map((value) => value.toString(36))
+      .join('')
+      .slice(0, 12);
+  }
+
+  return Math.random().toString(36).slice(-12);
+};
+
+export const UserCreationDialog = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  isSubmitting,
+  initialRole = 'CURATOR',
+}: UserCreationDialogProps) => {
+  const [currentStep, setCurrentStep] = useState<UserCreationStep>('account');
+  const [formState, setFormState] = useState<UserCreationState>({
+    email: '',
+    displayName: '',
+    role: initialRole,
+    password: '',
+    confirmPassword: '',
+    bio: '',
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setCurrentStep('account');
+    setFormState({
+      email: '',
+      displayName: '',
+      role: initialRole,
+      password: '',
+      confirmPassword: '',
+      bio: '',
+    });
+    setError(null);
+  }, [isOpen, initialRole]);
+
+  const steps = useMemo(
+    () => [
+      { id: 'account', label: 'Account basics', description: 'Email, name, and permissions' },
+      { id: 'profile', label: 'Security & profile', description: 'Password and optional bio' },
+      { id: 'review', label: 'Review', description: 'Confirm the new account' },
+    ] as { id: UserCreationStep; label: string; description: string }[],
+    [],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const stepIndex = steps.findIndex((entry) => entry.id === currentStep);
+  const canGoBack = stepIndex > 0 && !isSubmitting;
+  const isFinalStep = currentStep === 'review';
+
+  const handleGeneratePassword = () => {
+    if (isSubmitting) {
+      return;
+    }
+    const generated = passwordFromCrypto();
+    setFormState((previous) => ({
+      ...previous,
+      password: generated,
+      confirmPassword: generated,
+    }));
+  };
+
+  const goToStep = (step: UserCreationStep) => {
+    if (isSubmitting) {
+      return;
+    }
+    setError(null);
+    setCurrentStep(step);
+  };
+
+  const validateAccountStep = () => {
+    const trimmedEmail = formState.email.trim();
+    const trimmedName = formState.displayName.trim();
+
+    if (!trimmedEmail || !trimmedName) {
+      setError('Provide at least an email address and display name to continue.');
+      return false;
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      setError('The email address looks invalid.');
+      return false;
+    }
+
+    setError(null);
+    return true;
+  };
+
+  const validateProfileStep = () => {
+    if (!formState.password) {
+      setError('Set an initial password or generate one automatically.');
+      return false;
+    }
+
+    if (formState.password !== formState.confirmPassword) {
+      setError('Password confirmation does not match.');
+      return false;
+    }
+
+    if (formState.password.length < 8) {
+      setError('Passwords should be at least 8 characters long.');
+      return false;
+    }
+
+    setError(null);
+    return true;
+  };
+
+  const handleNext = () => {
+    if (currentStep === 'account') {
+      if (validateAccountStep()) {
+        setCurrentStep('profile');
+      }
+      return;
+    }
+
+    if (currentStep === 'profile') {
+      if (validateProfileStep()) {
+        setCurrentStep('review');
+      }
+      return;
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) {
+      return;
+    }
+
+    if (!isFinalStep) {
+      handleNext();
+      return;
+    }
+
+    if (!validateAccountStep() || !validateProfileStep()) {
+      return;
+    }
+
+    setError(null);
+    const payload = {
+      email: formState.email.trim(),
+      displayName: formState.displayName.trim(),
+      password: formState.password,
+      role: formState.role,
+      bio: formState.bio.trim() ? formState.bio.trim() : undefined,
+    };
+
+    const result = await onSubmit(payload);
+    if (!result.ok) {
+      setError(result.message || 'Account could not be created. Check the status banner for details.');
+      return;
+    }
+
+    onClose();
+  };
+
+  return (
+    <div
+      className="modal user-creation-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="user-creation-title"
+      aria-describedby="user-creation-steps"
+    >
+      <div className="modal__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="modal__content user-creation-dialog__content">
+        <header className="modal__header">
+          <h2 id="user-creation-title">Create a new account</h2>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Close dialog" disabled={isSubmitting}>
+            ×
+          </button>
+        </header>
+        <div className="user-creation-dialog__steps" id="user-creation-steps">
+          {steps.map((step, index) => {
+            const isActive = step.id === currentStep;
+            const isComplete = index < stepIndex;
+            return (
+              <button
+                key={step.id}
+                type="button"
+                className={`user-creation-dialog__step${isActive ? ' user-creation-dialog__step--active' : ''}${
+                  isComplete ? ' user-creation-dialog__step--complete' : ''
+                }`}
+                onClick={() => goToStep(step.id)}
+                disabled={isSubmitting || (!isActive && !isComplete)}
+                aria-current={isActive ? 'step' : undefined}
+              >
+                <span className="user-creation-dialog__step-index">{index + 1}</span>
+                <span className="user-creation-dialog__step-label">
+                  <strong>{step.label}</strong>
+                  <small>{step.description}</small>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <form className="modal__body user-creation-dialog__body" onSubmit={handleSubmit}>
+          {currentStep === 'account' ? (
+            <div className="user-creation-dialog__section">
+              <p className="user-creation-dialog__hint">
+                Start with the basics—VisionSuit needs a unique email, a public-facing display name, and the right permission
+                level.
+              </p>
+              <label className="form-field">
+                <span>Email</span>
+                <input
+                  type="email"
+                  value={formState.email}
+                  onChange={(event) => setFormState((previous) => ({ ...previous, email: event.target.value }))}
+                  autoComplete="email"
+                  required
+                  disabled={isSubmitting}
+                />
+              </label>
+              <label className="form-field">
+                <span>Display name</span>
+                <input
+                  value={formState.displayName}
+                  onChange={(event) => setFormState((previous) => ({ ...previous, displayName: event.target.value }))}
+                  autoComplete="name"
+                  required
+                  disabled={isSubmitting}
+                />
+              </label>
+              <label className="form-field">
+                <span>Role</span>
+                <select
+                  value={formState.role}
+                  onChange={(event) =>
+                    setFormState((previous) => ({ ...previous, role: event.target.value as User['role'] }))
+                  }
+                  disabled={isSubmitting}
+                >
+                  <option value="CURATOR">Curator — content curation & uploads</option>
+                  <option value="ADMIN">Admin — full platform access</option>
+                </select>
+              </label>
+            </div>
+          ) : null}
+
+          {currentStep === 'profile' ? (
+            <div className="user-creation-dialog__section">
+              <p className="user-creation-dialog__hint">
+                Set a strong password or let VisionSuit generate one instantly. Add an optional bio to personalise the profile.
+              </p>
+              <div className="user-creation-dialog__password-row">
+                <label className="form-field">
+                  <span>Password</span>
+                  <input
+                    type="password"
+                    value={formState.password}
+                    onChange={(event) => setFormState((previous) => ({ ...previous, password: event.target.value }))}
+                    autoComplete="new-password"
+                    required
+                    disabled={isSubmitting}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="button button--ghost"
+                  onClick={handleGeneratePassword}
+                  disabled={isSubmitting}
+                >
+                  Generate secure password
+                </button>
+              </div>
+              <label className="form-field">
+                <span>Confirm password</span>
+                <input
+                  type="password"
+                  value={formState.confirmPassword}
+                  onChange={(event) => setFormState((previous) => ({ ...previous, confirmPassword: event.target.value }))}
+                  autoComplete="new-password"
+                  required
+                  disabled={isSubmitting}
+                />
+              </label>
+              <label className="form-field">
+                <span>Bio (optional)</span>
+                <textarea
+                  rows={3}
+                  value={formState.bio}
+                  onChange={(event) => setFormState((previous) => ({ ...previous, bio: event.target.value }))}
+                  disabled={isSubmitting}
+                />
+              </label>
+            </div>
+          ) : null}
+
+          {currentStep === 'review' ? (
+            <div className="user-creation-dialog__section">
+              <p className="user-creation-dialog__hint">
+                Double-check everything before provisioning the account. You can jump back to adjust details instantly.
+              </p>
+              <dl className="user-creation-dialog__summary">
+                <div>
+                  <dt>Email</dt>
+                  <dd>{formState.email.trim()}</dd>
+                </div>
+                <div>
+                  <dt>Display name</dt>
+                  <dd>{formState.displayName.trim()}</dd>
+                </div>
+                <div>
+                  <dt>Role</dt>
+                  <dd>{formState.role === 'ADMIN' ? 'Admin — full access' : 'Curator — uploads & curation'}</dd>
+                </div>
+                <div>
+                  <dt>Password</dt>
+                  <dd>{'•'.repeat(Math.max(8, formState.password.length))}</dd>
+                </div>
+                <div>
+                  <dt>Bio</dt>
+                  <dd>{formState.bio.trim() || <span className="user-creation-dialog__empty">No bio provided</span>}</dd>
+                </div>
+              </dl>
+            </div>
+          ) : null}
+
+          {error ? (
+            <p className="form-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <div className="modal__actions">
+            <button type="button" className="button" onClick={onClose} disabled={isSubmitting}>
+              Cancel
+            </button>
+            {canGoBack ? (
+              <button
+                type="button"
+                className="button button--ghost"
+                onClick={() => goToStep(steps[Math.max(0, stepIndex - 1)].id)}
+                disabled={isSubmitting}
+              >
+                Back
+              </button>
+            ) : null}
+            {!isFinalStep ? (
+              <button type="button" className="button button--primary" onClick={handleNext} disabled={isSubmitting}>
+                Continue
+              </button>
+            ) : (
+              <button type="submit" className="button button--primary" disabled={isSubmitting}>
+                {isSubmitting ? 'Creating account…' : 'Create account'}
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -294,6 +294,19 @@ body {
   color: #f8fafc;
 }
 
+.button--ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.button--ghost:hover:not(:disabled),
+.button--ghost:focus-visible:not(:disabled) {
+  border-color: rgba(125, 211, 252, 0.45);
+  background: rgba(15, 23, 42, 0.5);
+  color: #f8fafc;
+}
+
 .content {
   display: flex;
   flex-direction: column;
@@ -641,6 +654,178 @@ body {
   padding: 2rem;
 }
 
+.user-creation-dialog__content {
+  width: min(640px, calc(100% - 2rem));
+  padding: 2.5rem 2.75rem 2.25rem;
+  gap: 2rem;
+}
+
+.user-creation-dialog__steps {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.user-creation-dialog__step {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  background: rgba(15, 23, 42, 0.78);
+  color: rgba(226, 232, 240, 0.78);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.user-creation-dialog__step-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.user-creation-dialog__step strong {
+  display: block;
+  font-size: 0.95rem;
+  color: #f8fafc;
+}
+
+.user-creation-dialog__step small {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.user-creation-dialog__step:hover:not(:disabled),
+.user-creation-dialog__step:focus-visible:not(:disabled) {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.5);
+  box-shadow: 0 12px 28px rgba(14, 165, 233, 0.25);
+  transform: translateY(-1px);
+}
+
+.user-creation-dialog__step--active {
+  border-color: rgba(37, 99, 235, 0.55);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(14, 165, 233, 0.28));
+  color: #f8fafc;
+}
+
+.user-creation-dialog__step--complete {
+  border-style: dashed;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.user-creation-dialog__step-index {
+  display: grid;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.2);
+  color: #f8fafc;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.user-creation-dialog__step--active .user-creation-dialog__step-index {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.65), rgba(14, 165, 233, 0.55));
+  color: #0f172a;
+}
+
+.user-creation-dialog__step--complete .user-creation-dialog__step-index {
+  background: rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.user-creation-dialog__body {
+  gap: 1.5rem;
+}
+
+.user-creation-dialog__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.user-creation-dialog__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.user-creation-dialog__password-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.user-creation-dialog__password-row .form-field {
+  flex: 1 1 220px;
+}
+
+.user-creation-dialog__summary {
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.user-creation-dialog__summary div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.user-creation-dialog__summary dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.user-creation-dialog__summary dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #f8fafc;
+}
+
+.user-creation-dialog__empty {
+  color: rgba(148, 163, 184, 0.75);
+  font-style: italic;
+}
+
+.role-summary-dialog__body {
+  gap: 1.25rem;
+}
+
+.role-summary-dialog__intro {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.role-summary-dialog__list {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: rgba(191, 219, 254, 0.85);
+  font-size: 0.9rem;
+}
+
+.role-summary-dialog__list li {
+  line-height: 1.5;
+}
+
 .modal__header {
   display: flex;
   align-items: center;
@@ -904,6 +1089,95 @@ body {
   font-weight: 600;
   letter-spacing: 0.01em;
   color: #f8fafc;
+}
+
+.admin__section--onboarding {
+  gap: 2rem;
+}
+
+.admin__section-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.admin__section-intro h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.admin__section-intro p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(203, 213, 225, 0.85);
+  max-width: 56ch;
+}
+
+.user-onboarding-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.user-onboarding-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.6rem;
+  border-radius: 20px;
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.65), rgba(30, 41, 59, 0.58));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 24px 48px rgba(2, 6, 23, 0.3);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.user-onboarding-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.35);
+  box-shadow: 0 26px 54px rgba(14, 165, 233, 0.22);
+}
+
+.user-onboarding-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.user-onboarding-card h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.user-onboarding-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(203, 213, 225, 0.8);
+}
+
+.user-onboarding-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: rgba(191, 219, 254, 0.8);
+  font-size: 0.9rem;
+}
+
+.user-onboarding-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.user-onboarding-footnote {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
 }
 
 .admin__form {


### PR DESCRIPTION
## Summary
- add a multi-step user creation dialog with validation, review, and password generation
- refresh the admin user onboarding section with role presets and permission summary modals
- extend styling plus README and changelog entries to cover the new onboarding flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceab82f29c8333906d2c2f231c9fd5