### PR TITLE
Fix model explorer gallery initialization

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -460,3 +460,8 @@
 - **General**: Finalized curator-facing deletion and gallery linking so model and collection maintenance works without admin support.
 - **Technical Changes**: Regenerated the Prisma client, tightened gallery mapper typings, restored missing backend type imports, and verified linting for both backend and frontend workspaces.
 - **Data Changes**: None; the feature operates on existing Prisma models.
+
+## 093 – Model explorer initialization guard
+- **General**: Prevented the model explorer from crashing when opening the page by initializing gallery linking state safely.
+- **Technical Changes**: Reordered the gallery memoization and effect in `frontend/src/components/AssetExplorer.tsx` so React never references `linkableGalleries` before it is computed.
+- **Data Changes**: None; client-side state management only.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -552,20 +552,6 @@ export const AssetExplorer = ({
   }, [activeAsset]);
 
   useEffect(() => {
-    if (linkableGalleries.length === 0) {
-      setSelectedGalleryId('');
-      return;
-    }
-
-    setSelectedGalleryId((current) => {
-      if (current && linkableGalleries.some((entry) => entry.id === current)) {
-        return current;
-      }
-      return linkableGalleries[0]?.id ?? '';
-    });
-  }, [linkableGalleries]);
-
-  useEffect(() => {
     if (triggerCopyStatus === 'idle') {
       return;
     }
@@ -988,6 +974,20 @@ export const AssetExplorer = ({
       .map((gallery) => ({ id: gallery.id, title: gallery.title }))
       .sort((first, second) => first.title.localeCompare(second.title, 'en'));
   }, [canManageActiveAsset, currentUser, galleries, relatedGalleries]);
+
+  useEffect(() => {
+    if (linkableGalleries.length === 0) {
+      setSelectedGalleryId('');
+      return;
+    }
+
+    setSelectedGalleryId((current) => {
+      if (current && linkableGalleries.some((entry) => entry.id === current)) {
+        return current;
+      }
+      return linkableGalleries[0]?.id ?? '';
+    });
+  }, [linkableGalleries]);
 
   const metadataEntries = useMemo(
     () => buildMetadataRows(activeVersion?.metadata as Record<string, unknown> | null),


### PR DESCRIPTION
## Summary
- prevent the model explorer from referencing linkable galleries before they are memoized
- document the initialization fix in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfd58781d08333a521787d4de4ee69