### PR TITLE
Add SDXL validation workflow sample

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -570,3 +570,13 @@
 - **General**: Added standalone scripts so GPU render nodes can validate MinIO storage without the full VisionSuit stack.
 - **Technical Changes**: Shipped bucket provisioning, checkpoint/LoRA upload, and output download helpers plus README instructions for their usage.
 - **Data Changes**: Scripts can create MinIO buckets and upload test assets during validation runs.
+
+## 114 – ComfyUI workflow CLI validation
+- **General**: Added a non-interactive workflow runner so operators can validate renders without the ComfyUI web UI.
+- **Technical Changes**: Introduced `gpuworker/scripts/test-run-workflow.sh` to source MinIO credentials, post workflows to `/prompt`, poll queue/history endpoints, report asset identifiers, and optionally call `test-export-outputs`.
+- **Data Changes**: Reads existing MinIO environment variables and touches only ComfyUI’s HTTP API plus optional MinIO downloads; no repository data is persisted.
+
+## 033 – SDXL workflow validation pack
+- **General**: Delivered an automation-focused SDXL validation workflow that pairs with the ComfyUI API runner for hands-free checks.
+- **Technical Changes**: Added `gpuworker/workflows/validation.json` capturing the calicomixPonyXL base plus DoomGirl LoRA pipeline and updated the GPU worker README with usage guidance and paths.
+- **Data Changes**: New workflow JSON references the `calicomixPonyXL_v20.safetensors` checkpoint and `DoomGirl.safetensors` adapter for validation renders.

