### PR TITLE
Add AWS CLI fallback to GPU worker installer

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -560,3 +560,8 @@
 - **General**: Equipped the GPU worker installer with intelligent GPU detection and automated driver/runtime setup for NVIDIA and AMD hosts.
 - **Technical Changes**: Added vendor detection with lspci/nvidia-smi/ROCm tools, provisioned CUDA or ROCm repositories, adjusted PyTorch index selection, expanded base dependencies, and refreshed GPU worker documentation plus the project README.
 - **Data Changes**: None.
+
+## 112 – GPU worker AWS CLI fallback (commit TBD)
+- **General**: Unblocked the GPU worker installer on distributions that no longer ship `awscli` via APT.
+- **Technical Changes**: Added an `ensure_aws_cli` helper that installs the official AWS CLI v2 bundle when necessary and refreshed the README to explain the behavior.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The script upserts an `ADMIN` role account, activates it, and stores the hashed 
 ### Dedicated GPU worker provisioning
 
 A remote ComfyUI render node can be prepared independently of the VisionSuit stack. Copy the [`gpuworker/`](gpuworker/README.md) directory to the GPU host, run `sudo ./gpuworker/install.sh`, and provide the MinIO endpoint URL when prompted so the worker targets the correct storage instance. The installer now autodetects NVIDIA and AMD GPUs, installs the matching driver stack (CUDA with the distribution-recommended NVIDIA package or ROCm + HIP for AMD), and falls back to CPU-only PyTorch wheels when no discrete GPU is found. After installation, populate `/etc/comfyui/minio.env` with MinIO credentials before enabling the `comfyui` systemd service. The helper toolkit (`generate-model-manifest`, `sync-loras`, and `upload-outputs`) keeps base models, LoRAs, and rendered outputs synchronized with MinIO.
+If the host repositories omit the legacy `awscli` package, the installer automatically downloads the official AWS CLI v2 bundle so the synchronization helpers remain available.
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary
- add an ensure_aws_cli helper so the gpu worker installer falls back to the official AWS CLI v2 bundle when apt lacks awscli
- refresh the GPU worker documentation and changelog to highlight the new AWS CLI handling

## Testing
- bash -n gpuworker/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68d032106c6c8333beef364761d05279