### PR TITLE
Add USER member like support and UI polish

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -505,3 +505,8 @@
 - **General**: Expanded the on-site generator roadmap with detailed queue management and virtual credit policies.
 - **Technical Changes**: Documented Redis-backed queue operations, prioritization tiers, credit-aware submissions, ledger schema considerations, and monitoring/operational responses.
 - **Data Changes**: None; outlined prospective metadata and credit ledger fields only.
+
+## 101 – Member likes rollout
+- **General**: Enabled the USER member role with public registration, single-tap image likes, and updated guest restrictions across the platform.
+- **Technical Changes**: Added a shared gallery include builder with like hydration, enforced auth on download/like routes, refreshed the gallery explorer UI for accessible inline like controls, updated admin role summaries, and wired the API client plus profile views to surface total like counts.
+- **Data Changes**: Introduced the `ImageLike` table with composite keys and defaulted new accounts to the USER role via Prisma migration.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 
 - **Unified operations dashboard** – Persistent sidebar navigation with instant switching between Home, Models, and Images, plus glassy health cards with color-coded LED beacons for the front end, API, and MinIO services.
 - **Role-aware access control** – JWT-based authentication with session persistence, an admin workspace for user/model/gallery management, a dialog-driven onboarding wizard with role presets, protected upload flows, and private uploads that stay exclusive to their owner for curators while administrators always see the full inventory in their workspace (with optional audit mode on curator profiles for spot checks).
+- **Member registration & reactions** – Public self-service signup promotes visitors into the USER role, unlocks downloads, comments, and single-tap image likes, surfaces received-like totals across profiles, and keeps upload rights reserved for curators and admins.
 - **Self-service account management** – Sidebar account settings let curators update their display name, bio, and password, now proxy uploaded avatars (PNG/JPG/WebP ≤ 5 MB) through the API, and automatically reroute legacy MinIO avatar links so external domains never surface `127.0.0.1` references.
 - **Guided three-step upload wizard** – Collects metadata, files, and review feedback with validation, drag & drop, and live responses from the production-ready `POST /api/uploads` endpoint.
 - **Data-driven explorers** – Fast filters and full-text search across LoRA assets and galleries, complete with tag badges, five-column tiles, and seamless infinite scrolling with active filter indicators.
@@ -16,6 +17,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 ## Good to Know
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
+- Guests browse-only—downloads, comments, and reactions remain disabled until they register and sign in.
 - Home spotlight tiles are fully interactive—click previews to jump straight into the model or gallery explorers, and tap tag chips to filter matching content instantly.
 - Curators can edit and delete their own models, collections, and images directly from the explorers (each destructive action ships with a “Nicht umkehrbar ist wenn gelöscht wird. weg ist weg.” warning), while administrators continue to see controls for every entry.
 - Manual collection linking lets curators attach their own galleries to models from the detail view, while administrators can pair any collection when moderation requires intervention.

