### PR TITLE
Finalize curator asset management

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -158,6 +158,11 @@
 - **Technical Changes**: Made metadata fields optional in types, guarded lightbox and card rendering with optional chaining, and documented the resilience improvement.
 - **Data Changes**: None.
 
+## 033 – Curator asset lifecycle tools
+- **General**: Empowered curators and admins to fully manage models, collections, and images with safe deletion workflows and flexible gallery links.
+- **Technical Changes**: Added a backend endpoint for linking models to galleries, refreshed the model explorer with irreversible delete confirmations and link management UI, expanded the gallery explorer with delete actions, updated shared styles, and extended the API client plus app state handlers.
+- **Data Changes**: None; feature relies on existing Prisma models.
+
 ## 033 – Ranking administration suite (commit TBD)
 - **General**: Empowered administrators to tune ranking math, expand the ladder, and moderate curator visibility.
 - **Technical Changes**: Added configurable ranking settings and tier management APIs, introduced user-specific ranking overrides, refreshed profile scoring with dynamic weights, and surfaced ranking blocks in the UI.
@@ -450,3 +455,8 @@
 - **General**: Restored comprehensive moderation access so administrators always see every model, gallery, and image without toggling audit mode in the workspace.
 - **Technical Changes**: Let admin requests bypass `isPublic` filters across asset and gallery listings, ensured gallery serialization includes private entries for admins, and allowed admin profile views to include private uploads while leaving audit mode behavior intact.
 - **Data Changes**: None; visibility rules operate on existing records only.
+
+## 092 – Curator deletion & linking hardening
+- **General**: Finalized curator-facing deletion and gallery linking so model and collection maintenance works without admin support.
+- **Technical Changes**: Regenerated the Prisma client, tightened gallery mapper typings, restored missing backend type imports, and verified linting for both backend and frontend workspaces.
+- **Data Changes**: None; the feature operates on existing Prisma models.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
 - Home spotlight tiles are fully interactive—click previews to jump straight into the model or gallery explorers, and tap tag chips to filter matching content instantly.
-- Curators can edit their own models, collections, and images directly from the explorers, while administrators continue to see edit controls for every entry.
+- Curators can edit and delete their own models, collections, and images directly from the explorers (each destructive action ships with a “Nicht umkehrbar ist wenn gelöscht wird. weg ist weg.” warning), while administrators continue to see controls for every entry.
+- Manual collection linking lets curators attach their own galleries to models from the detail view, while administrators can pair any collection when moderation requires intervention.
 - Private uploads remain hidden from other curators; the administration workspace now surfaces every model, gallery, and image for admins by default, while the **Audit** toggle on curator profiles remains available for targeted moderation checks.
 - Signed-in users can open the **Account settings** dialog from the sidebar to adjust profile details or rotate their password in a single modal workflow.
 - Administration workspace now offers moderation grids for models and images, ranking controls (weights, tiers, and user resets), a streamlined model gallery that opens full management controls in the mainframe, persistent bulk tools tuned for six-figure libraries, multi-step onboarding with permission previews, and one-click actions to promote, rename, or remove secondary model versions. Ranking inputs immediately cache typed values so the tab stays responsive while backend refreshes complete.

