### PR TITLE
Fix asset explorer initialization bug

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -460,3 +460,8 @@
 - **General**: Finalized curator-facing deletion and gallery linking so model and collection maintenance works without admin support.
 - **Technical Changes**: Regenerated the Prisma client, tightened gallery mapper typings, restored missing backend type imports, and verified linting for both backend and frontend workspaces.
 - **Data Changes**: None; the feature operates on existing Prisma models.
+
+## 093 – Asset explorer initialization fix
+- **General**: Prevented the model explorer from crashing when curators open the collection linking dialog.
+- **Technical Changes**: Moved the linkable gallery memoization ahead of its dependent effect so React never reads an uninitialized binding during setup.
+- **Data Changes**: None; state initialization only.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -552,20 +552,6 @@ export const AssetExplorer = ({
   }, [activeAsset]);
 
   useEffect(() => {
-    if (linkableGalleries.length === 0) {
-      setSelectedGalleryId('');
-      return;
-    }
-
-    setSelectedGalleryId((current) => {
-      if (current && linkableGalleries.some((entry) => entry.id === current)) {
-        return current;
-      }
-      return linkableGalleries[0]?.id ?? '';
-    });
-  }, [linkableGalleries]);
-
-  useEffect(() => {
     if (triggerCopyStatus === 'idle') {
       return;
     }
@@ -988,6 +974,20 @@ export const AssetExplorer = ({
       .map((gallery) => ({ id: gallery.id, title: gallery.title }))
       .sort((first, second) => first.title.localeCompare(second.title, 'en'));
   }, [canManageActiveAsset, currentUser, galleries, relatedGalleries]);
+
+  useEffect(() => {
+    if (linkableGalleries.length === 0) {
+      setSelectedGalleryId('');
+      return;
+    }
+
+    setSelectedGalleryId((current) => {
+      if (current && linkableGalleries.some((entry) => entry.id === current)) {
+        return current;
+      }
+      return linkableGalleries[0]?.id ?? '';
+    });
+  }, [linkableGalleries]);
 
   const metadataEntries = useMemo(
     () => buildMetadataRows(activeVersion?.metadata as Record<string, unknown> | null),


### PR DESCRIPTION
## Summary
- prevent the model explorer from throwing a ReferenceError when initializing the gallery linking dialog
- keep the gallery selection effect after the memoized linkable galleries list so setup runs reliably

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfd4e7079c8333838f372022c594e0