### PR TITLE
Add ComfyUI GPU worker installer with MinIO hooks

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -545,3 +545,8 @@
 - **General**: Added community support details and proper project attribution.
 - **Technical Changes**: Introduced a global footer in the frontend with Discord support and MythosMachina/AsaTyr credits, and refreshed the README with matching links.
 - **Data Changes**: None.
+
+## 109 – GPU worker bootstrap
+- **General**: Added a dedicated installer to provision ComfyUI GPU workers with MinIO connectivity.
+- **Technical Changes**: Introduced `gpuworker/install.sh`, MinIO helper scripts for model manifests, LoRA sync, and output uploads, plus documentation updates in the main README and a focused GPU worker guide.
+- **Data Changes**: None; scripts interact with runtime storage only.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ npm run create-admin -- \
 
 The script upserts an `ADMIN` role account, activates it, and stores the hashed password.
 
+### Dedicated GPU worker provisioning
+
+A remote ComfyUI render node can be prepared independently of the VisionSuit stack. Copy the [`gpuworker/`](gpuworker/README.md) directory to the GPU host, run `sudo ./gpuworker/install.sh`, and then populate `/etc/comfyui/minio.env` with MinIO credentials before enabling the `comfyui` systemd service. The helper toolkit (`generate-model-manifest`, `sync-loras`, and `upload-outputs`) keeps base models, LoRAs, and rendered outputs synchronized with MinIO.
+
 ## Development Workflow
 
 ### Unified dev starter

--- a/gpuworker/README.md
+++ b/gpuworker/README.md
@@ -1,0 +1,25 @@
+# GPU Worker Bootstrap
+
+The `gpuworker` directory contains a self-contained installer for preparing a dedicated ComfyUI render node on a fresh GPU host. The script configures the operating system, clones ComfyUI, and installs helper utilities that integrate the worker with MinIO-hosted models and outputs.
+
+## Quick start
+
+1. Copy the `gpuworker/` directory to the target GPU host.
+2. Run the installer with elevated privileges:
+   ```bash
+   sudo ./gpuworker/install.sh
+   ```
+3. Edit `/etc/comfyui/minio.env` and provide the MinIO endpoint, credentials, and bucket names before starting the `comfyui` systemd service:
+   ```bash
+   sudo systemctl enable --now comfyui.service
+   ```
+
+## MinIO helper commands
+
+The installer publishes a small toolkit into `/usr/local/bin` so the worker can stay synchronized with MinIO:
+
+- `generate-model-manifest` – produces a JSON manifest of available base-model checkpoints from MinIO for ComfyUI's dropdowns.
+- `sync-loras` – downloads the latest LoRA adapters from MinIO into the worker's local cache.
+- `upload-outputs` – pushes freshly rendered outputs from the worker back into the configured MinIO bucket.
+
+All helpers rely on the values stored in `/etc/comfyui/minio.env`. Update that file or export the variables inline to override destinations or prefixes.

