### PR TITLE
Guard ModelVersion migration against duplicates

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -440,3 +440,8 @@
 - **General**: Locked down private models, images, and collections so they’re only visible to their owners, while giving administrators an explicit Audit switch on curator profiles to moderate hidden uploads on demand.
 - **Technical Changes**: Added optional auth middleware, Prisma `isPublic` flags for models and images, request-level filtering across asset and gallery endpoints, profile visibility signalling, audit-aware gallery serialization, and refreshed the React profile view with an Audit control, privacy notices, and private badges.
 - **Data Changes**: Introduced a Prisma migration that persists the new `isPublic` columns for `ModelAsset` and `ImageAsset` records.
+
+## 090 – Model version migration guard
+- **General**: Unblocked local migrations by ensuring the new model version table setup skips recreating already-provisioned structures.
+- **Technical Changes**: Updated the `add_asset_visibility` Prisma migration to conditionally create the `ModelVersion` table and associated indexes when they are missing.
+- **Data Changes**: None; existing `ModelVersion` rows remain untouched.

--- a/backend/prisma/migrations/20250921091425_add_asset_visibility/migration.sql
+++ b/backend/prisma/migrations/20250921091425_add_asset_visibility/migration.sql
@@ -1,5 +1,5 @@
--- CreateTable
-CREATE TABLE "ModelVersion" (
+-- Guarded create to avoid conflicts if the table was provisioned manually
+CREATE TABLE IF NOT EXISTS "ModelVersion" (
     "id" TEXT NOT NULL PRIMARY KEY,
     "modelId" TEXT NOT NULL,
     "version" TEXT NOT NULL,
@@ -104,8 +104,7 @@ ALTER TABLE "new_UserRankingState" RENAME TO "UserRankingState";
 PRAGMA foreign_keys=ON;
 PRAGMA defer_foreign_keys=OFF;
 
--- CreateIndex
-CREATE UNIQUE INDEX "ModelVersion_storagePath_key" ON "ModelVersion"("storagePath");
+CREATE UNIQUE INDEX IF NOT EXISTS "ModelVersion_storagePath_key" ON "ModelVersion"("storagePath");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "ModelVersion_modelId_version_key" ON "ModelVersion"("modelId", "version");
+CREATE UNIQUE INDEX IF NOT EXISTS "ModelVersion_modelId_version_key" ON "ModelVersion"("modelId", "version");


### PR DESCRIPTION
## Summary
- ensure the `add_asset_visibility` migration skips recreating the `ModelVersion` table when it already exists
- guard the accompanying unique indexes and document the fix in changelog entry 090

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfca0106a4833396d3045b056285ae