### PR TITLE
Add Discord support and footer credits

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -540,3 +540,8 @@
 - **General**: Prioritized the enlarged image view by relocating gallery comments into a collapsible side panel.
 - **Technical Changes**: Embedded the comment section inside the metadata column, added a show/hide toggle with smooth focus handling, adjusted modal layout measurements, and refined styles so the side rail scrolls independently without obscuring the media.
 - **Data Changes**: None; UI-only adjustments.
+
+## 108 – Support channel and credits
+- **General**: Added community support details and proper project attribution.
+- **Technical Changes**: Introduced a global footer in the frontend with Discord support and MythosMachina/AsaTyr credits, and refreshed the README with matching links.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ VisionSuit is evolving toward a richer community layer featuring reactions, thre
 
 An [On-Site Image Generator Project Plan](docs/on-site-image-generator-plan.md) details how a headless ComfyUI service, MinIO-hosted models, and curated review tooling will deliver in-platform rendering with governed moderation and retention workflows.
 
+## Support & Credits
+
+For real-time assistance, join the [VisionSuit Support Discord](https://discord.gg/UEb68YQwKR). VisionSuit is produced by [MythosMachina](https://github.com/MythosMachina) and developed by [AsaTyr](https://github.com/AsaTyr2018/).
+
 ## Architecture Overview
 
 | Layer | Purpose & Key Technologies |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -839,6 +839,7 @@ export const App = () => {
     activeView === 'profile' && activeProfile
       ? `Featuring ${activeProfile.stats.modelCount} model${activeProfile.stats.modelCount === 1 ? '' : 's'} and ${activeProfile.stats.galleryCount} collection${activeProfile.stats.galleryCount === 1 ? '' : 's'}.`
       : currentMeta.description;
+  const currentYear = new Date().getFullYear();
 
   return (
     <div className="app">
@@ -956,6 +957,27 @@ export const App = () => {
             {errorMessage ? <div className="content__alert">{errorMessage}</div> : null}
 
             {renderContent()}
+
+            <footer className="footer" aria-label="Support and credits">
+              <div>
+                <p className="footer__title">VisionSuit Support</p>
+                <div className="footer__links">
+                  <a href="https://discord.gg/UEb68YQwKR" target="_blank" rel="noreferrer noopener">
+                    Join the Discord Support Hub
+                  </a>
+                  <a href="https://github.com/MythosMachina" target="_blank" rel="noreferrer noopener">
+                    MythosMachina Studio
+                  </a>
+                  <a href="https://github.com/AsaTyr2018/" target="_blank" rel="noreferrer noopener">
+                    AsaTyr on GitHub
+                  </a>
+                </div>
+              </div>
+              <div className="footer__status">
+                <span>© {currentYear} MythosMachina. All rights reserved.</span>
+                <span>Developed by AsaTyr.</span>
+              </div>
+            </footer>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a support and credits section to the README with the Discord hub and GitHub links
- introduce a global footer in the VisionSuit frontend with Discord support access and studio/developer attribution
- document the update in the project changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0185915b883339e764ec1ce265c0e