### PR TITLE
Fix gallery image edit dialog layering

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -370,3 +370,8 @@
 - **General**: Restored the gallery explorer lightbox so collections open without crashing.
 - **Technical Changes**: Moved the active gallery memoization before dependent effects to prevent accessing uninitialized bindings.
 - **Data Changes**: None.
+
+## 2025-09-20 – Image edit dialog layering fix
+- **General**: Ensured the image edit dialog surfaces above the lightbox when curators edit a single gallery image.
+- **Technical Changes**: Raised the modal z-index styling in `frontend/src/index.css` so edit dialogs overlay the gallery image modal backdrop.
+- **Data Changes**: None; styling adjustment only.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2852,7 +2852,7 @@ main {
 .edit-dialog {
   position: fixed;
   inset: 0;
-  z-index: 70;
+  z-index: 120;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- ensure the image edit dialog sits above the gallery lightbox by raising the modal z-index
- note the styling adjustment in the changelog entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf02bd11d8833388c82efc03bfb638