### PR TITLE
Add curator profile view and public profile API

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -385,3 +385,8 @@
 - **General**: Shortened the image metadata edit experience by spreading controls into columns so the dialog stays within the viewport.
 - **Technical Changes**: Widened the image edit dialog container and introduced a responsive three-column grid for metadata fields in `frontend/src/components/ImageAssetEditDialog.tsx` and `frontend/src/index.css`.
 - **Data Changes**: None; purely presentational improvements to existing metadata inputs.
+
+## 2025-09-24 – Curator profile spotlight
+- **General**: Introduced curator profile pages with contribution stats, ranks, and full listings of each curator’s models and collections.
+- **Technical Changes**: Added a public `/api/users/:id/profile` endpoint, new profile view state management, reusable curator link styling, `UserProfile` component, and expanded explorers/admin panels to open profiles.
+- **Data Changes**: None; profile data is derived from existing users, models, galleries, and images.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - **Role-aware access control** – JWT-based authentication with session persistence, an admin workspace for user/model/gallery management, a dialog-driven onboarding wizard with role presets, and protected upload flows.
 - **Guided three-step upload wizard** – Collects metadata, files, and review feedback with validation, drag & drop, and live responses from the production-ready `POST /api/uploads` endpoint.
 - **Data-driven explorers** – Fast filters and full-text search across LoRA assets and galleries, complete with tag badges, five-column tiles, and seamless infinite scrolling with active filter indicators.
+- **Curator spotlight profiles** – Dedicated profile view with avatars, rank progression, bios, and live listings of every model and collection uploaded by the curator, reachable from any curator name across the interface.
 - **Versioned modelcards** – Dedicated model dialogs with inline descriptions, quick switches between safetensor versions, in-place editing for curators/admins, an integrated flow for uploading new revisions including preview handling, and admin tooling to promote or retire revisions.
 - **Governed storage pipeline** – Direct MinIO ingestion with automatic tagging, secure download proxying via the backend, audit trails, and guardrails for file size (≤ 2 GB) and batch limits (≤ 12 files).
 
@@ -23,6 +24,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - Interface remains resilient when the backend returns incomplete gallery payloads—missing owners, metadata, or even entry arrays—and the metadata card now stretches across the dialog for easier scanning.
 - Automatic extraction of EXIF, Stable Diffusion prompt data, and safetensor headers populates searchable base-model references and frequency tables for tags.
 - Modelcards include a dedicated Trigger/Activator field that is required during uploads or edits and ships with a click-to-copy shortcut for quick prompting.
+- Click any curator name—from home cards to explorer panels and admin lists—to jump straight into the curator’s profile with contribution stats and navigation back to their models or collections.
 
 ## Community Roadmap
 

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -72,6 +72,7 @@ interface AdminPanelProps {
   galleries: Gallery[];
   token: string;
   onRefresh: () => Promise<void>;
+  onOpenProfile?: (userId: string) => void;
 }
 
 type AdminTab = 'users' | 'models' | 'images' | 'galleries';
@@ -168,7 +169,7 @@ const truncateText = (value: string, limit = 160) => {
   return `${value.slice(0, limit - 1).trimEnd()}…`;
 };
 