--- a/gpuworker/README.md
+++ b/gpuworker/README.md
@@ -48,3 +48,13 @@ When VisionSuit has not yet been wired to the worker you can still verify connec
   ```
 
 Each test script reads `/etc/comfyui/minio.env`, honours optional `MINIO_*_PREFIX` values, and requires the AWS CLI to be installed.
+
+### API-driven workflow validation
+
+Operators can run workflows without the ComfyUI web UI by calling `scripts/test-run-workflow.sh`. The helper reads `/etc/comfyui/minio.env`, posts the selected workflow JSON to the configured ComfyUI API, polls the queue until completion, and prints the generated asset identifiers. Optional flags let you target remote hosts, change the polling interval, or trigger `test-export-outputs` automatically to download the results. A prebuilt SDXL workflow tailored for automation ships in `workflows/validation.json` (base model: `calicomixPonyXL_v20.safetensors`, LoRA: `DoomGirl.safetensors`).
+
+Example:
+
+```bash
+scripts/test-run-workflow.sh --workflow workflows/validation.json --host comfyui.local --export-dir ~/tmp/comfyui-run
+```

--- a/gpuworker/scripts/test-run-workflow.sh
+++ b/gpuworker/scripts/test-run-workflow.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} --workflow WORKFLOW.json [options]
+
+Queues a ComfyUI workflow via the HTTP API and waits for completion.
+
+Options:
+  -f, --workflow FILE     Workflow JSON exported from ComfyUI (required).
+  -H, --host HOST         ComfyUI host (default: 127.0.0.1).
+  -p, --port PORT         ComfyUI port (default: 8188).
+      --scheme SCHEME     URL scheme for the ComfyUI API (default: http).
+      --url URL           Full base URL (overrides scheme/host/port).
+      --env-file FILE     MinIO environment file (default: /etc/comfyui/minio.env).
+      --export-dir DIR    Automatically run test-export-outputs into DIR after success.
+  -s, --sleep SECONDS     Polling interval in seconds (default: 2).
+  -h, --help              Show this help message.
+USAGE
+}
+
+ensure_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command '$1' is not available." >&2
+    exit 1
+  fi
+}
+
+SCHEME="http"
+HOST="127.0.0.1"
+PORT="8188"
+BASE_URL=""
+WORKFLOW_FILE=""
+ENV_FILE="${MINIO_ENV_FILE:-/etc/comfyui/minio.env}"
+EXPORT_DIR=""
+SLEEP_SECONDS=2
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--workflow|-w)
+      WORKFLOW_FILE="$2"
+      shift 2
+      ;;
+    -H|--host)
+      HOST="$2"
+      shift 2
+      ;;
+    -p|--port)
+      PORT="$2"
+      shift 2
+      ;;
+    --scheme)
+      SCHEME="$2"
+      shift 2
+      ;;
+    --url)
+      BASE_URL="${2%/}"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --export-dir)
+      EXPORT_DIR="$2"
+      shift 2
+      ;;
+    -s|--sleep)
+      SLEEP_SECONDS="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$WORKFLOW_FILE" ]]; then
+  echo "--workflow is required." >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$WORKFLOW_FILE" ]]; then
+  echo "Workflow file '$WORKFLOW_FILE' not found." >&2
+  exit 1
+fi
+
+ensure_command curl
+ensure_command jq
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+if [[ -z "$BASE_URL" ]]; then
+  BASE_URL="${SCHEME}://${HOST}:${PORT}"
+else
+  BASE_URL="${BASE_URL%/}"
+fi
+
+CLIENT_ID="${COMFY_CLIENT_ID:-$(cat /proc/sys/kernel/random/uuid)}"
+PAYLOAD=$(jq -n --arg client_id "$CLIENT_ID" --slurpfile prompt "$WORKFLOW_FILE" '{prompt: $prompt[0], client_id: $client_id}')
+
+QUEUE_RESPONSE=$(curl -sS -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$BASE_URL/prompt")
+PROMPT_ID=$(printf '%s' "$QUEUE_RESPONSE" | jq -r '.prompt_id // .promptId // .id // empty')
+
+if [[ -z "$PROMPT_ID" ]]; then
+  echo "Failed to retrieve prompt ID from response: $QUEUE_RESPONSE" >&2
+  exit 1
+fi
+
+echo "Queued workflow with prompt ID $PROMPT_ID (client: $CLIENT_ID)."
+
+declare -i attempt=0
+STATUS_LABEL="queued"
+COMPLETED="false"
+FAILED="false"
+
+while true; do
+  ((attempt++))
+  sleep "$SLEEP_SECONDS"
+
+  QUEUE_JSON=$(curl -sS "$BASE_URL/queue" || true)
+  PENDING_INDEX=""
+  QUEUE_INDEX=""
+  if [[ -n "$QUEUE_JSON" ]]; then
+    PENDING_INDEX=$(printf '%s' "$QUEUE_JSON" | jq -r --arg id "$PROMPT_ID" '((.pending // []) | map(.prompt_id) | index($id)) // empty') || true
+    QUEUE_INDEX=$(printf '%s' "$QUEUE_JSON" | jq -r --arg id "$PROMPT_ID" '((.queue // []) | map(.prompt_id) | index($id)) // empty') || true
+  fi
+
+  HISTORY_JSON=$(curl -sS "$BASE_URL/history/$PROMPT_ID" || true)
+  HISTORY_NODE=""
+  if [[ -n "$HISTORY_JSON" ]]; then
+    HISTORY_NODE=$(printf '%s' "$HISTORY_JSON" | jq -c --arg id "$PROMPT_ID" '
+      if type == "object" then
+        if has("history") then (.history[$id] // empty)
+        elif has($id) then (.[$id] // empty)
+        else .
+        end
+      else empty
+      end
+    ') || true
+  fi
+
+  if [[ -n "$HISTORY_NODE" && "$HISTORY_NODE" != "null" ]]; then
+    STATUS_LABEL=$(printf '%s' "$HISTORY_NODE" | jq -r '.status.status? // .status.state? // .status.text? // ""')
+    COMPLETED=$(printf '%s' "$HISTORY_NODE" | jq -r '(.status.completed? // false) | tostring')
+    FAILED=$(printf '%s' "$HISTORY_NODE" | jq -r '((.status.failed? // false) or (.status.status? == "error") or (.status.status? == "failed")) | tostring')
+    PROGRESS=$(printf '%s' "$HISTORY_NODE" | jq -r '.status.progress? // empty')
+  else
+    STATUS_LABEL="queued"
+    COMPLETED="false"
+    FAILED="false"
+    PROGRESS=""
+  fi
+
+  if [[ -n "$QUEUE_INDEX" ]]; then
+    POSITION=$((QUEUE_INDEX + 1))
+    echo "[Attempt $attempt] Waiting in queue position $POSITION (status: ${STATUS_LABEL:-unknown})."
+  elif [[ -n "$PENDING_INDEX" ]]; then
+    echo "[Attempt $attempt] Workflow is running (status: ${STATUS_LABEL:-unknown})."
+  else
+    if [[ "$COMPLETED" == "true" ]]; then
+      echo "[Attempt $attempt] Workflow completed successfully."
+    elif [[ "$FAILED" == "true" ]]; then
+      echo "[Attempt $attempt] Workflow reported failure (status: ${STATUS_LABEL:-unknown})."
+    else
+      if [[ -n "$PROGRESS" && "$PROGRESS" != "null" ]]; then
+        echo "[Attempt $attempt] Workflow progress: $PROGRESS (status: ${STATUS_LABEL:-unknown})."
+      else
+        echo "[Attempt $attempt] Workflow is waiting for completion (status: ${STATUS_LABEL:-unknown})."
+      fi
+    fi
+  fi
+
+  if [[ "$FAILED" == "true" ]]; then
+    ERROR_MESSAGE=""
+    if [[ -n "$HISTORY_NODE" && "$HISTORY_NODE" != "null" ]]; then
+      ERROR_MESSAGE=$(printf '%s' "$HISTORY_NODE" | jq -r '.status.error? // .status.message? // empty')
+    fi
+    [[ -n "$ERROR_MESSAGE" ]] && echo "Error details: $ERROR_MESSAGE" >&2
+    exit 1
+  fi
+
+  if [[ "$COMPLETED" == "true" ]]; then
+    break
+  fi
+
+done
+
+if [[ -z "$HISTORY_NODE" || "$HISTORY_NODE" == "null" ]]; then
+  HISTORY_JSON=$(curl -sS "$BASE_URL/history/$PROMPT_ID" || true)
+  if [[ -n "$HISTORY_JSON" ]]; then
+    HISTORY_NODE=$(printf '%s' "$HISTORY_JSON" | jq -c --arg id "$PROMPT_ID" '
+      if type == "object" then
+        if has("history") then (.history[$id] // empty)
+        elif has($id) then (.[$id] // empty)
+        else .
+        end
+      else empty
+      end
+    ') || true
+  fi
+fi
+
+echo "Generated assets:"
+if [[ -n "$HISTORY_NODE" && "$HISTORY_NODE" != "null" ]]; then
+  ASSET_LINES=$(printf '%s' "$HISTORY_NODE" | jq -r '
+    if .outputs then
+      .outputs | to_entries[] | . as $entry |
+      ($entry.value.images[]? | "- Node \($entry.key) image: \(.subfolder // ".")/\(.filename)") ,
+      ($entry.value.gifs[]? | "- Node \($entry.key) gif: \(.subfolder // ".")/\(.filename)") ,
+      ($entry.value.files[]? | "- Node \($entry.key) file: \(.subfolder // ".")/\(.filename)") ,
+      ($entry.value.text[]? | "- Node \($entry.key) text: \(.text)")
+    else
+      empty
+    end
+  ')
+  if [[ -n "$ASSET_LINES" ]]; then
+    while IFS= read -r line; do
+      printf '%s\n' "$line"
+    done <<<"$ASSET_LINES"
+  else
+    echo "- No asset metadata was reported by ComfyUI."
+  fi
+else
+  echo "- Unable to retrieve asset metadata."
+fi
+
+if [[ -n "$EXPORT_DIR" ]]; then
+  if command -v test-export-outputs >/dev/null 2>&1; then
+    echo "Exporting outputs to '$EXPORT_DIR' via test-export-outputs..."
+    test-export-outputs "$EXPORT_DIR"
+  else
+    echo "test-export-outputs not found on PATH; skipping automatic export." >&2
+  fi
+fi
+
+exit 0

--- a/gpuworker/workflows/validation.json
+++ b/gpuworker/workflows/validation.json
@@ -1,0 +1,176 @@
+{
+  "last_node_id": 8,
+  "last_link_id": 11,
+  "workflow_name": "SDXL DoomGirl Validation",
+  "notes": "Automation-focused SDXL workflow using calicomixPonyXL base with DoomGirl LoRA",
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CheckpointLoaderSimple",
+      "pos": [80, -40],
+      "size": {"0": 315, "1": 130},
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "MODEL", "type": "MODEL", "links": [1]},
+        {"name": "CLIP", "type": "CLIP", "links": [2]},
+        {"name": "VAE", "type": "VAE", "links": [7]}
+      ],
+      "properties": {"Node name for S&R": "CheckpointLoaderSimple"},
+      "widgets_values": ["calicomixPonyXL_v20.safetensors"]
+    },
+    {
+      "id": 2,
+      "type": "LoraLoader",
+      "pos": [460, -60],
+      "size": {"0": 310, "1": 180},
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {"name": "model", "type": "MODEL", "link": 1},
+        {"name": "clip", "type": "CLIP", "link": 2}
+      ],
+      "outputs": [
+        {"name": "MODEL", "type": "MODEL", "links": [4]},
+        {"name": "CLIP", "type": "CLIP", "links": [5, 6]}
+      ],
+      "properties": {"Node name for S&R": "LoraLoader"},
+      "widgets_values": ["DoomGirl.safetensors", 0.85, 0.8]
+    },
+    {
+      "id": 3,
+      "type": "CLIPTextEncodeSDXL",
+      "pos": [460, 220],
+      "size": {"0": 340, "1": 230},
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {"name": "clip", "type": "CLIP", "link": 5}
+      ],
+      "outputs": [
+        {"name": "CONDITIONING", "type": "CONDITIONING", "links": [8]}
+      ],
+      "properties": {"Node name for S&R": "CLIPTextEncodeSDXL"},
+      "widgets_values": [
+        "Heroic Doom marine portrait, cinematic angle, ultra-detailed armor, volumetric lighting",
+        "studio quality, 85mm lens, high dynamic range",
+        1
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CLIPTextEncodeSDXL",
+      "pos": [460, 520],
+      "size": {"0": 340, "1": 230},
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {"name": "clip", "type": "CLIP", "link": 6}
+      ],
+      "outputs": [
+        {"name": "CONDITIONING", "type": "CONDITIONING", "links": [9]}
+      ],
+      "properties": {"Node name for S&R": "CLIPTextEncodeSDXL"},
+      "widgets_values": [
+        "",
+        "blurry, low detail, deformed anatomy, duplicate limbs, watermark",
+        1
+      ]
+    },
+    {
+      "id": 5,
+      "type": "EmptyLatentImage",
+      "pos": [480, 820],
+      "size": {"0": 210, "1": 150},
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "LATENT", "type": "LATENT", "links": [3]}
+      ],
+      "properties": {"Node name for S&R": "EmptyLatentImage"},
+      "widgets_values": [1024, 1024, 1]
+    },
+    {
+      "id": 6,
+      "type": "KSampler",
+      "pos": [820, 220],
+      "size": {"0": 330, "1": 340},
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {"name": "model", "type": "MODEL", "link": 4},
+        {"name": "positive", "type": "CONDITIONING", "link": 8},
+        {"name": "negative", "type": "CONDITIONING", "link": 9},
+        {"name": "latent_image", "type": "LATENT", "link": 3}
+      ],
+      "outputs": [
+        {"name": "LATENT", "type": "LATENT", "links": [10]}
+      ],
+      "properties": {"Node name for S&R": "KSampler"},
+      "widgets_values": [123456789, 30, 0, 0, 6.5, "dpmpp_2m", "karras", 1]
+    },
+    {
+      "id": 7,
+      "type": "VAEDecode",
+      "pos": [1180, 260],
+      "size": {"0": 250, "1": 170},
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {"name": "samples", "type": "LATENT", "link": 10},
+        {"name": "vae", "type": "VAE", "link": 7}
+      ],
+      "outputs": [
+        {"name": "IMAGE", "type": "IMAGE", "links": [11]}
+      ],
+      "properties": {"Node name for S&R": "VAEDecode"}
+    },
+    {
+      "id": 8,
+      "type": "SaveImage",
+      "pos": [1460, 260],
+      "size": {"0": 240, "1": 150},
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {"name": "images", "type": "IMAGE", "link": 11}
+      ],
+      "outputs": [],
+      "properties": {},
+      "widgets_values": ["validation/sdxl_doomgirl", false, "outputs"]
+    }
+  ],
+  "links": [
+    [1, 1, 0, 2, 0, "MODEL"],
+    [2, 1, 1, 2, 1, "CLIP"],
+    [3, 5, 0, 6, 3, "LATENT"],
+    [4, 2, 0, 6, 0, "MODEL"],
+    [5, 2, 1, 3, 0, "CLIP"],
+    [6, 2, 1, 4, 0, "CLIP"],
+    [7, 1, 2, 7, 1, "VAE"],
+    [8, 3, 0, 6, 1, "CONDITIONING"],
+    [9, 4, 0, 6, 2, "CONDITIONING"],
+    [10, 6, 0, 7, 0, "LATENT"],
+    [11, 7, 0, 8, 0, "IMAGE"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "custom_node_auto_load": false,
+    "workspace": {
+      "colormap": null,
+      "guid": "sdxl-validation"
+    }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
## Summary
- add an automation-oriented SDXL validation workflow JSON using calicomixPonyXL_v20 with the DoomGirl LoRA
- surface the packaged workflow and usage path inside the GPU worker README
- log the new workflow asset in the changelog for operators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d03e0496788333b47142ad8fddeddf