### PR TITLE
Add comments for models and images

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -530,3 +530,8 @@
 - **General**: Hid the model download button from guests so only signed-in members can fetch safetensors.
 - **Technical Changes**: Updated the asset explorer to require USER-or-higher roles before rendering the download link and added README guidance about the new requirement.
 - **Data Changes**: None.
+
+## 106 – Comment threads for models & gallery images
+- **General**: Opened persistent discussions on modelcards and gallery imagery with inline like toggles for every response.
+- **Technical Changes**: Added Prisma tables for model/image comments plus likes, exposed REST endpoints for loading, posting, and reacting to comments, wired new API helpers, built a reusable CommentSection component with anchors in both explorers, and refreshed styling plus README highlights for the quick comment links.
+- **Data Changes**: Introduced the `ModelComment`, `ModelCommentLike`, `ImageComment`, and `ImageCommentLike` tables via Prisma migration.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - Guests can browse public assets, while downloads, comments, and reactions require a signed-in account (USER role or higher).
 - Home spotlight tiles are fully interactive—click previews to jump straight into the model or gallery explorers, and tap tag chips to filter matching content instantly.
 - Gallery and model previews now ship with an intelligent two-minute cache token so browsers keep recent imagery warm while automatically reloading whenever the underlying asset changes.
+- Model detail views and the gallery lightbox now include full comment threads with quick anchors beneath the download/like actions; signed-in members can post feedback and react to individual responses in place.
 - Curators can edit and delete their own models, collections, and images directly from the explorers (each destructive action ships with a “Nicht umkehrbar ist wenn gelöscht wird. weg ist weg.” warning), while administrators continue to see controls for every entry.
 - Manual collection linking lets curators attach their own galleries to models from the detail view, while administrators can pair any collection when moderation requires intervention.
 - Private uploads remain hidden from other curators; the administration workspace now surfaces every model, gallery, and image for admins by default, and the token-aware storage proxy streams private previews directly in the browser for moderation. The **Audit** toggle on curator profiles remains available for targeted spot checks.

--- a/backend/prisma/migrations/20250922120000_add_asset_comments/migration.sql
+++ b/backend/prisma/migrations/20250922120000_add_asset_comments/migration.sql
@@ -1,0 +1,55 @@
+-- CreateTable
+CREATE TABLE "ModelComment" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "modelId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ModelComment_modelId_fkey" FOREIGN KEY ("modelId") REFERENCES "ModelAsset" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ModelComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ModelCommentLike" (
+    "commentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ModelCommentLike_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "ModelComment" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ModelCommentLike_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY ("commentId", "userId")
+);
+
+-- CreateTable
+CREATE TABLE "ImageComment" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "imageId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ImageComment_imageId_fkey" FOREIGN KEY ("imageId") REFERENCES "ImageAsset" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ImageComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "ImageCommentLike" (
+    "commentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ImageCommentLike_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "ImageComment" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ImageCommentLike_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY ("commentId", "userId")
+);
+
+-- CreateIndex
+CREATE INDEX "ModelComment_modelId_idx" ON "ModelComment"("modelId");
+
+-- CreateIndex
+CREATE INDEX "ModelCommentLike_userId_idx" ON "ModelCommentLike"("userId");
+
+-- CreateIndex
+CREATE INDEX "ImageComment_imageId_idx" ON "ImageComment"("imageId");
+
+-- CreateIndex
+CREATE INDEX "ImageCommentLike_userId_idx" ON "ImageCommentLike"("userId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -29,6 +29,10 @@ model User {
   assets      ModelAsset[] @relation("AssetOwner")
   images      ImageAsset[] @relation("ImageOwner")
   imageLikes ImageLike[]
+  modelComments ModelComment[]
+  modelCommentLikes ModelCommentLike[]
+  imageComments ImageComment[]
+  imageCommentLikes ImageCommentLike[]
   uploadDrafts UploadDraft[]
   rankingState UserRankingState?
 }
@@ -65,6 +69,7 @@ model ModelAsset {
   tags         AssetTag[]
   galleryItems GalleryEntry[] @relation("GalleryModel")
   versions     ModelVersion[]
+  comments     ModelComment[]
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
 }
