### PR TITLE
Polish service status cards in the sidebar

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -347,3 +347,12 @@
 - **General**: Updated the browser tab title to reflect the VisionSuit brand instead of the Vite starter text.
 - **Technical Changes**: Changed the HTML document title in `frontend/index.html` to "VisionSuit" for production readiness.
 - **Data Changes**: None.
+## 2025-09-23 – Sidebar service status refinement
+- **General**: Elevated the service indicator deck with cohesive glassmorphism cards and contextual badges.
+- **Technical Changes**: Reworked the sidebar status markup with service initials, introduced gradient icon styling and status-aware card accents, refreshed health pill visuals, and updated the README highlight to describe the polished cards.
+- **Data Changes**: None; presentation-only updates for health indicators.
+
+## 2025-09-23 – Sidebar status LED redesign (commit TBD)
+- **General**: Replaced the sidebar service text badges with compact LED indicators that stay visible within the card layout.
+- **Technical Changes**: Updated the service status header markup, introduced dedicated LED styling with accessibility helpers, and refreshed the README highlight to mention the beacons.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 
 ## Core Highlights
 
-- **Unified operations dashboard** – Persistent sidebar navigation with instant switching between Home, Models, and Images, plus live health badges for the front end, API, and MinIO services.
+- **Unified operations dashboard** – Persistent sidebar navigation with instant switching between Home, Models, and Images, plus glassy health cards with color-coded LED beacons for the front end, API, and MinIO services.
 - **Role-aware access control** – JWT-based authentication with session persistence, an admin workspace for user/model/gallery management, a dialog-driven onboarding wizard with role presets, and protected upload flows.
 - **Guided three-step upload wizard** – Collects metadata, files, and review feedback with validation, drag & drop, and live responses from the production-ready `POST /api/uploads` endpoint.
 - **Data-driven explorers** – Fast filters and full-text search across LoRA assets and galleries, complete with tag badges, five-column tiles, and seamless infinite scrolling with active filter indicators.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,12 @@ const statusLabels: Record<ServiceState, string> = {
   unknown: 'Unknown',
 };
 
+const serviceBadgeLabels: Record<ServiceStatusKey, string> = {
+  frontend: 'UI',
+  backend: 'API',
+  minio: 'S3',
+};
+
 const createInitialStatus = (): Record<ServiceStatusKey, ServiceIndicator> => ({
   frontend: { label: 'Frontend', status: 'online', message: 'UI active.' },
   backend: { label: 'Backend', status: 'unknown', message: 'Status check in progress…' },
@@ -544,12 +550,20 @@ export const App = () => {
               {(['frontend', 'backend', 'minio'] as ServiceStatusKey[]).map((key) => {
                 const entry = serviceStatus[key];
                 return (
-                  <li key={key} className="sidebar__status-item">
-                    <div className="sidebar__status-header">
-                      <span>{entry.label}</span>
-                      <span className={`status-pill status-pill--${entry.status}`}>{statusLabels[entry.status]}</span>
+                  <li key={key} className={`sidebar__status-item sidebar__status-item--${entry.status}`}>
+                    <span className={`sidebar__status-icon sidebar__status-icon--${key}`} aria-hidden="true">
+                      {serviceBadgeLabels[key]}
+                    </span>
+                    <div className="sidebar__status-content">
+                      <div className="sidebar__status-header">
+                        <span className="sidebar__status-title">{entry.label}</span>
+                        <span className="status-led-wrapper">
+                          <span className={`status-led status-led--${entry.status}`} aria-hidden="true" />
+                          <span className="visually-hidden">{statusLabels[entry.status]}</span>
+                        </span>
+                      </div>
+                      <p className="sidebar__status-message">{entry.message}</p>
                     </div>
-                    <p>{entry.message}</p>
                   </li>
                 );
               })}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -109,13 +109,13 @@ body {
 .sidebar__status {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.2rem;
 }
 
 .sidebar__status h2 {
   margin: 0;
   font-size: 0.95rem;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: rgba(148, 163, 184, 0.9);
 }
@@ -126,69 +126,185 @@ body {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
 }
 
 .sidebar__status-item {
-  padding: 1rem;
-  border-radius: 14px;
-  background: rgba(15, 23, 42, 0.75);
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.88), rgba(30, 41, 59, 0.78));
   border: 1px solid rgba(59, 130, 246, 0.18);
+  box-shadow: 0 24px 42px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(24px);
+  overflow: hidden;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.sidebar__status-item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 90% 10%, rgba(59, 130, 246, 0.2), transparent 55%);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.sidebar__status-item:hover,
+.sidebar__status-item:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 48px rgba(15, 23, 42, 0.55);
+}
+
+.sidebar__status-item:hover::after,
+.sidebar__status-item:focus-within::after {
+  opacity: 1;
+}
+
+.sidebar__status-item--online {
+  border-color: rgba(34, 197, 94, 0.32);
+  box-shadow: 0 24px 44px rgba(34, 197, 94, 0.16);
+}
+
+.sidebar__status-item--offline {
+  border-color: rgba(248, 113, 113, 0.32);
+  box-shadow: 0 24px 42px rgba(248, 113, 113, 0.18);
+}
+
+.sidebar__status-item--degraded {
+  border-color: rgba(234, 179, 8, 0.32);
+  box-shadow: 0 24px 42px rgba(234, 179, 8, 0.18);
+}
+
+.sidebar__status-item--unknown {
+  border-color: rgba(148, 163, 184, 0.28);
+}
+
+.sidebar__status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 252, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.24), rgba(30, 64, 175, 0.18));
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.45);
+  flex-shrink: 0;
+}
+
+.sidebar__status-icon--frontend {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.38), rgba(14, 165, 233, 0.26));
+  border-color: rgba(96, 165, 250, 0.45);
+  color: rgba(224, 242, 254, 0.96);
+  box-shadow: 0 18px 38px rgba(37, 99, 235, 0.28);
+}
+
+.sidebar__status-icon--backend {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.38), rgba(236, 72, 153, 0.24));
+  border-color: rgba(167, 139, 250, 0.42);
+  color: rgba(250, 245, 255, 0.95);
+  box-shadow: 0 18px 38px rgba(124, 58, 237, 0.28);
+}
+
+.sidebar__status-icon--minio {
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.36), rgba(96, 165, 250, 0.24));
+  border-color: rgba(94, 234, 212, 0.4);
+  color: rgba(236, 253, 245, 0.96);
+  box-shadow: 0 18px 38px rgba(15, 118, 110, 0.28);
+}
+
+.sidebar__status-content {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
 }
 
 .sidebar__status-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  font-weight: 500;
