### PR TITLE
Fix primary view initialization for App

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -395,3 +395,8 @@
 - **General**: Restored both model and gallery uploads by ensuring each wizard mode automatically supplies the correct asset type to the API.
 - **Technical Changes**: Renamed the upload wizard form state to `assetType`, adjusted validations, review summaries, and submission payloads to use the field, and forwarded the computed type to `createUploadDraft` so the backend receives `lora` or `image` as expected.
 - **Data Changes**: None; fixes adjust client-side form wiring only.
+
+## 2025-09-24 – Primary view initialization guard
+- **General**: Fixed the blank screen on startup by ensuring the primary view navigation helper initializes before any effects run.
+- **Technical Changes**: Moved the `openPrimaryView` callback above dependent effects in `frontend/src/App.tsx` so React doesn’t hit the temporal dead zone when guarding the admin view.
+- **Data Changes**: None; state management only.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,6 +100,14 @@ export const App = () => {
     return views;
   }, [authUser?.role]);
 
+  const openPrimaryView = useCallback((view: PrimaryViewKey) => {
+    setReturnView(view);
+    setActiveProfileId(null);
+    setActiveProfile(null);
+    setProfileError(null);
+    setActiveView(view);
+  }, []);
+
   const fetchServiceStatus = useCallback(async () => {
     try {
       const status = await api.getServiceStatus();
@@ -312,14 +320,6 @@ export const App = () => {
     }
     setIsGalleryUploadOpen(true);
   };
-
-  const openPrimaryView = useCallback((view: PrimaryViewKey) => {
-    setReturnView(view);
-    setActiveProfileId(null);
-    setActiveProfile(null);
-    setProfileError(null);
-    setActiveView(view);
-  }, []);
 
   const handleNavigateToGallery = (galleryId: string) => {
     setFocusedGalleryId(galleryId);


### PR DESCRIPTION
## Summary
- move the openPrimaryView callback ahead of effects that depend on it so the app boots without runtime errors
- document the fix in the changelog entry for 2025-09-24

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf11b6bca88333a7e486ef9d5e1677