### PR TITLE
Add helper for configuring Vite allowed hosts

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -470,3 +470,13 @@
 - **General**: Replaced the manual cover URL input with dedicated actions to upload a new image or pick one from the collection itself.
 - **Technical Changes**: Added a gallery cover upload endpoint with image validation and storage cleanup, refreshed the gallery editor UI with preview/status handling, selection grid styling, and API wiring for immediate updates, and exposed a client helper for the new upload call.
 - **Data Changes**: None; cover selections reuse existing gallery/image records.
+
+## 095 – Vite host allow list helper (commit TBD)
+- **General**: Simplified approving external domains for the front-end dev server.
+- **Technical Changes**: Added a Node helper to append domains to `frontend/allowed-hosts.json`, taught `vite.config.ts` to load the allow list, and documented the workflow in the README.
+- **Data Changes**: None; stores hostnames in a tracked configuration file only.
+
+## 096 – Neutralize Vite host documentation
+- **General**: Replaced references to a private domain with a neutral example so operators can copy commands safely.
+- **Technical Changes**: Updated the README usage sample for the allowed-host helper and refreshed the default `frontend/allowed-hosts.json` entry to use `example.com`.
+- **Data Changes**: Adjusted the tracked allow-list file to contain only the placeholder `example.com`.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ The PowerShell helper mirrors the Linux workflow: it logs in once, picks a rando
    Upgrade via `nvm` if the version is below 18.
 4. Open `http://<your-server-ip>:5173` to explore live filters for LoRA models and curated galleries.
 
+### Allowing external domains in Vite
+
+Vite blocks unknown hosts by default when the dev server is reachable from the internet. Use the helper to register additional
+domains:
+
+```bash
+node scripts/add-allowed-host.mjs example.com
+```
+
+Replace `example.com` with the domain you need to allow. The script normalizes the domain, updates `frontend/allowed-hosts.json`, and keeps the list sorted. Restart the Vite dev server after adding a new host so the updated allow list takes effect.
+
 ## Upload Pipeline
 
 1. **Authentication** – Every upload requires a valid JWT. Missing or expired tokens respond with `401/403` immediately.

--- a/frontend/allowed-hosts.json
+++ b/frontend/allowed-hosts.json
@@ -1,0 +1,3 @@
+[
+  "example.com"
+]

--- a/scripts/add-allowed-host.mjs
+++ b/scripts/add-allowed-host.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const [, , rawDomain] = process.argv
+
+const usage = () => {
+  console.error('Usage: node scripts/add-allowed-host.mjs <domain>')
+  process.exit(1)
+}
+
+if (!rawDomain) {
+  usage()
+}
+
+const sanitizeDomain = (input) => {
+  const trimmed = input.trim()
+
+  if (!trimmed) {
+    throw new Error('Domain cannot be empty.')
+  }
+
+  const withoutProtocol = trimmed.replace(/^[a-z]+:\/\//i, '')
+  const withoutCredentials = withoutProtocol.includes('@')
+    ? withoutProtocol.slice(withoutProtocol.lastIndexOf('@') + 1)
+    : withoutProtocol
+  const [hostCandidate] = withoutCredentials.split(/[/?#]/, 1)
+
+  if (!hostCandidate) {
+    throw new Error('Unable to extract host from input. Provide only a domain or hostname.')
+  }
+
+  const hostWithoutPort = hostCandidate.split(':')[0]
+  const normalized = hostWithoutPort.trim().toLowerCase()
+
+  if (!normalized) {
+    throw new Error('Domain resolves to an empty host after normalization.')
+  }
+
+  if (!/^[a-z0-9.-]+$/.test(normalized)) {
+    throw new Error(
+      `Unsupported host "${normalized}". Only alphanumeric characters, dots, and hyphens are allowed.`,
+    )
+  }
+
+  return normalized
+}
+
+let domain
+
+try {
+  domain = sanitizeDomain(rawDomain)
+} catch (error) {
+  console.error(`\n${error instanceof Error ? error.message : String(error)}`)
+  usage()
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, '..')
+const allowedHostsPath = resolve(repoRoot, 'frontend', 'allowed-hosts.json')
+
+let existingHosts = []
+
+if (existsSync(allowedHostsPath)) {
+  try {
+    const fileContent = readFileSync(allowedHostsPath, 'utf8')
+    const parsed = fileContent.trim().length > 0 ? JSON.parse(fileContent) : []
+
+    if (Array.isArray(parsed)) {
+      existingHosts = parsed
+        .filter((value) => typeof value === 'string')
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+    } else {
+      console.warn(
+        `Existing allowed hosts file at ${allowedHostsPath} is not an array. Resetting with sanitized domain only.`,
+      )
+    }
+  } catch (error) {
+    console.warn(`Failed to parse existing allowed hosts at ${allowedHostsPath}. Resetting file.`, error)
+  }
+}
+
+const lowerCaseSet = new Set(existingHosts.map((value) => value.toLowerCase()))
+
+if (lowerCaseSet.has(domain)) {
+  console.log(`Domain "${domain}" is already present in frontend/allowed-hosts.json.`)
+  process.exit(0)
+}
+
+const updatedHosts = [...existingHosts, domain]
+updatedHosts.sort((a, b) => a.localeCompare(b))
+
+writeFileSync(allowedHostsPath, `${JSON.stringify(updatedHosts, null, 2)}\n`, 'utf8')
+
+console.log(`Added "${domain}" to ${allowedHostsPath}.`)
+console.log('Restart the Vite dev server if it is running to apply the updated allow list.')


### PR DESCRIPTION
## Summary
- add a tracked `frontend/allowed-hosts.json` allow list seeded with an `example.com` placeholder domain
- load the allow list in `vite.config.ts` and expose a script that appends sanitized domains
- document the workflow in the README and changelog so operators can approve new hosts quickly

## Testing
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cfe09341448333853a327d1448b2f7