### PR TITLE
Adjust image edit dialog layout

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -375,3 +375,8 @@
 - **General**: Ensured the image edit dialog surfaces above the lightbox when curators edit a single gallery image.
 - **Technical Changes**: Raised the modal z-index styling in `frontend/src/index.css` so edit dialogs overlay the gallery image modal backdrop.
 - **Data Changes**: None; styling adjustment only.
+
+## 2025-09-24 – Image metadata layout compaction
+- **General**: Shortened the image metadata edit experience by spreading controls into columns so the dialog stays within the viewport.
+- **Technical Changes**: Widened the image edit dialog container and introduced a responsive three-column grid for metadata fields in `frontend/src/components/ImageAssetEditDialog.tsx` and `frontend/src/index.css`.
+- **Data Changes**: None; purely presentational improvements to existing metadata inputs.

--- a/frontend/src/components/ImageAssetEditDialog.tsx
+++ b/frontend/src/components/ImageAssetEditDialog.tsx
@@ -187,7 +187,7 @@ export const ImageAssetEditDialog = ({
 
   return (
     <div className="edit-dialog" role="dialog" aria-modal="true" aria-labelledby="image-edit-title" onClick={handleBackdropClick}>
-      <div className="edit-dialog__content">
+      <div className="edit-dialog__content edit-dialog__content--wide">
         <header className="edit-dialog__header">
           <h3 id="image-edit-title">Edit image details</h3>
           <button type="button" className="edit-dialog__close" onClick={onClose} disabled={isSubmitting}>
@@ -221,7 +221,7 @@ export const ImageAssetEditDialog = ({
               placeholder="Comma-separated tags"
             />
           </label>
-          <fieldset className="edit-dialog__fieldset">
+          <fieldset className="edit-dialog__fieldset edit-dialog__fieldset--columns">
             <legend>Metadata</legend>
             <label className="edit-dialog__field">
               <span>Seed</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2870,6 +2870,10 @@ main {
   padding: 1.5rem;
 }
 
+.edit-dialog__content--wide {
+  width: min(820px, 95vw);
+}
+
 .model-version-dialog__header,
 .edit-dialog__header {
   display: flex;
@@ -2962,6 +2966,15 @@ main {
   display: grid;
   gap: 0.75rem;
   background: rgba(15, 23, 42, 0.45);
+}
+
+.edit-dialog__fieldset--columns {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: start;
+}
+
+.edit-dialog__fieldset--columns legend {
+  grid-column: 1 / -1;
 }
 
 .edit-dialog__fieldset legend {


### PR DESCRIPTION
## Summary
- widen the image edit dialog container for images to support a compact metadata layout
- organize metadata inputs into a responsive three-column grid to limit dialog height
- document the UI improvement in the project changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf04037d548333a78b61263bc57bae