--- a/backend/src/lib/mappers/gallery.ts
+++ b/backend/src/lib/mappers/gallery.ts
@@ -1,0 +1,176 @@
+import type { Prisma } from '@prisma/client';
+
+import type { AuthenticatedUser } from '../auth';
+import { resolveStorageLocation } from '../storage';
+
+export type HydratedGalleryImage = Prisma.ImageAssetGetPayload<{
+  include: {
+    tags: { include: { tag: true } };
+    owner: { select: { id: true; displayName: true; email: true } };
+  };
+}>;
+
+type HydratedGalleryModel = Prisma.ModelAssetGetPayload<{
+  include: {
+    tags: { include: { tag: true } };
+    owner: { select: { id: true; displayName: true } };
+  };
+}>;
+
+type HydratedGalleryEntry = Prisma.GalleryEntryGetPayload<{
+  include: {
+    image: {
+      include: {
+        tags: { include: { tag: true } };
+        owner: { select: { id: true; displayName: true; email: true } };
+      };
+    };
+    asset: {
+      include: {
+        tags: { include: { tag: true } };
+        owner: { select: { id: true; displayName: true } };
+      };
+    };
+  };
+}>;
+
+export type HydratedGallery = Prisma.GalleryGetPayload<{
+  include: {
+    owner: { select: { id: true; displayName: true; email: true } };
+    entries: {
+      include: {
+        image: {
+          include: {
+            tags: { include: { tag: true } };
+            owner: { select: { id: true; displayName: true; email: true } };
+          };
+        };
+        asset: {
+          include: {
+            tags: { include: { tag: true } };
+            owner: { select: { id: true; displayName: true } };
+          };
+        };
+      };
+    };
+  };
+}>;
+
+export const canViewResource = (
+  viewer: AuthenticatedUser | undefined,
+  ownerId: string,
+  isPublic: boolean,
+  options: { includePrivate?: boolean } = {},
+) => {
+  if (options.includePrivate) {
+    return true;
+  }
+
+  if (isPublic) {
+    return true;
+  }
+
+  if (!viewer) {
+    return false;
+  }
+
+  return viewer.id === ownerId;
+};
+
+export const mapGalleryImageAsset = (image: HydratedGalleryImage) => {
+  const storage = resolveStorageLocation(image.storagePath);
+
+  return {
+    id: image.id,
+    title: image.title,
+    description: image.description,
+    isPublic: image.isPublic,
+    dimensions: image.width && image.height ? { width: image.width, height: image.height } : undefined,
+    fileSize: image.fileSize,
+    storagePath: storage.url ?? image.storagePath,
+    storageBucket: storage.bucket,
+    storageObject: storage.objectName,
+    prompt: image.prompt,
+    negativePrompt: image.negativePrompt,
+    metadata: {
+      seed: image.seed,
+      model: image.model,
+      sampler: image.sampler,
+      cfgScale: image.cfgScale,
+      steps: image.steps,
+    },
+    owner: image.owner,
+    tags: image.tags.map(({ tag }) => tag),
+    createdAt: image.createdAt,
+    updatedAt: image.updatedAt,
+  };
+};
+
+export const mapGallery = (
+  gallery: HydratedGallery,
+  options: { viewer?: AuthenticatedUser; includePrivate?: boolean } = {},
+) => {
+  const cover = resolveStorageLocation(gallery.coverImage);
+  const viewer = options.viewer;
+
+  return {
+    id: gallery.id,
+    slug: gallery.slug,
+    title: gallery.title,
+    description: gallery.description,
+    coverImage: cover.url ?? gallery.coverImage,
+    coverImageBucket: cover.bucket,
+    coverImageObject: cover.objectName,
+    isPublic: gallery.isPublic,
+    owner: gallery.owner,
+    createdAt: gallery.createdAt,
+    updatedAt: gallery.updatedAt,
+    entries: gallery.entries
+      .filter((entry) => {
+        if (options.includePrivate) {
+          return true;
+        }
+
+        const canViewAsset = entry.asset
+          ? canViewResource(viewer, entry.asset.ownerId, entry.asset.isPublic, options)
+          : false;
+        const canViewImage = entry.image
+          ? canViewResource(viewer, entry.image.ownerId, entry.image.isPublic, options)
+          : false;
+
+        return canViewAsset || canViewImage;
+      })
+      .map((entry) => {
+        const modelStorage = entry.asset ? resolveStorageLocation(entry.asset.storagePath) : null;
+        const modelPreview = entry.asset ? resolveStorageLocation(entry.asset.previewImage) : null;
+        const canViewAsset = entry.asset
+          ? canViewResource(viewer, entry.asset.ownerId, entry.asset.isPublic, options)
+          : false;
+        const canViewImage = entry.image
+          ? canViewResource(viewer, entry.image.ownerId, entry.image.isPublic, options)
+          : false;
+
+        return {
+          id: entry.id,
+          position: entry.position,
+          note: entry.note,
+          modelAsset: entry.asset && (options.includePrivate || canViewAsset)
+            ? {
+                ...entry.asset,
+                isPublic: entry.asset.isPublic,
+                storagePath: modelStorage?.url ?? entry.asset.storagePath,
+                storageBucket: modelStorage?.bucket ?? null,
+                storageObject: modelStorage?.objectName ?? null,
+                previewImage: modelPreview?.url ?? entry.asset.previewImage,
+                previewImageBucket: modelPreview?.bucket ?? null,
+                previewImageObject: modelPreview?.objectName ?? null,
+                tags: entry.asset.tags.map(({ tag }) => tag),
+              }
+            : null,
+          imageAsset: entry.image && (options.includePrivate || canViewImage)
+            ? mapGalleryImageAsset(entry.image)
+            : null,
+        };
+      }),
+  };
+};

