### PR TITLE
Route bulk import scripts through VisionSuit API

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -332,3 +332,13 @@
 - **General**: Reimagined account creation with preset-driven dialogs and clearer role guidance for administrators.
 - **Technical Changes**: Added a multi-step `UserCreationDialog` with validation and password generation, introduced role summary popups, revamped the admin onboarding panel styling, extended status handling, and refreshed README highlights.
 - **Data Changes**: None; interface and workflow updates only.
+
+## 2025-09-21 – Client bulk import scripts
+- **General**: Equipped curators with turnkey client importers so LoRA weights and previews can be staged locally and pushed to the VisionSuit server in bulk.
+- **Technical Changes**: Added dedicated Linux/macOS and Windows scripts that validate matching preview folders, pick a random cover image, generate a manifest, and upload packages over SSH; refreshed the README with setup and execution guidance.
+- **Data Changes**: None; tooling additions only.
+
+## 2025-09-20 – API-driven bulk import helpers
+- **General**: Reworked the client import tooling to authenticate against VisionSuit and upload LoRAs through the official pipeline instead of SSH transfers.
+- **Technical Changes**: Replaced the staging/manifest workflow with direct `POST /api/uploads` calls in both scripts, added credential prompts and file-cap trimming, refreshed README guidance, and documented password handling.
+- **Data Changes**: None; ingestion now flows through existing upload drafts and storage objects.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,40 @@ Default ports:
 
 > Tip: Always point `HOST` to a reachable address (e.g., `HOST=192.168.1.50 ./dev-start.sh`) when accessing services from other devices or containers.
 
+## Bulk Import Utilities
+
+Client-side helpers streamline batched LoRA transfers when curating existing libraries offline. Both scripts expect two sibling directories on the client machine:
+
+- `loras/` – contains `.safetensors` weights.
+- `images/` – contains folders named after each safetensor (without the extension) populated with preview renders.
+
+Each importer refuses to upload a model unless a matching image folder exists. After authentication the scripts pick a random preview render, keep up to ten additional images (VisionSuit accepts a maximum of twelve files per upload, including the LoRA), and stream the batch to `POST /api/uploads` so the backend can push artifacts into MinIO.
+
+### Linux and macOS
+
+1. Review and adjust `server_ip`, `server_username`, and `server_port` at the top of `scripts/bulk_import_linux.sh`.
+2. Ensure `curl` and `python3` are installed on the client.
+3. Provide the VisionSuit password either via the `VISIONSUIT_PASSWORD` environment variable or interactively when prompted.
+4. Run the script from the root of your asset stash (or pass custom directories):
+
+   ```bash
+   ./scripts/bulk_import_linux.sh ./loras ./images
+   ```
+
+The script authenticates with `POST /api/auth/login`, then uploads the LoRA and curated previews straight to the VisionSuit API. Models without imagery are skipped automatically.
+
+### Windows (PowerShell)
+
+1. Edit `$ServerIp`, `$ServerUsername`, and `$ServerPort` at the head of `scripts/bulk_import_windows.ps1`.
+2. Launch the script from PowerShell 7+ (pwsh). Enter your VisionSuit password when prompted or expose it via `VISIONSUIT_PASSWORD`.
+3. Run the importer with optional overrides for the source folders:
+
+   ```powershell
+   pwsh -File .\scripts\bulk_import_windows.ps1 -LorasDirectory .\loras -ImagesDirectory .\images
+   ```
+
+The PowerShell helper mirrors the Linux workflow: it logs in once, picks a random preview, trims excessive renders, and posts the bundle directly to the VisionSuit API for processing.
+
 ### Backend service
 
 1. `cd backend`