--- a/gpuworker/install.sh
+++ b/gpuworker/install.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "This installer must be run as root or with sudo." >&2
+  exit 1
+fi
+
+COMFY_USER="${COMFY_USER:-comfyui}"
+COMFY_GROUP="${COMFY_GROUP:-$COMFY_USER}"
+COMFY_REPO="${COMFY_REPO:-https://github.com/comfyanonymous/ComfyUI.git}"
+COMFY_BRANCH="${COMFY_BRANCH:-master}"
+COMFY_DIR="${COMFY_DIR:-/opt/comfyui}"
+COMFY_VENV="${COMFY_VENV:-$COMFY_DIR/.venv}"
+MODEL_ROOT="${MODEL_ROOT:-/var/lib/comfyui/models}"
+LORA_ROOT="${LORA_ROOT:-/var/lib/comfyui/loras}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-/var/lib/comfyui/outputs}"
+BIN_ROOT="${BIN_ROOT:-/usr/local/lib/comfyui}"
+SYMLINK_DIR="${SYMLINK_DIR:-/usr/local/bin}"
+SERVICE_FILE="${SERVICE_FILE:-/etc/systemd/system/comfyui.service}"
+MINIO_ENV_FILE="${MINIO_ENV_FILE:-/etc/comfyui/minio.env}"
+MINIO_ENV_DIR="$(dirname "$MINIO_ENV_FILE")"
+TORCH_PACKAGE_SPEC="${TORCH_PACKAGE_SPEC:-torch torchvision torchaudio}"
+TORCH_INDEX_URL="${TORCH_INDEX_URL:-https://download.pytorch.org/whl/cu121}"
+SCRIPTS_SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts"
+SCRIPT_NAMES=(generate-model-manifest.sh sync-loras.sh upload-outputs.sh)
+
+log() {
+  printf '\n[%s] %s\n' "$(date --iso-8601=seconds)" "$*"
+}
+
+install_packages() {
+  log "Installing system dependencies"
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -y
+  apt-get install -y --no-install-recommends \
+    git \
+    python3 \
+    python3-venv \
+    python3-pip \
+    build-essential \
+    libgl1 \
+    libglib2.0-0 \
+    curl \
+    wget \
+    unzip \
+    jq \
+    awscli \
+    pkg-config
+}
+
+ensure_user() {
+  if ! id "$COMFY_USER" &>/dev/null; then
+    log "Creating system user $COMFY_USER"
+    useradd --system --create-home --shell /usr/sbin/nologin "$COMFY_USER"
+  fi
+}
+
+clone_repo() {
+  if [[ -d "$COMFY_DIR/.git" ]]; then
+    log "Updating existing ComfyUI checkout"
+    git -C "$COMFY_DIR" fetch origin
+    git -C "$COMFY_DIR" checkout "$COMFY_BRANCH"
+    git -C "$COMFY_DIR" pull --ff-only origin "$COMFY_BRANCH"
+  else
+    log "Cloning ComfyUI into $COMFY_DIR"
+    install -d -m 0755 "$COMFY_DIR"
+    git clone --branch "$COMFY_BRANCH" "$COMFY_REPO" "$COMFY_DIR"
+  fi
+  chown -R "$COMFY_USER":"$COMFY_GROUP" "$COMFY_DIR"
+}
+
+setup_python() {
+  log "Configuring Python virtual environment"
+  python3 -m venv "$COMFY_VENV"
+  source "$COMFY_VENV/bin/activate"
+  pip install --upgrade pip wheel setuptools
+  if [[ -f "$COMFY_DIR/requirements.txt" ]]; then
+    pip install -r "$COMFY_DIR/requirements.txt"
+  fi
+  if [[ -n "$TORCH_PACKAGE_SPEC" ]]; then
+    log "Installing PyTorch packages via $TORCH_INDEX_URL"
+    pip install --index-url "$TORCH_INDEX_URL" $TORCH_PACKAGE_SPEC
+  fi
+  pip install --upgrade xformers || true
+  deactivate
+  chown -R "$COMFY_USER":"$COMFY_GROUP" "$COMFY_VENV"
+}
+
+prepare_directories() {
+  log "Ensuring asset directories exist"
+  install -d -m 0775 "$MODEL_ROOT"
+  install -d -m 0775 "$LORA_ROOT"
+  install -d -m 0775 "$OUTPUT_ROOT"
+  chown -R "$COMFY_USER":"$COMFY_GROUP" "$MODEL_ROOT" "$LORA_ROOT" "$OUTPUT_ROOT"
+}
+
+install_support_scripts() {
+  log "Installing MinIO helper scripts"
+  install -d -m 0755 "$BIN_ROOT"
+  for script in "${SCRIPT_NAMES[@]}"; do
+    if [[ -f "$SCRIPTS_SRC_DIR/$script" ]]; then
+      install -m 0755 "$SCRIPTS_SRC_DIR/$script" "$BIN_ROOT/$script"
+      ln -sf "$BIN_ROOT/$script" "$SYMLINK_DIR/${script%.sh}"
+    else
+      log "WARNING: Missing helper script $script in $SCRIPTS_SRC_DIR"
+    fi
+  done
+}
+
+stage_minio_env() {
+  install -d -m 0750 "$MINIO_ENV_DIR"
+  if [[ ! -f "$MINIO_ENV_FILE" ]]; then
+    log "Creating MinIO environment template at $MINIO_ENV_FILE"
+    cat <<'EOT' >"$MINIO_ENV_FILE"
+# Populate with production credentials before starting ComfyUI
+MINIO_ENDPOINT="https://minio.example.com"
+MINIO_REGION="us-east-1"
+MINIO_ACCESS_KEY="change-me"
+MINIO_SECRET_KEY="change-me"
+MINIO_MODELS_BUCKET="comfyui-models"
+MINIO_LORAS_BUCKET="comfyui-loras"
+MINIO_OUTPUTS_BUCKET="comfyui-outputs"
+MINIO_SECURE="true"
+EOT
+    chmod 0640 "$MINIO_ENV_FILE"
+  fi
+  chown -R "$COMFY_USER":"$COMFY_GROUP" "$MINIO_ENV_DIR"
+}
+
+install_service() {
+  log "Writing comfyui systemd service"
+  cat <<EOF2 >"$SERVICE_FILE"
+[Unit]
+Description=ComfyUI headless worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=$COMFY_USER
+Group=$COMFY_GROUP
+WorkingDirectory=$COMFY_DIR
+EnvironmentFile=$MINIO_ENV_FILE
+Environment=COMFYUI_MODEL_DIR=$MODEL_ROOT
+Environment=COMFYUI_LORA_DIR=$LORA_ROOT
+Environment=COMFYUI_OUTPUT_DIR=$OUTPUT_ROOT
+Environment=PYTHONUNBUFFERED=1
+ExecStart=$COMFY_VENV/bin/python main.py --listen 0.0.0.0 --disable-auto-launch --port 8188
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF2
+  systemctl daemon-reload
+  log "Enable with: systemctl enable --now comfyui.service"
+}
+
+main() {
+  install_packages
+  ensure_user
+  clone_repo
+  setup_python
+  prepare_directories
+  install_support_scripts
+  stage_minio_env
+  install_service
+  log "Installation complete. Populate $MINIO_ENV_FILE with MinIO credentials before starting the service."
+}
+
+main "$@"

