### PR TITLE
Add GPU worker MinIO validation scripts

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -565,3 +565,8 @@
 - **General**: Unblocked the GPU worker installer on distributions that no longer ship `awscli` via APT.
 - **Technical Changes**: Added an `ensure_aws_cli` helper that installs the official AWS CLI v2 bundle when necessary and refreshed the README to explain the behavior.
 - **Data Changes**: None.
+
+## 113 – GPU worker MinIO test harness (commit TBD)
+- **General**: Added standalone scripts so GPU render nodes can validate MinIO storage without the full VisionSuit stack.
+- **Technical Changes**: Shipped bucket provisioning, checkpoint/LoRA upload, and output download helpers plus README instructions for their usage.
+- **Data Changes**: Scripts can create MinIO buckets and upload test assets during validation runs.

--- a/gpuworker/README.md
+++ b/gpuworker/README.md
@@ -32,3 +32,19 @@ The installer publishes a small toolkit into `/usr/local/bin` so the worker can 
 - `upload-outputs` – pushes freshly rendered outputs from the worker back into the configured MinIO bucket.
 
 All helpers rely on the values stored in `/etc/comfyui/minio.env`. Update that file or export the variables inline to override destinations or prefixes.
+
+## Test validation scripts
+
+When VisionSuit has not yet been wired to the worker you can still verify connectivity with the purpose-built test helpers (copied to `/usr/local/bin` alongside the other utilities):
+
+- `test-create-buckets` – ensures the configured checkpoint, LoRA, and output buckets exist (creating them when missing).
+- `test-upload-models` – uploads local checkpoint and/or LoRA files into MinIO so ComfyUI can discover them. Example:
+  ```bash
+  test-upload-models --models ~/Downloads/checkpoints --loras ~/Downloads/loras
+  ```
+- `test-export-outputs` – downloads renders from MinIO to a local folder for manual inspection. Example:
+  ```bash
+  test-export-outputs ~/tmp/comfyui-outputs
+  ```
+
+Each test script reads `/etc/comfyui/minio.env`, honours optional `MINIO_*_PREFIX` values, and requires the AWS CLI to be installed.

--- a/gpuworker/scripts/test-create-buckets.sh
+++ b/gpuworker/scripts/test-create-buckets.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required. Install it before running this script." >&2
+  exit 1
+fi
+
+ENV_FILE="${MINIO_ENV_FILE:-/etc/comfyui/minio.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+: "${MINIO_ENDPOINT:?Set MINIO_ENDPOINT in $ENV_FILE or the environment}"
+: "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in $ENV_FILE or the environment}"
+: "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in $ENV_FILE or the environment}"
+: "${MINIO_MODELS_BUCKET:?Set MINIO_MODELS_BUCKET in $ENV_FILE or the environment}"
+: "${MINIO_LORAS_BUCKET:?Set MINIO_LORAS_BUCKET in $ENV_FILE or the environment}"
+: "${MINIO_OUTPUTS_BUCKET:?Set MINIO_OUTPUTS_BUCKET in $ENV_FILE or the environment}"
+
+REGION="${MINIO_REGION:-us-east-1}"
+SCHEME_FLAG=()
+if [[ "${MINIO_SECURE:-true}" == "false" ]]; then
+  SCHEME_FLAG=("--no-verify-ssl")
+fi
+
+export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
+export AWS_DEFAULT_REGION="$REGION"
+export AWS_EC2_METADATA_DISABLED=true
+
+create_bucket() {
+  local bucket="$1"
+
+  if aws --endpoint-url "$MINIO_ENDPOINT" "${SCHEME_FLAG[@]}" s3api head-bucket --bucket "$bucket" >/dev/null 2>&1; then
+    echo "Bucket '$bucket' already exists."
+    return 0
+  fi
+
+  local create_args=(--bucket "$bucket")
+  if [[ "$REGION" != "us-east-1" && -n "$REGION" ]]; then
+    create_args+=(--create-bucket-configuration "LocationConstraint=$REGION")
+  fi
+
+  echo "Creating bucket '$bucket'..."
+  aws --endpoint-url "$MINIO_ENDPOINT" "${SCHEME_FLAG[@]}" s3api create-bucket "${create_args[@]}"
+  echo "Bucket '$bucket' created."
+}
+
+# Deduplicate buckets in case multiple roles share the same name.
+declare -A PROCESSED=()
+for bucket in "$MINIO_MODELS_BUCKET" "$MINIO_LORAS_BUCKET" "$MINIO_OUTPUTS_BUCKET"; do
+  if [[ -z "$bucket" || -n "${PROCESSED[$bucket]:-}" ]]; then
+    continue
+  fi
+  PROCESSED[$bucket]=1
+  create_bucket "$bucket"
+done
+
+echo "All requested buckets are available."