--- a/backend/src/routes/galleries.ts
+++ b/backend/src/routes/galleries.ts
@@ -5,152 +5,16 @@ import { z } from 'zod';
 import type { AuthenticatedUser } from '../lib/auth';
 import { prisma } from '../lib/prisma';
 import { requireAuth } from '../lib/middleware/auth';
+import {
+  canViewResource,
+  HydratedGallery,
+  HydratedGalleryImage,
+  mapGallery,
+  mapGalleryImageAsset,
+} from '../lib/mappers/gallery';
 import { resolveStorageLocation } from '../lib/storage';
 
 export const galleriesRouter = Router();
-
-type HydratedGallery = Prisma.GalleryGetPayload<{
-  include: {
-    owner: { select: { id: true; displayName: true; email: true } };
-    entries: {
-      include: {
-        image: {
-          include: {
-            tags: { include: { tag: true } };
-            owner: { select: { id: true; displayName: true; email: true } };
-          };
-        };
-        asset: {
-          include: {
-            tags: { include: { tag: true } };
-            owner: { select: { id: true, displayName: true } };
-          };
-        };
-      };
-    };
-  };
-}>;
-
-type HydratedGalleryImage = NonNullable<HydratedGallery['entries'][number]['image']>;
-
-const canViewResource = (
-  viewer: AuthenticatedUser | undefined,
-  ownerId: string,
-  isPublic: boolean,
-  options: { includePrivate?: boolean } = {},
-) => {
-  if (options.includePrivate) {
-    return true;
-  }
-
-  if (isPublic) {
-    return true;
-  }
-
-  if (!viewer) {
-    return false;
-  }
-
-  return viewer.id === ownerId;
-};
-
-const mapGalleryImageAsset = (image: HydratedGalleryImage) => {
-  const storage = resolveStorageLocation(image.storagePath);
-
-  return {
-    id: image.id,
-    title: image.title,
-    description: image.description,
-    isPublic: image.isPublic,
-    dimensions: image.width && image.height ? { width: image.width, height: image.height } : undefined,
-    fileSize: image.fileSize,
-    storagePath: storage.url ?? image.storagePath,
-    storageBucket: storage.bucket,
-    storageObject: storage.objectName,
-    prompt: image.prompt,
-    negativePrompt: image.negativePrompt,
-    metadata: {
-      seed: image.seed,
-      model: image.model,
-      sampler: image.sampler,
-      cfgScale: image.cfgScale,
-      steps: image.steps,
-    },
-    owner: image.owner,
-    tags: image.tags.map(({ tag }) => tag),
-    createdAt: image.createdAt,
-    updatedAt: image.updatedAt,
-  };
-};
-
-const mapGallery = (
-  gallery: HydratedGallery,
-  options: { viewer?: AuthenticatedUser; includePrivate?: boolean } = {},
-) => {
-  const cover = resolveStorageLocation(gallery.coverImage);
-  const viewer = options.viewer;
-
-  return {
-    id: gallery.id,
-    slug: gallery.slug,
-    title: gallery.title,
-    description: gallery.description,
-    coverImage: cover.url ?? gallery.coverImage,
-    coverImageBucket: cover.bucket,
-    coverImageObject: cover.objectName,
-    isPublic: gallery.isPublic,
-    owner: gallery.owner,
-    createdAt: gallery.createdAt,
-    updatedAt: gallery.updatedAt,
-    entries: gallery.entries
-      .filter((entry) => {
-        if (options.includePrivate) {
-          return true;
-        }
-
-        const canViewAsset = entry.asset
-          ? canViewResource(viewer, entry.asset.ownerId, entry.asset.isPublic, options)
-          : false;
-        const canViewImage = entry.image
-          ? canViewResource(viewer, entry.image.ownerId, entry.image.isPublic, options)
-          : false;
-
-        return canViewAsset || canViewImage;
-      })
-      .map((entry) => {
-        const modelStorage = entry.asset ? resolveStorageLocation(entry.asset.storagePath) : null;
-        const modelPreview = entry.asset ? resolveStorageLocation(entry.asset.previewImage) : null;
-        const canViewAsset = entry.asset
-          ? canViewResource(viewer, entry.asset.ownerId, entry.asset.isPublic, options)
-          : false;
-        const canViewImage = entry.image
-          ? canViewResource(viewer, entry.image.ownerId, entry.image.isPublic, options)
-          : false;
-
-        return {
-          id: entry.id,
-          position: entry.position,
-          note: entry.note,
-          modelAsset: entry.asset && (options.includePrivate || canViewAsset)
-            ? {
-                ...entry.asset,
-                isPublic: entry.asset.isPublic,
-                storagePath: modelStorage?.url ?? entry.asset.storagePath,
-                storageBucket: modelStorage?.bucket ?? null,
-                storageObject: modelStorage?.objectName ?? null,
-                previewImage: modelPreview?.url ?? entry.asset.previewImage,
-                previewImageBucket: modelPreview?.bucket ?? null,
-                previewImageObject: modelPreview?.objectName ?? null,
-                tags: entry.asset.tags.map(({ tag }) => tag),
-              }
-            : null,
-          imageAsset: entry.image && (options.includePrivate || canViewImage)
-            ? mapGalleryImageAsset(entry.image)
-            : null,
-        };
-      }),
-  };
-};
 
 const noteTransformer = z
   .string()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -347,6 +347,42 @@ export const App = () => {
     });
   }, []);
 
