### PR TITLE
Fix gallery explorer initialization

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -198,7 +198,6 @@
 - **Technical Changes**: Adopted a named `:objectPath(*)` parameter, retained legacy fallback, and updated README endpoint documentation.
 - **Data Changes**: None.
 
-
 ## 2025-09-19 – Model card layout polish (commit TBD)
 - **General**: Smoothed the model card experience by aligning primary actions and tightening the dataset tags table.
 - **Technical Changes**: Converted the preview action stack to a full-width flex column, equalized button typography, and padded the tag frequency table with a fixed layout so headers and rows stay inside the dialog.
@@ -366,3 +365,8 @@
 - **General**: Restored the gallery explorer so collections with missing owners or entry arrays render instead of crashing to an empty panel.
 - **Technical Changes**: Added defensive helpers for owner and entry access, updated filters/sorters to use the safe lookups, hardened the detail dialogs, and refreshed README guidance about handling incomplete payloads.
 - **Data Changes**: None; safeguards run entirely on the client.
+
+## 2025-09-23 – Gallery explorer initialization fix (commit TBD)
+- **General**: Restored the gallery explorer lightbox so collections open without crashing.
+- **Technical Changes**: Moved the active gallery memoization before dependent effects to prevent accessing uninitialized bindings.
+- **Data Changes**: None.

--- a/frontend/src/components/GalleryExplorer.tsx
+++ b/frontend/src/components/GalleryExplorer.tsx
@@ -283,6 +283,29 @@ export const GalleryExplorer = ({
     onCloseDetail?.();
   }, [onCloseDetail]);
 
+  const activeGallery = useMemo(
+    () => (activeGalleryId ? galleries.find((gallery) => gallery.id === activeGalleryId) ?? null : null),
+    [activeGalleryId, galleries],
+  );
+
+  const activeGalleryImages = useMemo(() => (activeGallery ? getImageEntries(activeGallery) : []), [activeGallery]);
+
+  const activeGalleryModels = useMemo(() => {
+    if (!activeGallery) {
+      return [] as ModelAsset[];
+    }
+
+    const map = new Map<string, ModelAsset>();
+    getGalleryEntries(activeGallery).forEach((entry) => {
+      if (entry.modelAsset) {
+        map.set(entry.modelAsset.id, entry.modelAsset);
+      }
+    });
+    return Array.from(map.values());
+  }, [activeGallery]);
+
+  const activeGalleryOwner = useMemo(() => (activeGallery ? getGalleryOwner(activeGallery) : null), [activeGallery]);
+
   useEffect(() => {
     if (activeGalleryId && !galleries.some((gallery) => gallery.id === activeGalleryId)) {
       closeDetail();
@@ -373,29 +396,6 @@ export const GalleryExplorer = ({
   const loadMore = () => {
     setVisibleLimit((current) => Math.min(filteredGalleries.length, current + GALLERY_BATCH_SIZE));
   };
-
-  const activeGallery = useMemo(
-    () => (activeGalleryId ? galleries.find((gallery) => gallery.id === activeGalleryId) ?? null : null),
-    [activeGalleryId, galleries],
-  );
-
-  const activeGalleryImages = useMemo(() => (activeGallery ? getImageEntries(activeGallery) : []), [activeGallery]);
-
-  const activeGalleryModels = useMemo(() => {
-    if (!activeGallery) {
-      return [] as ModelAsset[];
-    }
-
-    const map = new Map<string, ModelAsset>();
-    getGalleryEntries(activeGallery).forEach((entry) => {
-      if (entry.modelAsset) {
-        map.set(entry.modelAsset.id, entry.modelAsset);
-      }
-    });
-    return Array.from(map.values());
-  }, [activeGallery]);
-
-  const activeGalleryOwner = useMemo(() => (activeGallery ? getGalleryOwner(activeGallery) : null), [activeGallery]);
 
   const canManageActiveGallery = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- move the active gallery memoization ahead of dependent effects to avoid runtime ReferenceErrors
- keep gallery explorer state reset logic intact so editing modals close correctly when no gallery is active

## Testing
- `npm run build` *(fails: existing TypeScript errors in unrelated components such as AdminPanel and UploadWizard)*

------
https://chatgpt.com/codex/tasks/task_e_68cf018eb8b883338ededbf48442ce4e