--- a/gpuworker/scripts/generate-model-manifest.sh
+++ b/gpuworker/scripts/generate-model-manifest.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${MINIO_ENV_FILE:-/etc/comfyui/minio.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+: "${MINIO_ENDPOINT:?Set MINIO_ENDPOINT in $ENV_FILE or the environment}"
+: "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in $ENV_FILE or the environment}"
+: "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in $ENV_FILE or the environment}"
+: "${MINIO_MODELS_BUCKET:?Set MINIO_MODELS_BUCKET in $ENV_FILE or the environment}"
+
+COMFY_DIR="${COMFY_DIR:-/opt/comfyui}"
+MANIFEST_PATH="${1:-$COMFY_DIR/config/minio-model-manifest.json}"
+PREFIX="${MINIO_MODELS_PREFIX:-}"
+REGION="${MINIO_REGION:-us-east-1}"
+SCHEME_FLAG=()
+
+if [[ "${MINIO_SECURE:-true}" == "false" ]]; then
+  SCHEME_FLAG=("--no-verify-ssl")
+fi
+
+export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
+export AWS_DEFAULT_REGION="$REGION"
+export AWS_EC2_METADATA_DISABLED=true
+
+mkdir -p "$(dirname "$MANIFEST_PATH")"
+
+QUERY='Contents[].{"key":Key,"size":Size,"last_modified":LastModified}'
+if [[ -n "$PREFIX" ]]; then
+  FILTER=(--prefix "$PREFIX")
+else
+  FILTER=()
+fi
+
+aws --endpoint-url "$MINIO_ENDPOINT" "${SCHEME_FLAG[@]}" s3api list-objects-v2 \
+  --bucket "$MINIO_MODELS_BUCKET" \
+  "${FILTER[@]}" \
+  --query "$QUERY" \
+  --output json >"$MANIFEST_PATH.tmp"
+
+if [[ ! -s "$MANIFEST_PATH.tmp" ]]; then
+  echo "[]" >"$MANIFEST_PATH.tmp"
+fi
+
+mv "$MANIFEST_PATH.tmp" "$MANIFEST_PATH"
+echo "Model manifest written to $MANIFEST_PATH"

--- a/gpuworker/scripts/sync-loras.sh
+++ b/gpuworker/scripts/sync-loras.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${MINIO_ENV_FILE:-/etc/comfyui/minio.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+: "${MINIO_ENDPOINT:?Set MINIO_ENDPOINT in $ENV_FILE or the environment}"
+: "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in $ENV_FILE or the environment}"
+: "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in $ENV_FILE or the environment}"
+: "${MINIO_LORAS_BUCKET:?Set MINIO_LORAS_BUCKET in $ENV_FILE or the environment}"
+
+TARGET_DIR="${1:-${LORA_ROOT:-/var/lib/comfyui/loras}}"
+PREFIX="${MINIO_LORAS_PREFIX:-}"
+REGION="${MINIO_REGION:-us-east-1}"
+SCHEME_FLAG=()
+
+if [[ "${MINIO_SECURE:-true}" == "false" ]]; then
+  SCHEME_FLAG=("--no-verify-ssl")
+fi
+
+export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
+export AWS_DEFAULT_REGION="$REGION"
+export AWS_EC2_METADATA_DISABLED=true
+
+mkdir -p "$TARGET_DIR"
+FILTER_ARGS=()
+if [[ -n "$PREFIX" ]]; then
+  FILTER_ARGS+=("--exclude" "*" "--include" "$PREFIX*")
+fi
+
+aws --endpoint-url "$MINIO_ENDPOINT" "${SCHEME_FLAG[@]}" s3 sync \
+  "s3://$MINIO_LORAS_BUCKET" "$TARGET_DIR" \
+  --only-show-errors \
+  "${FILTER_ARGS[@]}"
+
+echo "LoRA weights synchronized to $TARGET_DIR"

--- a/gpuworker/scripts/upload-outputs.sh
+++ b/gpuworker/scripts/upload-outputs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${MINIO_ENV_FILE:-/etc/comfyui/minio.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+: "${MINIO_ENDPOINT:?Set MINIO_ENDPOINT in $ENV_FILE or the environment}"
+: "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in $ENV_FILE or the environment}"
+: "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in $ENV_FILE or the environment}"
+: "${MINIO_OUTPUTS_BUCKET:?Set MINIO_OUTPUTS_BUCKET in $ENV_FILE or the environment}"
+
+SOURCE_DIR="${1:-${OUTPUT_ROOT:-/var/lib/comfyui/outputs}}"
+PREFIX="${MINIO_OUTPUTS_PREFIX:-}" 
+REGION="${MINIO_REGION:-us-east-1}"
+SCHEME_FLAG=()
+
+if [[ "${MINIO_SECURE:-true}" == "false" ]]; then
+  SCHEME_FLAG=("--no-verify-ssl")
+fi
+
+export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
+export AWS_DEFAULT_REGION="$REGION"
+export AWS_EC2_METADATA_DISABLED=true
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "Output directory $SOURCE_DIR does not exist" >&2
+  exit 1
+fi
+
+SYNC_DEST="s3://$MINIO_OUTPUTS_BUCKET/${PREFIX}" 
+SYNC_DEST="${SYNC_DEST%/}"
+
+aws --endpoint-url "$MINIO_ENDPOINT" "${SCHEME_FLAG[@]}" s3 sync \
+  "$SOURCE_DIR" "$SYNC_DEST" \
+  --acl private \
+  --no-progress
+
+echo "Outputs uploaded from $SOURCE_DIR to $SYNC_DEST"


### PR DESCRIPTION
## Summary
- add a standalone `gpuworker/install.sh` script that provisions ComfyUI with systemd support on a fresh GPU host
- include MinIO helper commands to publish model manifests, sync LoRAs, and upload outputs, along with focused documentation
- reference the GPU worker workflow from the main README and extend the project changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d01f74068c833385421d2f40afac22