### PR TITLE
Enable admin management of model versions

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -198,6 +198,11 @@
 - **Technical Changes**: Adopted a named `:objectPath(*)` parameter, retained legacy fallback, and updated README endpoint documentation.
 - **Data Changes**: None.
 
+## 2025-09-19 – Model version hierarchy controls (commit TBD)
+- **General**: Enabled full lifecycle management of secondary model revisions directly from the admin console.
+- **Technical Changes**: Added backend promotion and deletion endpoints, refined primary-version mapping to preserve chronology, exposed new API client helpers, and wired admin UI actions for promoting, renaming, and removing versions with refreshed README guidance.
+- **Data Changes**: None.
+
 ## 2025-09-19 – Model card layout polish (commit TBD)
 - **General**: Smoothed the model card experience by aligning primary actions and tightening the dataset tags table.
 - **Technical Changes**: Converted the preview action stack to a full-width flex column, equalized button typography, and padded the tag frequency table with a fixed layout so headers and rows stay inside the dialog.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - **Role-aware access control** – JWT-based authentication with session persistence, an admin workspace for user/model/gallery management, a dialog-driven onboarding wizard with role presets, and protected upload flows.
 - **Guided three-step upload wizard** – Collects metadata, files, and review feedback with validation, drag & drop, and live responses from the production-ready `POST /api/uploads` endpoint.
 - **Data-driven explorers** – Fast filters and full-text search across LoRA assets and galleries, complete with tag badges, five-column tiles, and seamless infinite scrolling with active filter indicators.
-- **Versioned modelcards** – Dedicated model dialogs with inline descriptions, quick switches between safetensor versions, in-place editing for curators/admins, and an integrated flow for uploading new revisions including preview handling.
+- **Versioned modelcards** – Dedicated model dialogs with inline descriptions, quick switches between safetensor versions, in-place editing for curators/admins, an integrated flow for uploading new revisions including preview handling, and admin tooling to promote or retire revisions.
 - **Governed storage pipeline** – Direct MinIO ingestion with automatic tagging, secure download proxying via the backend, audit trails, and guardrails for file size (≤ 2 GB) and batch limits (≤ 12 files).
 
 ## Good to Know
@@ -16,7 +16,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
 - Home spotlight tiles are fully interactive—click previews to jump straight into the model or gallery explorers, and tap tag chips to filter matching content instantly.
 - Curators can edit their own models, collections, and images directly from the explorers, while administrators continue to see edit controls for every entry.
-- Administration workspace now offers a compact moderation grid across models and images with lazy thumbnails, inline version histories, collapsible edit drawers, persistent bulk tools tuned for six-figure libraries, and a multi-step user onboarding dialog with permission previews.
+- Administration workspace now offers a compact moderation grid across models and images with lazy thumbnails, inline version histories, collapsible edit drawers, persistent bulk tools tuned for six-figure libraries, multi-step user onboarding with permission previews, and one-click actions to promote, rename, or remove secondary model versions.
 - Gallery uploads support multi-select (up to 12 files/2 GB), role-aware gallery selection, and on-the-fly gallery creation.
 - Model uploads enforce exactly one safetensor/ZIP archive plus a cover image; additional renders can be attached afterwards from the gallery explorer.
 - Gallery explorer offers a five-column grid with random cover art, consistent tile sizing, and a detail dialog per collection with an EXIF lightbox for every image.
@@ -198,6 +198,9 @@ Batch uploads validate up to 12 files per request and enforce the 2 GB size ce
 - `POST /api/users/bulk-delete` – Bulk account deletion (admin only).
 - `POST /api/assets/models/bulk-delete` – Bulk removal of models including storage cleanup.
 - `POST /api/assets/models/:id/versions` – Adds safetensor revisions with previews to an existing modelcard.
+- `PUT /api/assets/models/:modelId/versions/:versionId` – Renames an existing model revision.
+- `POST /api/assets/models/:modelId/versions/:versionId/promote` – Promotes a revision to become the primary profile.
+- `DELETE /api/assets/models/:modelId/versions/:versionId` – Removes a secondary revision and associated storage objects.
 - `POST /api/assets/images/bulk-delete` – Bulk removal of gallery images and cover cleanup.
 - `PUT /api/galleries/:id` – Edit gallery metadata, visibility, and ordering.
 - `DELETE /api/galleries/:id` – Delete a gallery (admin or owner permissions).

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -482,6 +482,54 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
     await withStatus(() => api.updateModelAsset(token, model.id, payload), 'Model updated.');
   };
 