--- a/gpuworker/scripts/test-export-outputs.sh
+++ b/gpuworker/scripts/test-export-outputs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} [destination]
+
+Downloads rendered outputs from the configured MinIO bucket for validation.
+  destination   Local directory to write the files into (default: ./comfyui-test-outputs)
+  -h, --help    Show this help message.
+USAGE
+}
+
+DESTINATION="./comfyui-test-outputs"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      DESTINATION="$1"
+      shift
+      ;;
+  esac
+done
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required. Install it before running this script." >&2
+  exit 1
+fi
+
+ENV_FILE="${MINIO_ENV_FILE:-/etc/comfyui/minio.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+: "${MINIO_ENDPOINT:?Set MINIO_ENDPOINT in $ENV_FILE or the environment}"
+: "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in $ENV_FILE or the environment}"
+: "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in $ENV_FILE or the environment}"
+: "${MINIO_OUTPUTS_BUCKET:?Set MINIO_OUTPUTS_BUCKET in $ENV_FILE or the environment}"
+
+REGION="${MINIO_REGION:-us-east-1}"
+SCHEME_FLAG=()
+if [[ "${MINIO_SECURE:-true}" == "false" ]]; then
+  SCHEME_FLAG=("--no-verify-ssl")
+fi
+
+export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
+export AWS_DEFAULT_REGION="$REGION"
+export AWS_EC2_METADATA_DISABLED=true
+
+mkdir -p "$DESTINATION"
+
+SOURCE="s3://$MINIO_OUTPUTS_BUCKET"
+PREFIX="${MINIO_OUTPUTS_PREFIX:-}"
+if [[ -n "$PREFIX" ]]; then
+  PREFIX="${PREFIX#/}"
+  PREFIX="${PREFIX%/}"
+  SOURCE="${SOURCE}/${PREFIX}"
+fi
+
+echo "Syncing outputs from '$SOURCE' to '$DESTINATION'..."
+aws --endpoint-url "$MINIO_ENDPOINT" "${SCHEME_FLAG[@]}" s3 sync "$SOURCE" "$DESTINATION"
+echo "Outputs downloaded to $DESTINATION"

