### PR TITLE
Update frontend document title

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -342,3 +342,8 @@
 - **General**: Reworked the client import tooling to authenticate against VisionSuit and upload LoRAs through the official pipeline instead of SSH transfers.
 - **Technical Changes**: Replaced the staging/manifest workflow with direct `POST /api/uploads` calls in both scripts, added credential prompts and file-cap trimming, refreshed README guidance, and documented password handling.
 - **Data Changes**: None; ingestion now flows through existing upload drafts and storage objects.
+
+## 2025-09-22 – Frontend title alignment (commit TBD)
+- **General**: Updated the browser tab title to reflect the VisionSuit brand instead of the Vite starter text.
+- **Technical Changes**: Changed the HTML document title in `frontend/index.html` to "VisionSuit" for production readiness.
+- **Data Changes**: None.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>VisionSuit</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- set the Vite HTML document title to "VisionSuit" so the tab reflects the product branding
- record the adjustment in the changelog for release tracking

## Testing
- npm run build *(fails: existing TypeScript errors in AdminPanel, AssetExplorer, LoginDialog, UploadWizard, and UserCreationDialog)*

------
https://chatgpt.com/codex/tasks/task_e_68cef4a0fbb08333985a8a39836cfed6