-export const AdminPanel = ({ users, models, images, galleries, token, onRefresh }: AdminPanelProps) => {
+export const AdminPanel = ({ users, models, images, galleries, token, onRefresh, onOpenProfile }: AdminPanelProps) => {
   const [activeTab, setActiveTab] = useState<AdminTab>('users');
   const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [isBusy, setIsBusy] = useState(false);
@@ -1118,7 +1119,20 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                             </label>
                             <div className="admin-model-card__titles">
                               <h4>{model.title}</h4>
-                              <span className="admin-model-card__subtitle">by {model.owner.displayName}</span>
+                              <span className="admin-model-card__subtitle">
+                                by{' '}
+                                {onOpenProfile ? (
+                                  <button
+                                    type="button"
+                                    className="curator-link"
+                                    onClick={() => onOpenProfile(model.owner.id)}
+                                  >
+                                    {model.owner.displayName}
+                                  </button>
+                                ) : (
+                                  model.owner.displayName
+                                )}
+                              </span>
                             </div>
                             <div className="admin-model-card__meta">
                               <span className="admin-badge">{model.version}</span>
@@ -1458,7 +1472,20 @@ export const AdminPanel = ({ users, models, images, galleries, token, onRefresh 
                             </label>
                             <div className="admin-image-card__titles">
                               <h4>{image.title}</h4>
-                              <span className="admin-image-card__subtitle">by {image.owner.displayName}</span>
+                              <span className="admin-image-card__subtitle">
+                                by{' '}
+                                {onOpenProfile ? (
+                                  <button
+                                    type="button"
+                                    className="curator-link"
+                                    onClick={() => onOpenProfile(image.owner.id)}
+                                  >
+                                    {image.owner.displayName}
+                                  </button>
+                                ) : (
+                                  image.owner.displayName
+                                )}
+                              </span>
                             </div>
                             <div className="admin-image-card__meta">
                               <span className="admin-badge admin-badge--muted">{updatedLabel}</span>

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -1,0 +1,326 @@
+import { useMemo } from 'react';
+
+import { resolveStorageUrl } from '../lib/storage';
+import type {
+  UserProfile as UserProfileResponse,
+  UserProfileGallerySummary,
+  UserProfileModelSummary,
+} from '../types/api';
+
+interface UserProfileProps {
+  profile: UserProfileResponse | null;
+  isLoading: boolean;
+  error?: string | null;
+  onBack?: () => void;
+  onRetry?: () => void;
+  onOpenModel?: (modelId: string) => void;
+  onOpenGallery?: (galleryId: string) => void;
+}
+
+const formatDate = (value: string) => {
+  try {
+    return new Intl.DateTimeFormat('en', { dateStyle: 'medium' }).format(new Date(value));
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn('Failed to format date', error);
+    }
+    return value;
+  }
+};
+
+const formatRole = (role: UserProfileResponse['role']) => (role === 'ADMIN' ? 'Administrator' : 'Curator');
+
+const getInitials = (name: string) => {
+  const parts = name.trim().split(/\s+/).slice(0, 2);
+  if (parts.length === 0) {
+    return '?';
+  }
+  return parts
+    .map((part) => part.charAt(0).toUpperCase())
+    .join('');
+};
+
+const renderModelCard = (
+  model: UserProfileModelSummary,
+  onOpenModel?: (modelId: string) => void,
+) => {
+  const previewUrl = resolveStorageUrl(model.previewImage, model.previewImageBucket, model.previewImageObject) ?? model.previewImage ?? undefined;
+  const tagList = model.tags.slice(0, 4);
+  const remainingTags = model.tags.length - tagList.length;
+
+  if (!onOpenModel) {
+    return (
+      <article key={model.id} className="profile-view__model-card">
+        <div className={`profile-view__model-media${previewUrl ? '' : ' profile-view__model-media--empty'}`}>
+          {previewUrl ? <img src={previewUrl} alt={model.title} loading="lazy" /> : <span>No preview</span>}
+        </div>
+        <div className="profile-view__model-body">
+          <h3>{model.title}</h3>
+          <p>Version {model.version}</p>
+          <p className="profile-view__model-updated">Updated {formatDate(model.updatedAt)}</p>
+          {tagList.length > 0 ? (
+            <ul className="profile-view__tag-list">
+              {tagList.map((tag) => (
+                <li key={tag.id}>#{tag.label}</li>
+              ))}
+              {remainingTags > 0 ? <li className="profile-view__tag-more">+{remainingTags}</li> : null}
+            </ul>
+          ) : (
+            <p className="profile-view__tag-empty">No tags assigned yet.</p>
+          )}
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <button
+      key={model.id}
+      type="button"
+      className="profile-view__model-card profile-view__model-card--interactive"
+      onClick={() => onOpenModel(model.id)}
+      aria-label={`Open ${model.title} in the model explorer`}
+    >
+      <div className={`profile-view__model-media${previewUrl ? '' : ' profile-view__model-media--empty'}`}>
+        {previewUrl ? <img src={previewUrl} alt={model.title} loading="lazy" /> : <span>No preview</span>}
+      </div>
+      <div className="profile-view__model-body">
+        <h3>{model.title}</h3>
+        <p>Version {model.version}</p>
+        <p className="profile-view__model-updated">Updated {formatDate(model.updatedAt)}</p>
+        {tagList.length > 0 ? (
+          <ul className="profile-view__tag-list">
+            {tagList.map((tag) => (
+              <li key={tag.id}>#{tag.label}</li>
+            ))}
+            {remainingTags > 0 ? <li className="profile-view__tag-more">+{remainingTags}</li> : null}
+          </ul>
+        ) : (
+          <p className="profile-view__tag-empty">No tags assigned yet.</p>
+        )}
+      </div>
+    </button>
+  );
+};
+
+const renderGalleryCard = (
+  gallery: UserProfileGallerySummary,
+  onOpenGallery?: (galleryId: string) => void,
+) => {
+  const coverUrl = resolveStorageUrl(gallery.coverImage, gallery.coverImageBucket, gallery.coverImageObject) ?? gallery.coverImage ?? undefined;
+  const entryLabel = gallery.stats.entryCount === 1 ? 'Entry' : 'Entries';
+
+  if (!onOpenGallery) {
+    return (
+      <article key={gallery.id} className="profile-view__gallery-card">
+        <div className={`profile-view__gallery-media${coverUrl ? '' : ' profile-view__gallery-media--empty'}`}>
+          {coverUrl ? <img src={coverUrl} alt={gallery.title} loading="lazy" /> : <span>No cover</span>}
+        </div>
+        <div className="profile-view__gallery-body">
+          <div className="profile-view__gallery-header">
+            <h3>{gallery.title}</h3>
+            <span className={`profile-view__gallery-badge${gallery.isPublic ? ' profile-view__gallery-badge--public' : ''}`}>
+              {gallery.isPublic ? 'Public' : 'Private'}
+            </span>
+          </div>
+          {gallery.description ? (
+            <p className="profile-view__gallery-description">{gallery.description}</p>
+          ) : (
+            <p className="profile-view__gallery-description profile-view__gallery-description--muted">
+              No description yet.
+            </p>
+          )}
+          <dl className="profile-view__gallery-stats">
+            <div>
+              <dt>{entryLabel}</dt>
+              <dd>{gallery.stats.entryCount}</dd>
+            </div>
+            <div>
+              <dt>Images</dt>
+              <dd>{gallery.stats.imageCount}</dd>
+            </div>
+            <div>
+              <dt>LoRAs</dt>
+              <dd>{gallery.stats.modelCount}</dd>
+            </div>
+          </dl>
+          <p className="profile-view__gallery-updated">Updated {formatDate(gallery.updatedAt)}</p>
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <button
+      key={gallery.id}
+      type="button"
+      className="profile-view__gallery-card profile-view__gallery-card--interactive"
+      onClick={() => onOpenGallery(gallery.id)}
+      aria-label={`Open ${gallery.title} in the gallery explorer`}
+    >
+      <div className={`profile-view__gallery-media${coverUrl ? '' : ' profile-view__gallery-media--empty'}`}>
+        {coverUrl ? <img src={coverUrl} alt={gallery.title} loading="lazy" /> : <span>No cover</span>}
+      </div>
+      <div className="profile-view__gallery-body">
+        <div className="profile-view__gallery-header">
+          <h3>{gallery.title}</h3>
+          <span className={`profile-view__gallery-badge${gallery.isPublic ? ' profile-view__gallery-badge--public' : ''}`}>
+            {gallery.isPublic ? 'Public' : 'Private'}
+          </span>
+        </div>
+        {gallery.description ? (
+          <p className="profile-view__gallery-description">{gallery.description}</p>
+        ) : (
+          <p className="profile-view__gallery-description profile-view__gallery-description--muted">
+            No description yet.
+          </p>
+        )}
+        <dl className="profile-view__gallery-stats">
+          <div>
+            <dt>{entryLabel}</dt>
+            <dd>{gallery.stats.entryCount}</dd>
+          </div>
+          <div>
+            <dt>Images</dt>
+            <dd>{gallery.stats.imageCount}</dd>
+          </div>
+          <div>
+            <dt>LoRAs</dt>
+            <dd>{gallery.stats.modelCount}</dd>
+          </div>
+        </dl>
+        <p className="profile-view__gallery-updated">Updated {formatDate(gallery.updatedAt)}</p>
+      </div>
+    </button>
+  );
+};
+
+export const UserProfile = ({
+  profile,
+  isLoading,
+  error,
+  onBack,
+  onRetry,
+  onOpenModel,
+  onOpenGallery,
+}: UserProfileProps) => {
+  const avatarUrl = profile?.avatarUrl ?? null;
+  const initials = profile ? getInitials(profile.displayName) : '?';
+  const nextRankDescription = useMemo(() => {
+    if (!profile) return null;
+    if (!profile.rank.nextLabel || profile.rank.nextScore == null) {
+      return null;
+    }
+    const remaining = profile.rank.nextScore - profile.rank.score;
+    if (remaining <= 0) {
+      return `Already eligible for ${profile.rank.nextLabel}.`;
+    }
+    return `${remaining} contribution point${remaining === 1 ? '' : 's'} to reach ${profile.rank.nextLabel}.`;
+  }, [profile]);
+
+  return (
+    <section className="profile-view">
+      <header className="profile-view__header">
+        <div className="profile-view__header-main">
+          <div className={`profile-view__avatar${avatarUrl ? '' : ' profile-view__avatar--placeholder'}`}>
+            {avatarUrl ? <img src={avatarUrl} alt={`${profile?.displayName ?? 'Curator'} avatar`} /> : <span>{initials}</span>}
+          </div>
+          <div className="profile-view__identity">
+            <div className="profile-view__identity-row">
+              <h2 className="profile-view__name">{profile?.displayName ?? 'Curator'}</h2>
+              {profile ? <span className="profile-view__rank-badge">{profile.rank.label}</span> : null}
+            </div>
+            {profile ? <p className="profile-view__rank-description">{profile.rank.description}</p> : null}
+            <dl className="profile-view__meta">
+              <div>
+                <dt>Role</dt>
+                <dd>{profile ? formatRole(profile.role) : 'Curator'}</dd>
+              </div>
+              <div>
+                <dt>Joined</dt>
+                <dd>{profile ? formatDate(profile.joinedAt) : '—'}</dd>
+              </div>
+              <div>
+                <dt>Score</dt>
+                <dd>{profile ? profile.rank.score : '—'}</dd>
+              </div>
+            </dl>
+            {nextRankDescription ? <p className="profile-view__rank-progress">{nextRankDescription}</p> : null}
+          </div>
+        </div>
+        <div className="profile-view__header-actions">
+          {onRetry ? (
+            <button type="button" className="profile-view__action" onClick={onRetry} disabled={isLoading}>
+              Refresh profile
+            </button>
+          ) : null}
+          {onBack ? (
+            <button type="button" className="profile-view__action profile-view__action--primary" onClick={onBack}>
+              Back
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      {isLoading && !profile ? <div className="profile-view__status">Loading profile…</div> : null}
+      {error ? <div className="profile-view__error">{error}</div> : null}
+
+      {profile ? (
+        <>
+          <section className="profile-view__section">
+            <h3>About</h3>
+            {profile.bio ? (
+              <p className="profile-view__bio">{profile.bio}</p>
+            ) : (
+              <p className="profile-view__bio profile-view__bio--muted">This curator has not written a bio yet.</p>
+            )}
+          </section>
+
+          <section className="profile-view__section profile-view__section--stats" aria-label="Contribution stats">
+            <div>
+              <span className="profile-view__stat-value">{profile.stats.modelCount}</span>
+              <span className="profile-view__stat-label">Models</span>
+            </div>
+            <div>
+              <span className="profile-view__stat-value">{profile.stats.galleryCount}</span>
+              <span className="profile-view__stat-label">Collections</span>
+            </div>
+            <div>
+              <span className="profile-view__stat-value">{profile.stats.imageCount}</span>
+              <span className="profile-view__stat-label">Images</span>
+            </div>
+          </section>
+
+          <section className="profile-view__section">
+            <div className="profile-view__section-heading">
+              <h3>Uploaded models</h3>
+              <span className="profile-view__section-count">{profile.models.length}</span>
+            </div>
+            {profile.models.length > 0 ? (
+              <div className="profile-view__model-grid" role="list">
+                {profile.models.map((model) => renderModelCard(model, onOpenModel))}
+              </div>
+            ) : (
+              <p className="profile-view__empty">No models uploaded yet.</p>
+            )}
+          </section>
+
+          <section className="profile-view__section">
+            <div className="profile-view__section-heading">
+              <h3>Collections</h3>
+              <span className="profile-view__section-count">{profile.galleries.length}</span>
+            </div>
+            {profile.galleries.length > 0 ? (
+              <div className="profile-view__gallery-grid" role="list">
+                {profile.galleries.map((gallery) => renderGalleryCard(gallery, onOpenGallery))}
+              </div>
+            ) : (
+              <p className="profile-view__empty">No collections curated yet.</p>
+            )}
+          </section>
+        </>
+      ) : null}
+    </section>
+  );
+};
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6104,3 +6104,486 @@ button {
     padding: 1.5rem;
   }
 }
+
+/* Curator profile view */
+.curator-link {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: #93c5fd;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.curator-link:hover,
+.curator-link:focus-visible {
+  color: #bfdbfe;
+  text-decoration: underline;
+}
+
+.curator-link:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.55);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.profile-view {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.profile-view__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.6rem 2rem;
+  border-radius: 26px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.7));
+  box-shadow: 0 26px 60px rgba(2, 6, 23, 0.35);
+}
+
+.profile-view__header-main {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.profile-view__avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 24px;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: #bfdbfe;
+  font-size: 1.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.profile-view__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.profile-view__avatar--placeholder {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(59, 130, 246, 0.15));
+}
+
+.profile-view__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.profile-view__identity-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.profile-view__name {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.profile-view__rank-badge {
+  border-radius: 999px;
+  border: 1px solid rgba(165, 180, 252, 0.35);
+  padding: 0.3rem 0.85rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #c7d2fe;
+  background: rgba(79, 70, 229, 0.25);
+}
+
+.profile-view__rank-description {
+  margin: 0;
+  font-size: 0.92rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.profile-view__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+.profile-view__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 80px;
+}
+
+.profile-view__meta dt {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.profile-view__meta dd {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.profile-view__rank-progress {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.profile-view__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.profile-view__action {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.55);
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.6rem 1.4rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.profile-view__action:hover,
+.profile-view__action:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(226, 232, 240, 0.55);
+  color: #ffffff;
+}
+
+.profile-view__action--primary {
+  border-color: rgba(99, 102, 241, 0.6);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(99, 102, 241, 0.35));
+  color: #c7d2fe;
+}
+
+.profile-view__action--primary:hover,
+.profile-view__action--primary:focus-visible {
+  border-color: rgba(165, 180, 252, 0.85);
+  color: #ffffff;
+}
+
+.profile-view__status {
+  padding: 1rem 1.4rem;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.profile-view__error {
+  padding: 1rem 1.4rem;
+  border-radius: 20px;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+}
+
+.profile-view__section {
+  padding: 1.5rem;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 24px 50px rgba(2, 6, 23, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-view__section h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.profile-view__bio {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.profile-view__bio--muted {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.profile-view__section--stats {
+  flex-direction: row;
+  justify-content: space-around;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.profile-view__section--stats > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-view__stat-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.profile-view__stat-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.profile-view__section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.profile-view__section-count {
+  border-radius: 999px;
+  padding: 0.25rem 0.8rem;
+  font-size: 0.75rem;
+  background: rgba(59, 130, 246, 0.2);
+  color: #bfdbfe;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+.profile-view__model-grid,
+.profile-view__gallery-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.profile-view__model-card,
+.profile-view__gallery-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1.1rem;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.72);
+  text-align: left;
+  color: inherit;
+}
+
+.profile-view__model-card--interactive,
+.profile-view__gallery-card--interactive {
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-view__model-card--interactive:hover,
+.profile-view__model-card--interactive:focus-visible,
+.profile-view__gallery-card--interactive:hover,
+.profile-view__gallery-card--interactive:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(96, 165, 250, 0.45);
+  box-shadow: 0 24px 55px rgba(30, 64, 175, 0.35);
+}
+
+.profile-view__model-media,
+.profile-view__gallery-media {
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  min-height: 140px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.profile-view__model-media img,
+.profile-view__gallery-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.profile-view__model-media--empty,
+.profile-view__gallery-media--empty {
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.profile-view__model-body,
+.profile-view__gallery-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile-view__model-body h3,
+.profile-view__gallery-body h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.profile-view__model-body p,
+.profile-view__gallery-body p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.profile-view__model-updated,
+.profile-view__gallery-updated {
+  font-size: 0.78rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.profile-view__tag-list {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  list-style: none;
+}
+
+.profile-view__tag-list li {
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+  background: rgba(59, 130, 246, 0.15);
+  color: #bfdbfe;
+  font-size: 0.75rem;
+}
+
+.profile-view__tag-more {
+  background: rgba(148, 163, 184, 0.2);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.profile-view__tag-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.profile-view__gallery-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.profile-view__gallery-badge {
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.profile-view__gallery-badge--public {
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #bbf7d0;
+  background: rgba(22, 163, 74, 0.18);
+}
+
+.profile-view__gallery-description {
+  margin: 0;
+  font-size: 0.88rem;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.5;
+}
+
+.profile-view__gallery-description--muted {
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.profile-view__gallery-stats {
+  display: flex;
+  gap: 1.2rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.profile-view__gallery-stats div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-view__gallery-stats dt {
+  margin: 0;
+  font-weight: 600;
+}
+
+.profile-view__gallery-stats dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.profile-view__empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+@media (max-width: 720px) {
+  .profile-view__section--stats {
+    flex-direction: column;
+    text-align: left;
+    align-items: flex-start;
+  }
+
+  .profile-view__header {
+    padding: 1.2rem 1.4rem;
+  }
+
+  .profile-view__avatar {
+    width: 80px;
+    height: 80px;
+  }
+}
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   MetaStats,
   ModelAsset,
   ServiceStatusResponse,
+  UserProfile,
   User,
 } from '../types/api';
 
@@ -254,6 +255,7 @@ export const api = {
       body: JSON.stringify({ email, password }),
     }),
   getCurrentUser: (token: string) => request<{ user: User }>('/api/auth/me', {}, token),
+  getUserProfile: (userId: string) => request<{ profile: UserProfile }>(`/api/users/${userId}/profile`),
   getUsers: (token: string) => request<{ users: User[] }>('/api/users', {}, token),
   createUser: (token: string, payload: { email: string; displayName: string; password: string; role: string; bio?: string }) =>
     request<{ user: User }>(

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -19,6 +19,64 @@ export interface User {
   updatedAt?: string;
 }
 
+export interface UserProfileRank {
+  label: string;
+  description: string;
+  minimumScore: number;
+  nextLabel: string | null;
+  nextScore: number | null;
+  score: number;
+}
+
+export interface UserProfileModelSummary {
+  id: string;
+  title: string;
+  slug: string;
+  version: string;
+  description?: string | null;
+  previewImage?: string | null;
+  previewImageBucket?: string | null;
+  previewImageObject?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  tags: Tag[];
+}
+
+export interface UserProfileGallerySummary {
+  id: string;
+  title: string;
+  slug: string;
+  description?: string | null;
+  isPublic: boolean;
+  coverImage?: string | null;
+  coverImageBucket?: string | null;
+  coverImageObject?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  stats: {
+    entryCount: number;
+    imageCount: number;
+    modelCount: number;
+  };
+}
+
+export interface UserProfile {
+  id: string;
+  displayName: string;
+  bio: string | null;
+  avatarUrl: string | null;
+  role: UserRole;
+  joinedAt: string;
+  rank: UserProfileRank;
+  stats: {
+    modelCount: number;
+    galleryCount: number;
+    imageCount: number;
+  };
+  models: UserProfileModelSummary[];
+  galleries: UserProfileGallerySummary[];
+}
+
 export interface ModelVersion {
   id: string;
   version: string;


### PR DESCRIPTION
## Summary
- add a public `/api/users/:id/profile` endpoint that maps user contributions, preview URLs, and computed ranks
- introduce a curator profile view with the `UserProfile` component and wire clickable curator names across home, explorers, and the admin panel
- style the new profile surface, expose curator links, and document the feature in the README and changelog

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cf0a9bd4ec83338347b8f1d4d2277a