### PR TITLE
Add secure avatar uploads

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -198,6 +198,11 @@
 - **Technical Changes**: Adopted a named `:objectPath(*)` parameter, retained legacy fallback, and updated README endpoint documentation.
 - **Data Changes**: None.
 
+## 2025-09-20 – Avatar upload pipeline (commit TBD)
+- **General**: Enabled secure on-platform avatar uploads with built-in validation and MinIO-backed delivery.
+- **Technical Changes**: Added the `/api/users/:id/avatar` endpoint with strict MIME checks and size guards, updated auth user serialization, wired the React account settings dialog and API client for file uploads, and refreshed styles plus documentation.
+- **Data Changes**: Stores uploaded avatars in the image bucket under user-specific prefixes; database schema unchanged.
+
 ## 2025-09-19 – Model version hierarchy controls (commit TBD)
 - **General**: Enabled full lifecycle management of secondary model revisions directly from the admin console.
 - **Technical Changes**: Added backend promotion and deletion endpoints, refined primary-version mapping to preserve chronology, exposed new API client helpers, and wired admin UI actions for promoting, renaming, and removing versions with refreshed README guidance.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 
 - **Unified operations dashboard** – Persistent sidebar navigation with instant switching between Home, Models, and Images, plus glassy health cards with color-coded LED beacons for the front end, API, and MinIO services.
 - **Role-aware access control** – JWT-based authentication with session persistence, an admin workspace for user/model/gallery management, a dialog-driven onboarding wizard with role presets, and protected upload flows.
-- **Self-service account management** – Sidebar account settings let curators update their display name, bio, avatar, and password without waiting for admin intervention.
+- **Self-service account management** – Sidebar account settings let curators update their display name, bio, and password and now support direct avatar uploads (PNG/JPG/WebP ≤ 5 MB) alongside external image links.
 - **Guided three-step upload wizard** – Collects metadata, files, and review feedback with validation, drag & drop, and live responses from the production-ready `POST /api/uploads` endpoint.
 - **Data-driven explorers** – Fast filters and full-text search across LoRA assets and galleries, complete with tag badges, five-column tiles, and seamless infinite scrolling with active filter indicators.
 - **Curator spotlight profiles** – Dedicated profile view with avatars, rank progression, bios, and live listings of every model and collection uploaded by the curator, reachable from any curator name across the interface.
@@ -198,6 +198,7 @@ Batch uploads validate up to 12 files per request and enforce the 2 GB size ce
 - `GET /api/users` – Admin-only listing of accounts.
 - `POST /api/users` – Admin-only account provisioning.
 - `PUT /api/users/:id` – Admin-only account maintenance, deactivation, and role changes.
+- `POST /api/users/:id/avatar` – Uploads a curator avatar (PNG/JPG/WebP up to 5 MB, GIFs rejected) and returns the refreshed profile payload.
 - `PUT /api/users/:id/profile` – Update a curator’s display name, bio, or avatar (self-service or admin override).
 - `PUT /api/users/:id/password` – Change a password after verifying the current credential (self-service or admin override).
 - `DELETE /api/users/:id` – Admin-only user removal (no self-delete).

--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -3,6 +3,7 @@ import jwt, { type Secret, type SignOptions } from 'jsonwebtoken';
 import type { User, UserRole } from '@prisma/client';
 
 import { appConfig } from '../config';
+import { resolveStorageLocation } from './storage';
 
 export interface AuthTokenPayload {
   sub: string;
@@ -48,11 +49,15 @@ export const verifyAccessToken = (token: string): AuthTokenPayload => {
   return { sub, role, displayName, email };
 };
 
-export const toAuthUser = (user: Pick<User, 'id' | 'email' | 'displayName' | 'role' | 'bio' | 'avatarUrl'>): AuthenticatedUser => ({
-  id: user.id,
-  email: user.email,
-  displayName: user.displayName,
-  role: user.role,
-  bio: user.bio,
-  avatarUrl: user.avatarUrl,
-});
+export const toAuthUser = (user: Pick<User, 'id' | 'email' | 'displayName' | 'role' | 'bio' | 'avatarUrl'>): AuthenticatedUser => {
+  const avatar = resolveStorageLocation(user.avatarUrl ?? undefined);
+
+  return {
+    id: user.id,
+    email: user.email,
+    displayName: user.displayName,
+    role: user.role,
+    bio: user.bio,
+    avatarUrl: avatar.url ?? user.avatarUrl ?? null,
+  };
+};

--- a/backend/src/lib/uploadLimits.ts
+++ b/backend/src/lib/uploadLimits.ts
@@ -1,2 +1,3 @@
 export const MAX_UPLOAD_FILES = 12;
 export const MAX_TOTAL_SIZE_BYTES = 2_147_483_648; // 2 GB
+export const MAX_AVATAR_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1037,6 +1037,12 @@ body {
   color: rgba(248, 113, 113, 0.9);
 }
 
+.account-settings__hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
 .account-settings__actions {
   margin-top: 0.5rem;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -288,6 +288,19 @@ export const api = {
       },
       token,
     ),
+  uploadAvatar: (token: string, id: string, file: File) => {
+    const formData = new FormData();
+    formData.append('avatar', file, file.name);
+
+    return request<{ user: User }>(
+      `/api/users/${id}/avatar`,
+      {
+        method: 'POST',
+        body: formData,
+      },
+      token,
+    );
+  },
   changePassword: (
     token: string,
     id: string,


### PR DESCRIPTION
## Summary
- add a protected `/api/users/:id/avatar` endpoint that validates image uploads, pushes them to MinIO, and surfaces resolved URLs in auth payloads
- extend the account settings dialog with direct avatar upload controls, client-side guards, and refreshed styling/docs
- document the new capability and changelog entry including the 5 MB limit and disallowed GIFs

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cf19ab0ab883338d438c400878a912