+  const handleAssetDeleted = useCallback(
+    (assetId: string) => {
+      setAssets((previous) => previous.filter((asset) => asset.id !== assetId));
+      setGalleries((previous) =>
+        previous.map((gallery) => ({
+          ...gallery,
+          entries: gallery.entries.filter((entry) => entry.modelAsset?.id !== assetId),
+        })),
+      );
+      refreshData().catch((error) => console.error('Failed to refresh after model deletion', error));
+    },
+    [refreshData],
+  );
+
+  const handleGalleryDeleted = useCallback(
+    (galleryId: string) => {
+      setGalleries((previous) => previous.filter((gallery) => gallery.id !== galleryId));
+      refreshData().catch((error) => console.error('Failed to refresh after gallery deletion', error));
+    },
+    [refreshData],
+  );
+
+  const handleImageDeleted = useCallback(
+    (imageId: string) => {
+      setImages((previous) => previous.filter((image) => image.id !== imageId));
+      setGalleries((previous) =>
+        previous.map((gallery) => ({
+          ...gallery,
+          entries: gallery.entries.filter((entry) => entry.imageAsset?.id !== imageId),
+        })),
+      );
+      refreshData().catch((error) => console.error('Failed to refresh after image deletion', error));
+    },
+    [refreshData],
+  );
+
   const handleOpenAssetUpload = () => {
     if (!isAuthenticated) {
       setIsLoginOpen(true);
@@ -680,9 +716,11 @@ export const App = () => {
           externalSearchQuery={modelTagQuery}
           onExternalSearchApplied={() => setModelTagQuery(null)}
           onAssetUpdated={handleAssetUpdated}
+          onAssetDeleted={handleAssetDeleted}
           authToken={token}
           currentUser={authUser}
           onOpenProfile={handleOpenUserProfile}
+          onGalleryUpdated={handleGalleryUpdated}
         />
       );
     }
@@ -703,6 +741,8 @@ export const App = () => {
           onGalleryUpdated={handleGalleryUpdated}
           onImageUpdated={handleImageUpdated}
           onOpenProfile={handleOpenUserProfile}
+          onGalleryDeleted={handleGalleryDeleted}
+          onImageDeleted={handleImageDeleted}
         />
       );
     }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3455,6 +3455,32 @@ main {
   outline: none;
 }
 
