### PR TITLE
Restrict model downloads to signed-in users

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -525,3 +525,8 @@
 - **General**: Sped up gallery and model browsing by keeping recent imagery hot in the browser while still refreshing instantly when assets change.
 - **Technical Changes**: Added cache-aware storage resolvers that append short-lived tokens based on `updatedAt` timestamps, updated all preview consumers to use the smarter resolver, and documented the behavior in the README.
 - **Data Changes**: None; cache keys derive from existing metadata.
+
+## 105 – Role-gated model downloads
+- **General**: Hid the model download button from guests so only signed-in members can fetch safetensors.
+- **Technical Changes**: Updated the asset explorer to require USER-or-higher roles before rendering the download link and added README guidance about the new requirement.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 ## Good to Know
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
-- Guests can browse and download public assets, while comments and reactions remain disabled until they register and sign in.
+- Guests can browse public assets, while downloads, comments, and reactions require a signed-in account (USER role or higher).
 - Home spotlight tiles are fully interactive—click previews to jump straight into the model or gallery explorers, and tap tag chips to filter matching content instantly.
 - Gallery and model previews now ship with an intelligent two-minute cache token so browsers keep recent imagery warm while automatically reloading whenever the underlying asset changes.
 - Curators can edit and delete their own models, collections, and images directly from the explorers (each destructive action ships with a “Nicht umkehrbar ist wenn gelöscht wird. weg ist weg.” warning), while administrators continue to see controls for every entry.

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -999,6 +999,9 @@ export const AssetExplorer = ({
     [activeVersion?.metadata],
   );
 
+  const canDownloadModel =
+    currentUser?.role === 'USER' || currentUser?.role === 'CURATOR' || currentUser?.role === 'ADMIN';
+
   const modelDownloadUrl = useMemo(() => {
     if (!activeVersion) {
       return null;
@@ -1009,6 +1012,8 @@ export const AssetExplorer = ({
       activeVersion.storagePath
     );
   }, [activeVersion]);
+
+  const downloadUnavailableLabel = canDownloadModel ? 'Download not available' : 'Sign in to download';
 
   useEffect(() => {
     if (!isTagDialogOpen) {
@@ -1476,7 +1481,7 @@ export const AssetExplorer = ({
                         </div>
                       )}
                       <div className="asset-detail__preview-actions">
-                        {modelDownloadUrl ? (
+                        {canDownloadModel && modelDownloadUrl ? (
                           <a
                             className="asset-detail__download asset-detail__action"
                             href={modelDownloadUrl}
@@ -1488,7 +1493,7 @@ export const AssetExplorer = ({
                           </a>
                         ) : (
                           <span className="asset-detail__download asset-detail__download--disabled asset-detail__action">
-                            Download not available
+                            {downloadUnavailableLabel}
                           </span>
                         )}
                         <div className="asset-detail__gallery-links">


### PR DESCRIPTION
## Summary
- gate the model download button in the asset explorer to USER-or-higher roles and show a sign-in message for guests
- note the new download requirement in the README to keep guest guidance current
- log the restriction in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d00866126c8333b29ebc2ec986c050