@@ -106,6 +111,7 @@ model ImageAsset {
   ownerId        String
   owner          User           @relation("ImageOwner", fields: [ownerId], references: [id])
   likes          ImageLike[]
+  comments       ImageComment[]
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
 }
@@ -120,6 +126,58 @@ model ImageLike {
 
   @@id([userId, imageId])
   @@index([imageId])
+}
+
+model ModelComment {
+  id        String   @id @default(cuid())
+  modelId   String
+  model     ModelAsset @relation(fields: [modelId], references: [id], onDelete: Cascade)
+  authorId  String
+  author    User       @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  content   String
+  likes     ModelCommentLike[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@index([modelId])
+}
+
+model ModelCommentLike {
+  commentId String
+  userId    String
+  createdAt DateTime @default(now())
+
+  comment ModelComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  user    User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([commentId, userId])
+  @@index([userId])
+}
+
+model ImageComment {
+  id        String   @id @default(cuid())
+  imageId   String
+  image     ImageAsset @relation(fields: [imageId], references: [id], onDelete: Cascade)
+  authorId  String
+  author    User       @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  content   String
+  likes     ImageCommentLike[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@index([imageId])
+}
+
+model ImageCommentLike {
+  commentId String
+  userId    String
+  createdAt DateTime @default(now())
+
+  comment ImageComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  user    User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([commentId, userId])
+  @@index([userId])
 }
 
 model GalleryEntry {

--- a/frontend/src/components/CommentSection.tsx
+++ b/frontend/src/components/CommentSection.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { FormEvent, ChangeEvent } from 'react';
+
+import type { AssetComment } from '../types/api';
+
+interface CommentSectionProps {
+  anchorId: string;
+  title?: string;
+  comments: AssetComment[];
+  isLoading: boolean;
+  isSubmitting?: boolean;
+  error?: string | null;
+  onRetry?: () => Promise<void> | void;
+  onSubmit?: (content: string) => Promise<void>;
+  onToggleLike?: (comment: AssetComment) => Promise<void> | void;
+  likeMutationId?: string | null;
+  canComment: boolean;
+  canLike: boolean;
+  emptyLabel?: string;
+}
+
+const formatTimestamp = (value: string) =>
+  new Date(value).toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+
+export const CommentSection = ({
+  anchorId,
+  title = 'Comments',
+  comments,
+  isLoading,
+  isSubmitting = false,
+  error,
+  onRetry,
+  onSubmit,
+  onToggleLike,
+  likeMutationId,
+  canComment,
+  canLike,
+  emptyLabel = 'No comments yet.',
+}: CommentSectionProps) => {
+  const [draft, setDraft] = useState('');
+  const disableForm = !canComment || !onSubmit;
+  const placeholder = disableForm
+    ? 'Sign in to join the conversation.'
+    : 'Share your feedback with the community…';
+
+  const sortedComments = useMemo(
+    () => [...comments].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()),
+    [comments],
+  );
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!onSubmit || disableForm) {
+        return;
+      }
+
+      const trimmed = draft.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      try {
+        await onSubmit(trimmed);
+        setDraft('');
+      } catch (submissionError) {
+        // Parent component surfaces a detailed error message; keep the draft for editing.
+        console.warn('Comment submission failed:', submissionError);
+      }
+    },
+    [disableForm, draft, onSubmit],
+  );
+
+  const handleChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+    setDraft(event.target.value);
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    try {
+      const result = onRetry?.();
+      if (result && typeof result.then === 'function') {
+        void result;
+      }
+    } catch (retryError) {
+      console.warn('Comment reload failed:', retryError);
+    }
+  }, [onRetry]);
+
+  return (
+    <section id={anchorId} className="comment-section" aria-live="polite">
+      <div className="comment-section__header">
+        <h4>{title}</h4>
+        {onRetry ? (
+          <button type="button" className="comment-section__refresh" onClick={handleRetry} disabled={isLoading}>
+            Refresh
+          </button>
+        ) : null}
+      </div>
+      {error ? (
+        <p className="comment-section__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {isLoading ? <p className="comment-section__status">Loading comments…</p> : null}
+      {!isLoading && sortedComments.length === 0 ? (
+        <p className="comment-section__empty">{emptyLabel}</p>
+      ) : null}
+      {!isLoading && sortedComments.length > 0 ? (
+        <ul className="comment-section__list">
+          {sortedComments.map((comment) => {
+            const createdLabel = formatTimestamp(comment.createdAt);
+            const isEdited = comment.updatedAt !== comment.createdAt;
+            const isMutating = likeMutationId === comment.id;
+            const likeActionLabel = comment.viewerHasLiked ? 'Remove like from comment' : 'Like comment';
+            const likeCountLabel = comment.likeCount === 1 ? '1 like' : `${comment.likeCount} likes`;
+            const likeButtonLabel = canLike ? `${likeActionLabel} (${likeCountLabel})` : 'Sign in to like comments';
+
+            return (
+              <li key={comment.id} className="comment-section__item">
+                <header className="comment-section__item-header">
+                  <div>
+                    <span className="comment-section__author">{comment.author.displayName}</span>
+                    <time dateTime={comment.createdAt}>{createdLabel}</time>
+                    {isEdited ? <span className="comment-section__edited">Edited</span> : null}
+                  </div>
+                  <button
+                    type="button"
+                    className={`comment-section__like${comment.viewerHasLiked ? ' comment-section__like--active' : ''}`}
+                    onClick={() => {
+                      if (!onToggleLike) {
+                        return;
+                      }
+                      void onToggleLike(comment);
+                    }}
+                    disabled={!canLike || !onToggleLike || isMutating}
+                    aria-pressed={comment.viewerHasLiked}
+                    aria-label={likeButtonLabel}
+                    title={likeButtonLabel}
+                  >
+                    <span aria-hidden="true">♥</span>
+                    <span aria-hidden="true">{comment.likeCount}</span>
+                    <span className="sr-only">{likeCountLabel}</span>
+                  </button>
+                </header>
+                <p className="comment-section__content">{comment.content}</p>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+      <form className="comment-section__form" onSubmit={handleSubmit}>
+        <label className="comment-section__input">
+          <span className="sr-only">Add a comment</span>
+          <textarea
+            value={draft}
+            onChange={handleChange}
+            placeholder={placeholder}
+            disabled={disableForm || isSubmitting}
+            rows={3}
+          />
+        </label>
+        <div className="comment-section__form-footer">
+          {!canComment ? <p className="comment-section__hint">Sign in to comment.</p> : null}
+          <button type="submit" disabled={disableForm || isSubmitting}>
+            {isSubmitting ? 'Posting…' : 'Post comment'}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3839,6 +3839,32 @@ main {
   text-transform: uppercase;
 }
 
+.asset-detail__comments-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.asset-detail__comments-link:hover,
+.asset-detail__comments-link:focus-visible {
+  background: rgba(59, 130, 246, 0.28);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #ffffff;
+  outline: none;
+}
+
 .asset-detail__action {
   display: flex;
   width: auto;
@@ -6491,6 +6517,258 @@ button {
   display: flex;
   align-items: center;
   gap: 0.65rem;
+}
+
+.gallery-image-modal__comments-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.gallery-image-modal__comments-link:hover,
+.gallery-image-modal__comments-link:focus-visible {
+  background: rgba(59, 130, 246, 0.28);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #ffffff;
+  outline: none;
+}
+
+.comment-section {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.comment-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.comment-section__header h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.comment-section__refresh {
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  background: rgba(59, 130, 246, 0.15);
+  color: rgba(226, 232, 240, 0.9);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.comment-section__refresh:hover,
+.comment-section__refresh:focus-visible {
+  background: rgba(59, 130, 246, 0.32);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #ffffff;
+  outline: none;
+}
+
+.comment-section__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(248, 113, 113, 0.12);
+  color: #fecaca;
+  font-size: 0.9rem;
+}
+
+.comment-section__status,
+.comment-section__empty {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.9rem;
+}
+
+.comment-section__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.comment-section__item {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.comment-section__item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.comment-section__item-header > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.comment-section__author {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.comment-section__item-header time {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.comment-section__edited {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.comment-section__content {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.92);
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.comment-section__like {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.65);
+  color: rgba(226, 232, 240, 0.9);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.comment-section__like:hover:not(:disabled),
+.comment-section__like:focus-visible:not(:disabled) {
+  background: rgba(59, 130, 246, 0.25);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #ffffff;
+  outline: none;
+}
+
+.comment-section__like--active {
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(59, 130, 246, 0.6);
+  color: #ffffff;
+}
+
+.comment-section__like--active:hover:not(:disabled),
+.comment-section__like--active:focus-visible:not(:disabled) {
+  background: rgba(59, 130, 246, 0.45);
+}
+
+.comment-section__like:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.comment-section__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.comment-section__input textarea {
+  width: 100%;
+  min-height: 96px;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+  color: rgba(226, 232, 240, 0.92);
+  padding: 0.8rem 1rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  resize: vertical;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.comment-section__input textarea:focus-visible {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.comment-section__input textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.comment-section__form-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.comment-section__hint {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.85rem;
+}
+
+.comment-section__form-footer button {
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  background: rgba(59, 130, 246, 0.2);
+  color: rgba(226, 232, 240, 0.92);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.comment-section__form-footer button:hover:not(:disabled),
+.comment-section__form-footer button:focus-visible:not(:disabled) {
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(59, 130, 246, 0.6);
+  color: #ffffff;
+  outline: none;
+}
+
+.comment-section__form-footer button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .gallery-image-modal__edit {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type {
   AuthResponse,
+  AssetComment,
   Gallery,
   ImageAsset,
   MetaStats,
@@ -289,6 +290,56 @@ export const api = {
   updateModelVersion: putModelVersion,
   promoteModelVersion,
   deleteModelVersion,
+  getModelComments: (modelId: string, token?: string | null) =>
+    request<{ comments: AssetComment[] }>(`/api/assets/models/${modelId}/comments`, {}, token ?? undefined).then(
+      (response) => response.comments,
+    ),
+  createModelComment: (modelId: string, content: string, token: string) =>
+    request<{ comment: AssetComment }>(
+      `/api/assets/models/${modelId}/comments`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ content }),
+      },
+      token,
+    ).then((response) => response.comment),
+  likeModelComment: (modelId: string, commentId: string, token: string) =>
+    request<{ comment: AssetComment }>(
+      `/api/assets/models/${modelId}/comments/${commentId}/like`,
+      { method: 'POST' },
+      token,
+    ).then((response) => response.comment),
+  unlikeModelComment: (modelId: string, commentId: string, token: string) =>
+    request<{ comment: AssetComment }>(
+      `/api/assets/models/${modelId}/comments/${commentId}/like`,
+      { method: 'DELETE' },
+      token,
+    ).then((response) => response.comment),
+  getImageComments: (imageId: string, token?: string | null) =>
+    request<{ comments: AssetComment[] }>(`/api/assets/images/${imageId}/comments`, {}, token ?? undefined).then(
+      (response) => response.comments,
+    ),
+  createImageComment: (imageId: string, content: string, token: string) =>
+    request<{ comment: AssetComment }>(
+      `/api/assets/images/${imageId}/comments`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ content }),
+      },
+      token,
+    ).then((response) => response.comment),
+  likeImageComment: (imageId: string, commentId: string, token: string) =>
+    request<{ comment: AssetComment }>(
+      `/api/assets/images/${imageId}/comments/${commentId}/like`,
+      { method: 'POST' },
+      token,
+    ).then((response) => response.comment),
+  unlikeImageComment: (imageId: string, commentId: string, token: string) =>
+    request<{ comment: AssetComment }>(
+      `/api/assets/images/${imageId}/comments/${commentId}/like`,
+      { method: 'DELETE' },
+      token,
+    ).then((response) => response.comment),
   likeImageAsset,
   unlikeImageAsset,
   login: (email: string, password: string) =>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -19,6 +19,23 @@ export interface User {
   updatedAt?: string;
 }
 
+export interface CommentAuthor {
+  id: string;
+  displayName: string;
+  role: UserRole;
+  avatarUrl: string | null;
+}
+
+export interface AssetComment {
+  id: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  likeCount: number;
+  viewerHasLiked: boolean;
+  author: CommentAuthor;
+}
+
 export interface UserProfileRank {
   label: string;
   description: string;


### PR DESCRIPTION
## Summary
- add Prisma models and migrations for model and image comments plus REST handlers for fetching, posting, and liking
- expose comment helpers to the frontend and reuse a shared CommentSection component in the model explorer and gallery modal with quick links
- refresh styling, README highlights, and changelog to document the new discussion features

## Testing
- npm run lint (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d00aa9327083338b1ace3016db5531