+  gap: 0.5rem;
+}
+
+.sidebar__status-title {
   color: #f8fafc;
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
-.sidebar__status-item p {
+.sidebar__status-message {
   margin: 0;
-  font-size: 0.85rem;
-  color: rgba(203, 213, 225, 0.75);
+  font-size: 0.82rem;
+  color: rgba(226, 232, 240, 0.72);
+  line-height: 1.4;
 }
 
-.status-pill {
+.status-led-wrapper {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 92px;
-  padding: 0.3rem 0.65rem;
+  width: 32px;
+  height: 32px;
   border-radius: 999px;
-  font-size: 0.75rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  border: 1px solid transparent;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.65));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 18px rgba(15, 23, 42, 0.45);
 }
 
-.status-pill--online {
-  background: rgba(34, 197, 94, 0.2);
-  border-color: rgba(34, 197, 94, 0.4);
-  color: rgba(187, 247, 208, 0.95);
+.status-led {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.6);
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.25), 0 0 12px rgba(148, 163, 184, 0.35);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
-.status-pill--offline {
-  background: rgba(248, 113, 113, 0.18);
-  border-color: rgba(248, 113, 113, 0.35);
-  color: rgba(254, 226, 226, 0.92);
+.status-led--online {
+  background: #34d399;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.28), 0 0 16px rgba(34, 197, 94, 0.65),
+    0 0 30px rgba(5, 150, 105, 0.55);
 }
 
-.status-pill--degraded {
-  background: rgba(234, 179, 8, 0.18);
-  border-color: rgba(234, 179, 8, 0.35);
-  color: rgba(254, 243, 199, 0.9);
+.status-led--offline {
+  background: #f87171;
+  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.32), 0 0 16px rgba(248, 113, 113, 0.65),
+    0 0 30px rgba(185, 28, 28, 0.55);
 }
 
-.status-pill--unknown {
-  background: rgba(148, 163, 184, 0.18);
-  border-color: rgba(148, 163, 184, 0.35);
-  color: rgba(226, 232, 240, 0.85);
+.status-led--degraded {
+  background: #facc15;
+  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.32), 0 0 16px rgba(202, 138, 4, 0.6),
+    0 0 30px rgba(202, 138, 4, 0.5);
+}
+
+.status-led--unknown {
+  background: #94a3b8;
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.3), 0 0 16px rgba(148, 163, 184, 0.5),
+    0 0 30px rgba(71, 85, 105, 0.45);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .sidebar__auth {


### PR DESCRIPTION
## Summary
- restyle the service status list with service initials, gradient icons, glassmorphism cards, and compact LED indicators that stay within the sidebar layout
- update the README highlight to mention the polished health cards and log the change in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef5b7cc1c8333b99060311510a197