+  const handlePromoteModelVersion = async (model: ModelAsset, version: ModelAsset['versions'][number]) => {
+    const label = version.version.trim() || 'this version';
+    if (!window.confirm(`Make ${label} the primary version for ${model.title}?`)) {
+      return;
+    }
+
+    await withStatus(
+      () => api.promoteModelVersion(token, model.id, version.id).then(() => undefined),
+      'Primary version updated.',
+    );
+  };
+
+  const handleRenameModelVersion = async (model: ModelAsset, version: ModelAsset['versions'][number]) => {
+    const original = version.version.trim();
+    const nextLabel = window.prompt('Enter a new label for this version', original);
+
+    if (nextLabel === null) {
+      return;
+    }
+
+    const trimmed = nextLabel.trim();
+    if (trimmed.length === 0) {
+      setStatus({ type: 'error', message: 'Version label cannot be empty.' });
+      return;
+    }
+
+    if (trimmed === original) {
+      return;
+    }
+
+    await withStatus(
+      () => api.updateModelVersion(token, model.id, version.id, { version: trimmed }).then(() => undefined),
+      'Version label updated.',
+    );
+  };
+
+  const handleDeleteModelVersion = async (model: ModelAsset, version: ModelAsset['versions'][number]) => {
+    const label = version.version.trim() || 'this version';
+    if (!window.confirm(`Delete ${label} from ${model.title}?`)) {
+      return;
+    }
+
+    await withStatus(
+      () => api.deleteModelVersion(token, model.id, version.id).then(() => undefined),
+      'Version deleted.',
+    );
+  };
+
   const handleDeleteModel = async (model: ModelAsset) => {
     if (!window.confirm(`Delete model "${model.title}"?`)) {
       return;
@@ -1194,6 +1242,34 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                                       >
                                         Download
                                       </a>
+                                      {version.id !== model.primaryVersionId ? (
+                                        <>
+                                          <button
+                                            type="button"
+                                            className="button button--subtle"
+                                            onClick={() => handlePromoteModelVersion(model, version)}
+                                            disabled={isBusy}
+                                          >
+                                            Make primary
+                                          </button>
+                                          <button
+                                            type="button"
+                                            className="button button--subtle"
+                                            onClick={() => handleRenameModelVersion(model, version)}
+                                            disabled={isBusy}
+                                          >
+                                            Rename
+                                          </button>
+                                          <button
+                                            type="button"
+                                            className="button button--danger"
+                                            onClick={() => handleDeleteModelVersion(model, version)}
+                                            disabled={isBusy}
+                                          >
+                                            Delete
+                                          </button>
+                                        </>
+                                      ) : null}
                                     </div>
                                   </li>
                                 );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -219,6 +219,24 @@ const putModelVersion = async (
   }
 };
 
+const promoteModelVersion = async (token: string, modelId: string, versionId: string) =>
+  request<ModelAsset>(
+    `/api/assets/models/${modelId}/versions/${versionId}/promote`,
+    {
+      method: 'POST',
+    },
+    token,
+  );
+
+const deleteModelVersion = async (token: string, modelId: string, versionId: string) =>
+  request<ModelAsset>(
+    `/api/assets/models/${modelId}/versions/${versionId}`,
+    {
+      method: 'DELETE',
+    },
+    token,
+  );
+
 export const api = {
   getStats: () => request<MetaStats>('/api/meta/stats'),
   getModelAssets: () => request<ModelAsset[]>('/api/assets/models'),
@@ -228,6 +246,8 @@ export const api = {
   createUploadDraft: postUploadDraft,
   createModelVersion: postModelVersion,
   updateModelVersion: putModelVersion,
+  promoteModelVersion,
+  deleteModelVersion,
   login: (email: string, password: string) =>
     request<AuthResponse>('/api/auth/login', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- add backend endpoints to promote and delete model versions while keeping primary metadata accurate
- expose new client helpers and admin UI actions for promoting, renaming, and removing secondary revisions
- document the version hierarchy management updates and record the change in the changelog

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cf05a69be8833391c96f8827b1b9dc