### PR TITLE
Handle missing gallery data in explorer

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -361,3 +361,8 @@
 - **General**: Enabled curators to edit their own models, galleries, and images directly from the explorers without requiring admin access.
 - **Technical Changes**: Added role-aware edit dialogs for models, images, and collections, refreshed state management in the explorers, expanded styling for new action buttons, and updated README guidance.
 - **Data Changes**: None; updates operate on existing records only.
+
+## 2025-09-23 – Gallery explorer resilience (commit TBD)
+- **General**: Restored the gallery explorer so collections with missing owners or entry arrays render instead of crashing to an empty panel.
+- **Technical Changes**: Added defensive helpers for owner and entry access, updated filters/sorters to use the safe lookups, hardened the detail dialogs, and refreshed README guidance about handling incomplete payloads.
+- **Data Changes**: None; safeguards run entirely on the client.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - Gallery uploads support multi-select (up to 12 files/2 GB), role-aware gallery selection, and on-the-fly gallery creation.
 - Model uploads enforce exactly one safetensor/ZIP archive plus a cover image; additional renders can be attached afterwards from the gallery explorer.
 - Gallery explorer offers a five-column grid with random cover art, consistent tile sizing, and a detail dialog per collection with an EXIF lightbox for every image.
-- Interface remains resilient even when the backend delivers entries without populated metadata, and the metadata card now stretches across the dialog for easier scanning.
+- Interface remains resilient when the backend returns incomplete gallery payloads—missing owners, metadata, or even entry arrays—and the metadata card now stretches across the dialog for easier scanning.
 - Automatic extraction of EXIF, Stable Diffusion prompt data, and safetensor headers populates searchable base-model references and frequency tables for tags.
 - Modelcards include a dedicated Trigger/Activator field that is required during uploads or edits and ships with a click-to-copy shortcut for quick prompting.
 


### PR DESCRIPTION
## Summary
- guard gallery owner and entry access in the explorer so incomplete payloads no longer crash the view
- update README highlights to reflect the hardened gallery handling
- log the resilience work in the project changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf001722fc833385ed6ed0e014ca0a