--- a/backend/prisma/migrations/20250921125359_add_user_role_and_image_likes/migration.sql
+++ b/backend/prisma/migrations/20250921125359_add_user_role_and_image_likes/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "ImageLike" (
+    "userId" TEXT NOT NULL,
+    "imageId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("userId", "imageId"),
+    CONSTRAINT "ImageLike_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ImageLike_imageId_fkey" FOREIGN KEY ("imageId") REFERENCES "ImageAsset" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'USER',
+    "bio" TEXT,
+    "avatarUrl" TEXT,
+    "passwordHash" TEXT NOT NULL DEFAULT '',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "lastLoginAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("avatarUrl", "bio", "createdAt", "displayName", "email", "id", "isActive", "lastLoginAt", "passwordHash", "role", "updatedAt") SELECT "avatarUrl", "bio", "createdAt", "displayName", "email", "id", "isActive", "lastLoginAt", "passwordHash", "role", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "ImageLike_imageId_idx" ON "ImageLike"("imageId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,6 +8,7 @@ generator client {
 }
 
 enum UserRole {
+  USER
   CURATOR
   ADMIN
 }
@@ -16,7 +17,7 @@ model User {
   id          String       @id @default(cuid())
   email       String       @unique
   displayName String
-  role        UserRole     @default(CURATOR)
+  role        UserRole     @default(USER)
   bio         String?
   avatarUrl   String?
   passwordHash String      @default("")
@@ -27,6 +28,7 @@ model User {
   galleries   Gallery[]    @relation("GalleryOwner")
   assets      ModelAsset[] @relation("AssetOwner")
   images      ImageAsset[] @relation("ImageOwner")
+  imageLikes ImageLike[]
   uploadDrafts UploadDraft[]
   rankingState UserRankingState?
 }
@@ -103,8 +105,21 @@ model ImageAsset {
   galleries      GalleryEntry[] @relation("GalleryImage")
   ownerId        String
   owner          User           @relation("ImageOwner", fields: [ownerId], references: [id])
+  likes          ImageLike[]
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
+}
+
+model ImageLike {
+  userId    String
+  imageId   String
+  createdAt DateTime @default(now())
+
+  user  User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  image ImageAsset @relation(fields: [imageId], references: [id], onDelete: Cascade)
+
+  @@id([userId, imageId])
+  @@index([imageId])
 }
 
 model GalleryEntry {

--- a/backend/src/lib/middleware/auth.ts
+++ b/backend/src/lib/middleware/auth.ts
@@ -95,6 +95,20 @@ export const requireAdmin = (req: Request, res: Response, next: NextFunction) =>
   next();
 };
 
+export const requireCurator = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    res.status(401).json({ message: 'Authentifizierung erforderlich.' });
+    return;
+  }
+
+  if (req.user.role === 'USER') {
+    res.status(403).json({ message: 'Kurator:innenrechte erforderlich.' });
+    return;
+  }
+
+  next();
+};
+
 export const requireSelfOrAdmin = (req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
     res.status(401).json({ message: 'Authentifizierung erforderlich.' });

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,12 +2,18 @@ import { Router } from 'express';
 import { z } from 'zod';
 
 import { prisma } from '../lib/prisma';
-import { createAccessToken, toAuthUser, verifyPassword } from '../lib/auth';
+import { createAccessToken, hashPassword, toAuthUser, verifyPassword } from '../lib/auth';
 import { requireAuth } from '../lib/middleware/auth';
 
 const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(6),
+});
+
+const registerSchema = z.object({
+  email: z.string().email(),
+  displayName: z.string().min(2).max(160),
+  password: z.string().min(8),
 });
 
 export const authRouter = Router();