--- a/scripts/bulk_import_linux.sh
+++ b/scripts/bulk_import_linux.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# VisionSuit bulk import helper for Linux/macOS clients.
+# Configure these connection settings before running the script.
+server_ip="192.168.1.10"
+server_username="admin@example.com"
+server_port=4000
+
+set -euo pipefail
+
+loras_dir=${1:-"./loras"}
+images_dir=${2:-"./images"}
+
+api_base="http://$server_ip:$server_port/api"
+login_url="$api_base/auth/login"
+upload_url="$api_base/uploads"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log "Missing required command: $1"
+    exit 1
+  fi
+}
+
+require_command curl
+require_command python3
+
+if [ ! -d "$loras_dir" ]; then
+  log "LoRA directory '$loras_dir' was not found."
+  exit 1
+fi
+
+if [ ! -d "$images_dir" ]; then
+  log "Image directory '$images_dir' was not found."
+  exit 1
+fi
+
+mime_type() {
+  python3 <<'PY' "$1"
+import mimetypes
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+mime, _ = mimetypes.guess_type(str(path))
+print(mime or 'application/octet-stream')
+PY
+}
+
+abs_path() {
+  python3 <<'PY' "$1"
+import os
+import sys
+
+print(os.path.abspath(sys.argv[1]))
+PY
+}
+
+password_from_env=${VISIONSUIT_PASSWORD:-}
+if [ -n "$password_from_env" ]; then
+  api_password="$password_from_env"
+else
+  read -r -s -p "Password for $server_username: " api_password
+  echo
+fi
+
+if [ -z "${api_password:-}" ]; then
+  log "Password is required to authenticate with VisionSuit."
+  exit 1
+fi
+
+login_payload=$(python3 <<'PY' "$server_username" "$api_password"
+import json
+import sys
+
+email = sys.argv[1]
+password = sys.argv[2]
+print(json.dumps({'email': email, 'password': password}))
+PY
+)
+
+login_body=$(mktemp)
+http_code=$(curl -sS -o "$login_body" -w '%{http_code}' -X POST "$login_url" \
+  -H 'Content-Type: application/json' \
+  -d "$login_payload") || {
+  rm -f "$login_body"
+  log "Login request to VisionSuit API failed."
+  exit 1
+}
+
+if [ "$http_code" != "200" ]; then
+  log "Authentication failed (HTTP $http_code): $(cat "$login_body")"
+  rm -f "$login_body"
+  exit 1
+fi
+
+auth_token=$(python3 <<'PY' "$login_body"
+import json
+import sys
+
+with open(sys.argv[1], 'r', encoding='utf-8') as fh:
+    data = json.load(fh)
+
+token = data.get('token')
+if not token:
+    raise SystemExit('Token not found in login response')
+
+print(token)
+PY
+) || {
+  log "Unable to extract token from VisionSuit login response."
+  rm -f "$login_body"
+  exit 1
+}
+
+rm -f "$login_body"
+
+log "Authenticated as $server_username. Starting bulk upload via VisionSuit API."
+
+upload_count=0
+skip_count=0
+
+while IFS= read -r -d '' lora_file; do
+  base_name=$(basename "$lora_file" ".safetensors")
+  image_folder="$images_dir/$base_name"
+
+  if [ ! -d "$image_folder" ]; then
+    log "Skipping '$base_name' because matching image folder '$image_folder' is missing."
+    skip_count=$((skip_count + 1))
+    continue
+  fi
+
+  mapfile -d '' -t raw_images < <(find "$image_folder" -type f \
+    \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.webp' -o -iname '*.bmp' \) -print0)
+
+  if [ "${#raw_images[@]}" -eq 0 ]; then
+    log "Skipping '$base_name' because no preview-ready images were found."
+    skip_count=$((skip_count + 1))
+    continue
+  fi
+
+  sorted_images=()
+  if [ "${#raw_images[@]}" -gt 0 ]; then
+    while IFS= read -r -d '' path; do
+      sorted_images+=("$path")
+    done < <(printf '%s\0' "${raw_images[@]}" | sort -z)
+  fi
+
+  if [ "${#sorted_images[@]}" -eq 0 ]; then
+    log "Skipping '$base_name' because image sorting failed."
+    skip_count=$((skip_count + 1))
+    continue
+  fi
+
+  preview_index=$((RANDOM % ${#sorted_images[@]}))
+  preview_path="${sorted_images[$preview_index]}"
+
+  other_images=()
+  for img in "${sorted_images[@]}"; do
+    if [ "$img" != "$preview_path" ]; then
+      other_images+=("$img")
+    fi
+  done
+
+  if [ "${#other_images[@]}" -gt 10 ]; then
+    trimmed=$(( ${#other_images[@]} - 10 ))
+    other_images=("${other_images[@]:0:10}")
+    log "Limiting additional images for '$base_name' to 10 due to API file cap (trimmed $trimmed)."
+  fi
+
+  form_args=(
+    -sS
+    -H "Authorization: Bearer $auth_token"
+    --form-string "assetType=lora"
+    --form-string "context=asset"
+    --form-string "title=$base_name"
+    --form-string "visibility=private"
+    --form-string "galleryMode=new"
+    --form-string "targetGallery=$base_name Collection"
+    --form-string "trigger=$base_name"
+  )
+
+  model_mime="application/octet-stream"
+  form_args+=(
+    -F "files=@$(abs_path "$lora_file");type=$model_mime"
+  )
+
+  preview_mime=$(mime_type "$preview_path")
+  form_args+=(
+    -F "files=@$(abs_path "$preview_path");type=$preview_mime"
+  )
+
+  for img in "${other_images[@]}"; do
+    img_mime=$(mime_type "$img")
+    form_args+=(
+      -F "files=@$(abs_path "$img");type=$img_mime"
+    )
+  done
+
+  response_file=$(mktemp)
+  http_code=$(curl "${form_args[@]}" -o "$response_file" -w '%{http_code}' "$upload_url") || {
+    log "Upload request failed for '$base_name'."
+    skip_count=$((skip_count + 1))
+    rm -f "$response_file"
+    continue
+  }
+
+  if [[ "$http_code" =~ ^2 ]]; then
+    log "Uploaded '$base_name' with preview '$(basename "$preview_path")'."
+    upload_count=$((upload_count + 1))
+  else
+    log "Upload failed for '$base_name' (HTTP $http_code): $(cat "$response_file")"
+    skip_count=$((skip_count + 1))
+  fi
+
+  rm -f "$response_file"
+done < <(find "$loras_dir" -maxdepth 1 -type f -name '*.safetensors' -print0)
+
+log "Completed import run: $upload_count uploaded, $skip_count skipped."

--- a/scripts/bulk_import_windows.ps1
+++ b/scripts/bulk_import_windows.ps1
@@ -1,0 +1,189 @@
+#!/usr/bin/env pwsh
+<#!
+.SYNOPSIS
+  VisionSuit bulk import helper for Windows clients.
+.DESCRIPTION
+  Uploads LoRA safetensors and matching preview images to the VisionSuit API.
+  Configure the connection variables below before running the script.
+#>
+
+$ServerIp = "192.168.1.10"
+$ServerUsername = "admin@example.com"
+$ServerPort = 4000
+
+param(
+  [string]$LorasDirectory = "./loras",
+  [string]$ImagesDirectory = "./images"
+)
+
+function Write-Log {
+  param([string]$Message)
+  $timestamp = (Get-Date).ToUniversalTime().ToString("s") + "Z"
+  Write-Host "[$timestamp] $Message"
+}
+
+function Get-PlainPassword {
+  param(
+    [string]$Prompt
+  )
+
+  if ($env:VISIONSUIT_PASSWORD) {
+    return $env:VISIONSUIT_PASSWORD
+  }
+
+  $secure = Read-Host -Prompt $Prompt -AsSecureString
+  if (-not $secure) {
+    return $null
+  }
+
+  $ptr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+  try {
+    return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr)
+  }
+  finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr)
+  }
+}
+
+function Get-MimeType {
+  param([string]$Path)
+
+  switch ([System.IO.Path]::GetExtension($Path).ToLowerInvariant()) {
+    '.png' { return 'image/png' }
+    '.jpg' { return 'image/jpeg' }
+    '.jpeg' { return 'image/jpeg' }
+    '.webp' { return 'image/webp' }
+    '.bmp' { return 'image/bmp' }
+    default { return 'application/octet-stream' }
+  }
+}
+
+if (-not (Test-Path $LorasDirectory)) {
+  Write-Log "LoRA directory '$LorasDirectory' was not found."
+  exit 1
+}
+
+if (-not (Test-Path $ImagesDirectory)) {
+  Write-Log "Image directory '$ImagesDirectory' was not found."
+  exit 1
+}
+
+$password = Get-PlainPassword -Prompt "Password for $ServerUsername"
+if (-not $password) {
+  Write-Log "Password is required to authenticate with VisionSuit."
+  exit 1
+}
+
+$apiBase = "http://$ServerIp`:$ServerPort/api"
+$loginBody = @{ email = $ServerUsername; password = $password } | ConvertTo-Json
+
+try {
+  $loginResponse = Invoke-RestMethod -Method Post -Uri "$apiBase/auth/login" -ContentType 'application/json' -Body $loginBody
+} catch {
+  Write-Log "Login request to VisionSuit API failed: $($_.Exception.Message)"
+  exit 1
+}
+
+if (-not $loginResponse.token) {
+  Write-Log "Authentication failed: $($loginResponse | ConvertTo-Json -Depth 5)"
+  exit 1
+}
+
+$token = $loginResponse.token
+$uploadUri = "$apiBase/uploads"
+
+$handler = [System.Net.Http.HttpClientHandler]::new()
+$httpClient = [System.Net.Http.HttpClient]::new($handler)
+$httpClient.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue('Bearer', $token)
+
+Write-Log "Authenticated as $ServerUsername. Starting bulk upload via VisionSuit API."
+
+$uploadCount = 0
+$skipCount = 0
+
+Get-ChildItem -Path $LorasDirectory -Filter *.safetensors -File | ForEach-Object {
+  $loraFile = $_
+  $baseName = [System.IO.Path]::GetFileNameWithoutExtension($loraFile.Name)
+  $imageFolder = Join-Path $ImagesDirectory $baseName
+
+  if (-not (Test-Path $imageFolder)) {
+    Write-Log "Skipping '$baseName' because matching image folder '$imageFolder' is missing."
+    $skipCount++
+    return
+  }
+
+  $imageFiles = Get-ChildItem -Path $imageFolder -Include *.png,*.jpg,*.jpeg,*.webp,*.bmp -File | Sort-Object FullName
+  if (-not $imageFiles) {
+    Write-Log "Skipping '$baseName' because no preview-ready images were found."
+    $skipCount++
+    return
+  }
+
+  $preview = Get-Random -InputObject $imageFiles
+  $otherImages = $imageFiles | Where-Object { $_.FullName -ne $preview.FullName }
+
+  if ($otherImages.Count -gt 10) {
+    $trimmed = $otherImages.Count - 10
+    $otherImages = $otherImages | Select-Object -First 10
+    Write-Log "Limiting additional images for '$baseName' to 10 due to API file cap (trimmed $trimmed)."
+  }
+
+  $orderedImages = @($preview) + $otherImages
+
+  $form = New-Object System.Net.Http.MultipartFormDataContent
+  $form.Add((New-Object System.Net.Http.StringContent('lora')), 'assetType')
+  $form.Add((New-Object System.Net.Http.StringContent('asset')), 'context')
+  $form.Add((New-Object System.Net.Http.StringContent($baseName)), 'title')
+  $form.Add((New-Object System.Net.Http.StringContent('private')), 'visibility')
+  $form.Add((New-Object System.Net.Http.StringContent('new')), 'galleryMode')
+  $form.Add((New-Object System.Net.Http.StringContent("$baseName Collection")), 'targetGallery')
+  $form.Add((New-Object System.Net.Http.StringContent($baseName)), 'trigger')
+
+  $disposables = @()
+
+  try {
+    $modelStream = [System.IO.File]::OpenRead($loraFile.FullName)
+    $disposables += $modelStream
+    $modelContent = New-Object System.Net.Http.StreamContent($modelStream)
+    $modelContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse('application/octet-stream')
+    $form.Add($modelContent, 'files', $loraFile.Name)
+
+    foreach ($image in $orderedImages) {
+      $imageStream = [System.IO.File]::OpenRead($image.FullName)
+      $disposables += $imageStream
+      $imageContent = New-Object System.Net.Http.StreamContent($imageStream)
+      $mime = Get-MimeType -Path $image.FullName
+      $imageContent.Headers.ContentType = [System.Net.Http.Headers.MediaTypeHeaderValue]::Parse($mime)
+      $form.Add($imageContent, 'files', $image.Name)
+    }
+
+    $response = $httpClient.PostAsync($uploadUri, $form).GetAwaiter().GetResult()
+    $body = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+
+    if ($response.IsSuccessStatusCode) {
+      Write-Log "Uploaded '$baseName' with preview '$($preview.Name)'."
+      $uploadCount++
+    }
+    else {
+      Write-Log "Upload failed for '$baseName' (HTTP $($response.StatusCode)): $body"
+      $skipCount++
+    }
+  }
+  catch {
+    Write-Log "Upload request failed for '$baseName': $($_.Exception.Message)"
+    $skipCount++
+  }
+  finally {
+    foreach ($item in $disposables) {
+      if ($item -is [System.IDisposable]) {
+        $item.Dispose()
+      }
+    }
+    $form.Dispose()
+  }
+}
+
+$httpClient.Dispose()
+$handler.Dispose()
+
+Write-Log "Completed import run: $uploadCount uploaded, $skipCount skipped."


### PR DESCRIPTION
## Summary
- rework the Linux/macOS importer to authenticate with VisionSuit and push LoRA packages via POST /api/uploads
- mirror the same API-driven flow in the Windows PowerShell helper with credential prompts and file-count trimming
- document the new workflow in the README and log the update in the changelog

## Testing
- not run (scripting and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ceb756e900833382fd6c50c65ba437