+.asset-detail__delete {
+  border: none;
+  background: rgba(220, 38, 38, 0.3);
+  color: rgba(254, 226, 226, 0.9);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.asset-detail__delete:hover,
+.asset-detail__delete:focus-visible {
+  background: rgba(220, 38, 38, 0.5);
+  color: #ffffff;
+  outline: none;
+}
+
+.asset-detail__delete:disabled {
+  cursor: wait;
+  background: rgba(120, 53, 15, 0.35);
+  color: rgba(248, 250, 252, 0.65);
+}
+
 .asset-detail__close {
   border: none;
   background: rgba(15, 23, 42, 0.45);
@@ -3765,6 +3791,130 @@ main {
   background: rgba(15, 23, 42, 0.55);
   border-color: rgba(148, 163, 184, 0.35);
   color: rgba(148, 163, 184, 0.7);
+}
+
+.asset-detail__gallery-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.asset-detail__gallery-links-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.asset-detail__gallery-links-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.asset-detail__gallery-links-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.asset-detail__gallery-links-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.asset-detail__gallery-remove {
+  border: none;
+  background: rgba(244, 63, 94, 0.18);
+  color: rgba(254, 226, 226, 0.92);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.asset-detail__gallery-remove:hover,
+.asset-detail__gallery-remove:focus-visible {
+  background: rgba(244, 63, 94, 0.32);
+  color: #ffffff;
+  outline: none;
+}
+
+.asset-detail__gallery-remove:disabled {
+  cursor: wait;
+  background: rgba(71, 85, 105, 0.4);
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.asset-detail__gallery-manage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.asset-detail__gallery-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.asset-detail__gallery-select select,
+.asset-detail__gallery-note input {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.65rem;
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.85rem;
+  min-width: 12rem;
+}
+
+.asset-detail__gallery-select select:disabled,
+.asset-detail__gallery-note input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.asset-detail__gallery-submit {
+  border: none;
+  background: rgba(34, 197, 94, 0.25);
+  color: rgba(220, 252, 231, 0.95);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.asset-detail__gallery-submit:hover,
+.asset-detail__gallery-submit:focus-visible {
+  background: rgba(34, 197, 94, 0.4);
+  color: #ffffff;
+  outline: none;
+}
+
+.asset-detail__gallery-submit:disabled {
+  cursor: not-allowed;
+  background: rgba(71, 85, 105, 0.4);
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.asset-detail__gallery-error {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(248, 113, 113, 0.95);
 }
 
 .asset-detail__section--tags {
@@ -5903,6 +6053,38 @@ button {
   outline: none;
 }
 
+.gallery-detail__delete {
+  border: none;
+  background: rgba(220, 38, 38, 0.28);
+  color: rgba(254, 226, 226, 0.92);
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.gallery-detail__delete:hover,
+.gallery-detail__delete:focus-visible {
+  background: rgba(220, 38, 38, 0.45);
+  color: #ffffff;
+  outline: none;
+}
+
+.gallery-detail__delete:disabled {
+  cursor: wait;
+  background: rgba(120, 53, 15, 0.4);
+  color: rgba(248, 250, 252, 0.7);
+}
+
+.gallery-detail__error {
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(248, 113, 113, 0.95);
+}
+
 .gallery-detail__badge {
   display: inline-flex;
   align-items: center;
@@ -6118,6 +6300,38 @@ button {
   background: rgba(59, 130, 246, 0.5);
   color: #ffffff;
   outline: none;
+}
+
+.gallery-image-modal__delete {
+  border: none;
+  background: rgba(220, 38, 38, 0.28);
+  color: rgba(254, 226, 226, 0.92);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  cursor: pointer;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.gallery-image-modal__delete:hover,
+.gallery-image-modal__delete:focus-visible {
+  background: rgba(220, 38, 38, 0.45);
+  color: #ffffff;
+  outline: none;
+}
+
+.gallery-image-modal__delete:disabled {
+  cursor: wait;
+  background: rgba(120, 53, 15, 0.4);
+  color: rgba(248, 250, 252, 0.7);
+}
+
+.gallery-image-modal__error {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(248, 113, 113, 0.95);
 }
 
 .gallery-image-modal__header h3 {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -370,6 +370,19 @@ export const api = {
       },
       token,
     ),
+  linkModelToGallery: (
+    token: string,
+    modelId: string,
+    payload: { galleryId: string; note?: string | null },
+  ) =>
+    request<{ gallery: Gallery }>(
+      `/api/assets/models/${modelId}/galleries`,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      },
+      token,
+    ),
   deleteModelAsset: (token: string, id: string) => request(`/api/assets/models/${id}`, { method: 'DELETE' }, token),
   bulkDeleteModelAssets: (token: string, ids: string[]) =>
     request<{ deleted: string[] }>(


### PR DESCRIPTION
## Summary
- centralize gallery hydration helpers in a shared mapper and restore missing Prisma/Auth type imports
- add the POST /api/assets/models/:id/galleries endpoint with ownership checks and reuse the shared mapper during responses
- expose model-to-gallery linking and irreversible delete flows across the React explorers, including the required warning copy and styling updates

## Testing
- npm run lint (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cfce82e40c83339b58e8a6518857a0