@@ -59,6 +65,56 @@ authRouter.post('/login', async (req, res, next) => {
     });
 
     res.json({
+      token,
+      user: toAuthUser(user),
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+authRouter.post('/register', async (req, res, next) => {
+  try {
+    const parsed = registerSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ message: 'Registrierungsdaten sind ungültig.', errors: parsed.error.flatten() });
+      return;
+    }
+
+    const email = parsed.data.email.toLowerCase();
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      res.status(409).json({ message: 'Für diese E-Mail-Adresse existiert bereits ein Konto.' });
+      return;
+    }
+
+    const passwordHash = await hashPassword(parsed.data.password);
+    const user = await prisma.user.create({
+      data: {
+        email,
+        displayName: parsed.data.displayName.trim(),
+        passwordHash,
+        role: 'USER',
+        isActive: true,
+      },
+      select: {
+        id: true,
+        email: true,
+        displayName: true,
+        role: true,
+        bio: true,
+        avatarUrl: true,
+      },
+    });
+
+    const token = createAccessToken({
+      sub: user.id,
+      role: user.role,
+      displayName: user.displayName,
+      email: user.email,
+    });
+
+    res.status(201).json({
       token,
       user: toAuthUser(user),
     });

--- a/backend/src/routes/storage.ts
+++ b/backend/src/routes/storage.ts
@@ -4,6 +4,7 @@ import { pipeline } from 'node:stream/promises';
 
 import { prisma } from '../lib/prisma';
 import { storageBuckets, storageClient } from '../lib/storage';
+import { requireAuth } from '../lib/middleware/auth';
 
 const allowedBuckets = new Set(Object.values(storageBuckets));
 
@@ -22,6 +23,8 @@ const sendBucketNotAllowed = (res: Response) => {
 };
 
 export const storageRouter = Router();
+
+storageRouter.use(requireAuth);
 
 const handleObjectRequest = async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/backend/src/routes/uploads.ts
+++ b/backend/src/routes/uploads.ts
@@ -9,7 +9,7 @@ import { prisma } from '../lib/prisma';
 import { MAX_TOTAL_SIZE_BYTES, MAX_UPLOAD_FILES } from '../lib/uploadLimits';
 import { storageBuckets, storageClient, getObjectUrl } from '../lib/storage';
 import { buildUniqueSlug, slugify } from '../lib/slug';
-import { requireAuth } from '../lib/middleware/auth';
+import { requireAuth, requireCurator } from '../lib/middleware/auth';
 import {
   extractImageMetadata,
   extractModelMetadataFromFile,
@@ -210,7 +210,7 @@ const createUploadSchema = z
 
 export const uploadsRouter = Router();
 
-uploadsRouter.post('/', requireAuth, upload.array('files'), async (req, res, next) => {
+uploadsRouter.post('/', requireAuth, requireCurator, upload.array('files'), async (req, res, next) => {
   try {
     const files = ((req as unknown as { files?: MulterFile[] }).files ?? []) as MulterFile[];
 

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -11,6 +11,15 @@ const roleSummaries: Record<
   User['role'],
   { title: string; headline: string; bullets: string[] }
 > = {
+  USER: {
+    title: 'Member permissions',
+    headline: 'Members explore curated content, download approved files, and react without upload rights.',
+    bullets: [
+      'Browse public galleries, LoRA models, and metadata safely.',
+      'Download approved assets directly through the governed proxy.',
+      'Engage with images by leaving likes while awaiting curator promotion.',
+    ],
+  },
   CURATOR: {
     title: 'Curator permissions',
     headline: 'Curators focus on creative intake and gallery management with safe defaults.',
@@ -36,7 +45,7 @@ const RoleSummaryDialog = ({ role, isOpen, onClose }: { role: User['role']; isOp
     return null;
   }
 
-  const summary = roleSummaries[role];
+  const summary = roleSummaries[role] ?? roleSummaries.CURATOR;
 
   return (
     <div className="modal role-summary-dialog" role="dialog" aria-modal="true" aria-labelledby="role-summary-title">
@@ -1041,6 +1050,37 @@ export const AdminPanel = ({
             <div className="user-onboarding-grid">
               <article className="user-onboarding-card">
                 <header>
+                  <h4>Member preset</h4>
+                  <p>For community accounts that react and download without uploading content.</p>
+                </header>
+                <ul className="user-onboarding-list">
+                  <li>Explore public galleries, models, and curator profiles.</li>
+                  <li>Download approved assets through the secured storage proxy.</li>
+                  <li>Engage with collections by leaving likes on favorite images.</li>
+                </ul>
+                <div className="user-onboarding-actions">
+                  <button
+                    type="button"
+                    className="button button--primary"
+                    onClick={() => {
+                      setUserDialogInitialRole('USER');
+                      setIsCreateUserDialogOpen(true);
+                    }}
+                    disabled={isBusy}
+                  >
+                    Create member account
+                  </button>
+                  <button
+                    type="button"
+                    className="button button--ghost"
+                    onClick={() => setRoleSummary('USER')}
+                  >
+                    Quick preview
+                  </button>
+                </div>
+              </article>
+              <article className="user-onboarding-card">
+                <header>
                   <h4>Curator preset</h4>
                   <p>For artists and moderators who manage uploads, tags, and galleries.</p>
                 </header>
@@ -1147,6 +1187,7 @@ export const AdminPanel = ({
                     disabled={isBusy}
                   >
                     <option value="all">All</option>
+                    <option value="USER">Members</option>
                     <option value="CURATOR">Curators</option>
                     <option value="ADMIN">Admin</option>
                   </select>
@@ -1233,6 +1274,7 @@ export const AdminPanel = ({
                         <label>
                           <span>Role</span>
                           <select name="role" defaultValue={user.role} disabled={isBusy}>
+                            <option value="USER">Member</option>
                             <option value="CURATOR">Curator</option>
                             <option value="ADMIN">Admin</option>
                           </select>

--- a/frontend/src/components/RegisterDialog.tsx
+++ b/frontend/src/components/RegisterDialog.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+
+interface RegisterDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (payload: { email: string; displayName: string; password: string }) => Promise<void>;
+  isSubmitting?: boolean;
+  errorMessage?: string | null;
+}
+
+export const RegisterDialog = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  isSubmitting = false,
+  errorMessage,
+}: RegisterDialogProps) => {
+  const [email, setEmail] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setEmail('');
+      setDisplayName('');
+      setPassword('');
+      setConfirmPassword('');
+      setLocalError(null);
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLocalError(null);
+
+    const trimmedEmail = email.trim();
+    const trimmedName = displayName.trim();
+
+    if (!trimmedEmail || !trimmedName || !password || !confirmPassword) {
+      setLocalError('Please fill out all fields to continue.');
+      return;
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      setLocalError('Please provide a valid email address.');
+      return;
+    }
+
+    if (password.length < 8) {
+      setLocalError('Passwords must contain at least 8 characters.');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setLocalError('Password confirmation does not match.');
+      return;
+    }
+
+    try {
+      await onSubmit({ email: trimmedEmail, displayName: trimmedName, password });
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : 'Registration failed.');
+    }
+  };
+
+  const displayError = localError ?? errorMessage;
+
+  return (
+    <div className="modal" role="dialog" aria-modal="true" aria-labelledby="register-dialog-title">
+      <div className="modal__backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="modal__content modal__content--compact">
+        <header className="modal__header">
+          <h2 id="register-dialog-title">Create account</h2>
+          <button type="button" className="modal__close" onClick={onClose} aria-label="Close dialog">
+            ×
+          </button>
+        </header>
+        <form className="modal__body" onSubmit={handleSubmit}>
+          <label className="form-field">
+            <span>Email</span>
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              autoComplete="email"
+              required
+            />
+          </label>
+          <label className="form-field">
+            <span>Display name</span>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              autoComplete="name"
+              required
+              minLength={2}
+            />
+          </label>
+          <label className="form-field">
+            <span>Password</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoComplete="new-password"
+              required
+              minLength={8}
+            />
+          </label>
+          <label className="form-field">
+            <span>Confirm password</span>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              autoComplete="new-password"
+              required
+              minLength={8}
+            />
+          </label>
+          {displayError ? <p className="form-error">{displayError}</p> : null}
+          <div className="modal__actions">
+            <button type="button" className="button" onClick={onClose} disabled={isSubmitting}>
+              Cancel
+            </button>
+            <button type="submit" className="button button--primary" disabled={isSubmitting}>
+              {isSubmitting ? 'Creating…' : 'Create account'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -32,7 +32,15 @@ const formatDate = (value: string) => {
   }
 };
 
-const formatRole = (role: UserProfileResponse['role']) => (role === 'ADMIN' ? 'Administrator' : 'Curator');
+const formatRole = (role: UserProfileResponse['role']) => {
+  if (role === 'ADMIN') {
+    return 'Administrator';
+  }
+  if (role === 'CURATOR') {
+    return 'Curator';
+  }
+  return 'Member';
+};
 
 const getInitials = (name: string) => {
   const parts = name.trim().split(/\s+/).slice(0, 2);
@@ -348,6 +356,16 @@ export const UserProfile = ({
             <div>
               <span className="profile-view__stat-value">{profile.stats.imageCount}</span>
               <span className="profile-view__stat-label">Images</span>
+            </div>
+            <div>
+              <span
+                className={`profile-view__stat-value${
+                  profile.stats.receivedLikeCount > 0 ? ' profile-view__stat-value--likes' : ''
+                }`}
+              >
+                {profile.stats.receivedLikeCount}
+              </span>
+              <span className="profile-view__stat-label">Received likes</span>
             </div>
           </section>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -678,6 +678,26 @@ body {
   color: rgba(226, 232, 240, 0.92);
 }
 
+.home-card__likes {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.home-card__likes::before {
+  content: '♥';
+  font-size: 0.85rem;
+  display: inline-block;
+  line-height: 1;
+  transform: translateY(-1px);
+}
+
+.home-card__likes--active {
+  color: rgba(220, 38, 38, 0.85);
+}
+
 .home-card__tags {
   margin: 0;
   padding: 0;
@@ -6296,26 +6316,129 @@ button {
   border: 1px solid rgba(59, 130, 246, 0.35);
   background: rgba(15, 23, 42, 0.7);
   aspect-ratio: 1 / 1;
+}
+
+.gallery-detail__thumb-trigger {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: transparent;
   padding: 0;
   cursor: pointer;
 }
 
-.gallery-detail__thumb img {
+.gallery-detail__thumb-trigger:hover {
+  outline: none;
+}
+
+.gallery-detail__thumb-trigger:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 3px rgba(59, 130, 246, 0.45);
+}
+
+.gallery-detail__thumb-trigger img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
 }
 
-.gallery-detail__note {
+.gallery-detail__thumb-footer {
   position: absolute;
-  bottom: 0;
   left: 0;
   right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
   padding: 0.4rem 0.6rem;
+  min-width: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.85) 100%);
+  z-index: 1;
+  pointer-events: none;
+}
+
+.gallery-detail__thumb-footer .gallery-like-button {
+  pointer-events: auto;
+}
+
+.gallery-detail__thumb-footer .gallery-detail__note {
+  pointer-events: auto;
+}
+
+.gallery-detail__note {
+  flex: 1;
   font-size: 0.75rem;
-  background: linear-gradient(180deg, transparent 0%, rgba(2, 6, 23, 0.85) 100%);
   color: rgba(226, 232, 240, 0.92);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.gallery-like-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  background: rgba(15, 23, 42, 0.78);
+  color: #f8fafc;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  line-height: 1;
+}
+
+.gallery-like-button span:first-child {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.gallery-like-button:hover:not(:disabled),
+.gallery-like-button:focus-visible:not(:disabled) {
+  background: rgba(59, 130, 246, 0.85);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.gallery-like-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.45);
+}
+
+.gallery-like-button--active {
+  background: rgba(220, 38, 38, 0.85);
+  color: #ffffff;
+}
+
+.gallery-like-button--active:hover:not(:disabled),
+.gallery-like-button--active:focus-visible:not(:disabled) {
+  background: rgba(220, 38, 38, 0.92);
+}
+
+.gallery-like-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.gallery-like-button--inline {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.7rem;
+}
+
+.gallery-like-button--inline span:first-child {
+  font-size: 0.85rem;
 }
 
 .gallery-detail__empty {
@@ -6886,6 +7009,10 @@ button {
   font-size: 1.8rem;
   font-weight: 700;
   color: #f8fafc;
+}
+
+.profile-view__stat-value--likes {
+  color: rgba(252, 165, 165, 0.95);
 }
 
 .profile-view__stat-label {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -260,6 +260,24 @@ const deleteModelVersion = async (token: string, modelId: string, versionId: str
     token,
   );
 
+const likeImageAsset = (token: string, imageId: string) =>
+  request<{ image: ImageAsset }>(
+    `/api/assets/images/${imageId}/likes`,
+    {
+      method: 'POST',
+    },
+    token,
+  );
+
+const unlikeImageAsset = (token: string, imageId: string) =>
+  request<{ image: ImageAsset }>(
+    `/api/assets/images/${imageId}/likes`,
+    {
+      method: 'DELETE',
+    },
+    token,
+  );
+
 export const api = {
   getStats: () => request<MetaStats>('/api/meta/stats'),
   getModelAssets: (token?: string) => request<ModelAsset[]>('/api/assets/models', {}, token),
@@ -271,10 +289,17 @@ export const api = {
   updateModelVersion: putModelVersion,
   promoteModelVersion,
   deleteModelVersion,
+  likeImageAsset,
+  unlikeImageAsset,
   login: (email: string, password: string) =>
     request<AuthResponse>('/api/auth/login', {
       method: 'POST',
       body: JSON.stringify({ email, password }),
+    }),
+  register: (email: string, displayName: string, password: string) =>
+    request<AuthResponse>('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({ email, displayName, password }),
     }),
   getCurrentUser: (token: string) => request<{ user: User }>('/api/auth/me', {}, token),
   getUserProfile: (userId: string, options?: { token?: string; audit?: boolean }) => {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -4,7 +4,7 @@ export interface Tag {
   category?: string | null;
 }
 
-export type UserRole = 'CURATOR' | 'ADMIN';
+export type UserRole = 'USER' | 'CURATOR' | 'ADMIN';
 
 export interface User {
   id: string;
@@ -93,6 +93,7 @@ export interface UserProfile {
     modelCount: number;
     galleryCount: number;
     imageCount: number;
+    receivedLikeCount: number;
   };
   models: UserProfileModelSummary[];
   galleries: UserProfileGallerySummary[];
@@ -178,6 +179,8 @@ export interface ImageAsset {
   tags: Tag[];
   createdAt: string;
   updatedAt: string;
+   likeCount: number;
+   viewerHasLiked: boolean;
 }
 
 export interface GalleryEntry {


### PR DESCRIPTION
## Summary
- export a shared gallery include builder, enforce USER permissions, and hydrate like counts across assets and galleries
- refine gallery explorer UI with accessible like buttons, modal fixes, and disabled guest interactions; update admin role summaries
- document USER registration, guest restrictions, and log the ImageLike migration in the changelog

## Testing
- npm run lint (backend)
- npm run lint (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68cff39f4e248333bfa7065ecb7a62ad