--- a/gpuworker/scripts/test-upload-models.sh
+++ b/gpuworker/scripts/test-upload-models.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} [--models PATH] [--loras PATH]
+
+Uploads local checkpoints and LoRA adapters into the MinIO buckets configured in /etc/comfyui/minio.env.
+  --models PATH   File or directory containing checkpoint files to upload to the models bucket.
+  --loras PATH    File or directory containing LoRA adapters to upload to the LoRA bucket.
+  -h, --help      Show this help message.
+
+Provide at least one of --models or --loras.
+USAGE
+}
+
+MODELS_PATH=""
+LORAS_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --models)
+      MODELS_PATH="${2:-}"
+      shift 2
+      ;;
+    --loras)
+      LORAS_PATH="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$MODELS_PATH" && -z "$LORAS_PATH" ]]; then
+  echo "Error: specify --models and/or --loras." >&2
+  usage >&2
+  exit 1
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required. Install it before running this script." >&2
+  exit 1
+fi
+
+ENV_FILE="${MINIO_ENV_FILE:-/etc/comfyui/minio.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+: "${MINIO_ENDPOINT:?Set MINIO_ENDPOINT in $ENV_FILE or the environment}"
+: "${MINIO_ACCESS_KEY:?Set MINIO_ACCESS_KEY in $ENV_FILE or the environment}"
+: "${MINIO_SECRET_KEY:?Set MINIO_SECRET_KEY in $ENV_FILE or the environment}"
+
+if [[ -n "$MODELS_PATH" ]]; then
+  : "${MINIO_MODELS_BUCKET:?Set MINIO_MODELS_BUCKET in $ENV_FILE or the environment}"
+fi
+if [[ -n "$LORAS_PATH" ]]; then
+  : "${MINIO_LORAS_BUCKET:?Set MINIO_LORAS_BUCKET in $ENV_FILE or the environment}"
+fi
+
+REGION="${MINIO_REGION:-us-east-1}"
+SCHEME_FLAG=()
+if [[ "${MINIO_SECURE:-true}" == "false" ]]; then
+  SCHEME_FLAG=("--no-verify-ssl")
+fi
+
+export AWS_ACCESS_KEY_ID="$MINIO_ACCESS_KEY"
+export AWS_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY"
+export AWS_DEFAULT_REGION="$REGION"
+export AWS_EC2_METADATA_DISABLED=true
+
+destination_uri() {
+  local bucket="$1"
+  local prefix="$2"
+  local trimmed_prefix="${prefix#/}"
+  trimmed_prefix="${trimmed_prefix%/}"
+  if [[ -n "$trimmed_prefix" ]]; then
+    echo "s3://$bucket/$trimmed_prefix/"
+  else
+    echo "s3://$bucket/"
+  fi
+}
+
+upload_payload() {
+  local label="$1"
+  local path="$2"
+  local bucket="$3"
+  local prefix="$4"
+
+  if [[ ! -e "$path" ]]; then
+    echo "Error: $label source '$path' does not exist." >&2
+    exit 1
+  fi
+
+  local destination
+  destination=$(destination_uri "$bucket" "$prefix")
+
+  echo "Uploading $label from '$path' to '$destination'..."
+  if [[ -d "$path" ]]; then
+    aws --endpoint-url "$MINIO_ENDPOINT" "${SCHEME_FLAG[@]}" s3 cp "$path" "$destination" --recursive
+  else
+    aws --endpoint-url "$MINIO_ENDPOINT" "${SCHEME_FLAG[@]}" s3 cp "$path" "$destination"
+  fi
+  echo "Uploaded $label to $destination"
+}
+
+if [[ -n "$MODELS_PATH" ]]; then
+  upload_payload "checkpoints" "$MODELS_PATH" "$MINIO_MODELS_BUCKET" "${MINIO_MODELS_PREFIX:-}"
+fi
+
+if [[ -n "$LORAS_PATH" ]]; then
+  upload_payload "LoRA adapters" "$LORAS_PATH" "$MINIO_LORAS_BUCKET" "${MINIO_LORAS_PREFIX:-}"
+fi
+
+echo "Upload complete."


### PR DESCRIPTION
## Summary
- add GPU worker test scripts that provision MinIO buckets, upload checkpoints/LoRAs, and download rendered outputs
- document the new helpers in the GPU worker README for operators running VisionSuit-independent validation
- extend the changelog with the latest GPU worker testing utilities entry

## Testing
- `shellcheck gpuworker/scripts/test-create-buckets.sh gpuworker/scripts/test-upload-models.sh gpuworker/scripts/test-export-outputs.sh` *(fails: shellcheck not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d03725ea908333b00d5faaeb11790c