### PR TITLE
Add generator base model sync helper

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -626,3 +626,8 @@
 - **General**: Ensured the On-Site Generator surfaces only real ComfyUI checkpoints by reading the dedicated MinIO bucket instead of relying on heuristics that exposed LoRA assets.
 - **Technical Changes**: Added a backend `/api/generator/base-models` endpoint driven by the new `GENERATOR_BASE_MODEL_BUCKET` config, refactored mapping utilities for reuse, fetched and rendered the base-model list on the client with loading/error states, updated styles, and refreshed documentation plus env templates.
 - **Data Changes**: None; changes are configuration-driven with no schema updates.
+
+## 124 – Generator checkpoint sync helper
+- **General**: Diagnosed missing base models in the On-Site Generator and added a synchronization path so MinIO checkpoints appear in the picker once they land in the bucket.
+- **Technical Changes**: Introduced `backend/scripts/syncGeneratorBaseModels.ts` with a matching `npm run generator:sync-base-models` alias to upsert public checkpoint assets, ensure ownership, and flag metadata for the generator pipeline.
+- **Data Changes**: None; the helper only registers existing MinIO objects without altering stored checkpoint files.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,14 @@ During execution the installer:
 4. Provisions MinIO credentials, configures buckets, and launches the `visionsuit-minio` container.
 5. Offers optional execution of `npm run prisma:migrate`, `npm run seed`, and `npm run create-admin` for initial data.
 
-Base checkpoints for the On-Site Generator live in the GPU worker bucket `comfyui-models`. When customizing bucket names, mirror the change inside `backend/.env` with `GENERATOR_BASE_MODEL_BUCKET` and inside `frontend/.env` via `VITE_GENERATOR_BASE_MODEL_BUCKET` so the generator UI continues to list only the real ComfyUI base models.
+Base checkpoints for the On-Site Generator live in the GPU worker bucket `comfyui-models`. When customizing bucket names, mirror the change inside `backend/.env` with `GENERATOR_BASE_MODEL_BUCKET` and inside `frontend/.env` via `VITE_GENERATOR_BASE_MODEL_BUCKET` so the generator UI continues to list only the real ComfyUI base models. After uploading or syncing new checkpoints into that bucket, register them with the VisionSuit database so the generator can resolve permissions and metadata:
+
+```bash
+cd backend
+npm run generator:sync-base-models
+```
+
+The helper script cross-references the configured bucket, creates public `checkpoint` model assets for any missing entries, and refreshes ownership/metadata for existing records so curators immediately see the freshly added base models inside the On-Site Generator picker.
 
 After completion the stack is ready for development or evaluation. Use `./dev-start.sh` for a combined watch mode when coding locally.
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:studio": "prisma studio",
     "seed": "ts-node --transpile-only prisma/seed.ts",
-    "create-admin": "ts-node --transpile-only scripts/createAdmin.ts"
+    "create-admin": "ts-node --transpile-only scripts/createAdmin.ts",
+    "generator:sync-base-models": "ts-node --transpile-only scripts/syncGeneratorBaseModels.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.16.2",

--- a/backend/scripts/syncGeneratorBaseModels.ts
+++ b/backend/scripts/syncGeneratorBaseModels.ts
@@ -1,0 +1,190 @@
+import { Prisma, PrismaClient, UserRole } from '@prisma/client';
+
+import '../src/config';
+
+import { appConfig } from '../src/config';
+import { storageClient } from '../src/lib/storage';
+import { buildUniqueSlug } from '../src/lib/slug';
+
+const prisma = new PrismaClient();
+
+const deriveTitle = (objectName: string) => {
+  const fileName = objectName.split('/').pop() ?? objectName;
+  const withoutExtension = fileName.replace(/\.[^.]+$/, '');
+  const spaced = withoutExtension.replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim();
+
+  if (spaced.length === 0) {
+    return fileName;
+  }
+
+  return spaced
+    .split(' ')
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+    .join(' ');
+};
+
+const ensureOwner = async () => {
+  const admin = await prisma.user.findFirst({
+    where: { role: UserRole.ADMIN },
+    orderBy: { createdAt: 'asc' },
+    select: { id: true, email: true, displayName: true },
+  });
+
+  if (!admin) {
+    throw new Error('No admin user found. Create an admin account before syncing base models.');
+  }
+
+  return admin;
+};
+
+const normalizeMetadata = (
+  current: Prisma.JsonValue | null | undefined,
+  bucket: string,
+  objectName: string,
+): { payload: Prisma.JsonObject; changed: boolean } => {
+  const base: Prisma.JsonObject =
+    current && typeof current === 'object' && !Array.isArray(current) ? { ...(current as Prisma.JsonObject) } : {};
+
+  let changed = false;
+
+  if (base.generatorBaseModel !== true) {
+    base.generatorBaseModel = true;
+    changed = true;
+  }
+
+  if (base.sourceBucket !== bucket) {
+    base.sourceBucket = bucket;
+    changed = true;
+  }
+
+  if (base.sourceObject !== objectName) {
+    base.sourceObject = objectName;
+    changed = true;
+  }
+
+  return { payload: base, changed };
+};
+
+const main = async () => {
+  const bucket = appConfig.generator.baseModelBucket.trim();
+  if (!bucket) {
+    throw new Error('GENERATOR_BASE_MODEL_BUCKET is not configured.');
+  }
+
+  const objects: Array<{ name: string; size: number }> = [];
+
+  try {
+    const stream = storageClient.listObjects(bucket, '', true);
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const item of stream) {
+      if (!item.name || item.name.endsWith('/')) {
+        continue;
+      }
+
+      const size = typeof item.size === 'number' && Number.isFinite(item.size) ? item.size : 0;
+      objects.push({ name: item.name, size });
+    }
+  } catch (error) {
+    throw new Error(
+      `Failed to list objects from bucket "${bucket}": ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (objects.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log(`[sync-generator-base-models] No checkpoints found in bucket "${bucket}".`);
+    return;
+  }
+
+  const storagePaths = objects.map((entry) => `s3://${bucket}/${entry.name}`);
+  const existingAssets = await prisma.modelAsset.findMany({
+    where: { storagePath: { in: storagePaths } },
+    select: { id: true, storagePath: true, isPublic: true, ownerId: true, metadata: true },
+  });
+  const assetsByPath = new Map(existingAssets.map((asset) => [asset.storagePath, asset]));
+
+  const owner = await ensureOwner();
+  const checkpointTag = await prisma.tag.upsert({
+    where: { label: 'checkpoint' },
+    update: { category: 'model-type' },
+    create: { label: 'checkpoint', category: 'model-type' },
+    select: { id: true },
+  });
+
+  let createdCount = 0;
+  let updatedCount = 0;
+  let unchangedCount = 0;
+
+  for (const entry of objects) {
+    const storagePath = `s3://${bucket}/${entry.name}`;
+    const existing = assetsByPath.get(storagePath);
+
+    if (existing) {
+      const updatePayload: Prisma.ModelAssetUpdateInput = {};
+      if (!existing.isPublic) {
+        updatePayload.isPublic = true;
+      }
+      if (existing.ownerId !== owner.id) {
+        updatePayload.owner = { connect: { id: owner.id } };
+      }
+
+      const metadataResult = normalizeMetadata(existing.metadata, bucket, entry.name);
+      if (metadataResult.changed) {
+        updatePayload.metadata = metadataResult.payload;
+      }
+
+      if (Object.keys(updatePayload).length > 0) {
+        await prisma.modelAsset.update({ where: { id: existing.id }, data: updatePayload });
+        updatedCount += 1;
+      } else {
+        unchangedCount += 1;
+      }
+      continue;
+    }
+
+    const title = deriveTitle(entry.name);
+    const slug = await buildUniqueSlug(
+      title,
+      async (candidate) => {
+        const found = await prisma.modelAsset.findUnique({ where: { slug: candidate } });
+        return Boolean(found);
+      },
+      'base-model',
+    );
+
+    await prisma.modelAsset.create({
+      data: {
+        slug,
+        title,
+        description: `Base checkpoint imported from ${bucket}/${entry.name}.`,
+        version: '1.0.0',
+        fileSize: entry.size > 0 ? entry.size : null,
+        checksum: null,
+        storagePath,
+        previewImage: null,
+        metadata: normalizeMetadata(null, bucket, entry.name).payload,
+        isPublic: true,
+        owner: { connect: { id: owner.id } },
+        tags: { create: [{ tagId: checkpointTag.id }] },
+      },
+    });
+
+    createdCount += 1;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[sync-generator-base-models] Created ${createdCount} checkpoint(s), updated ${updatedCount}, unchanged ${unchangedCount}.`,
+  );
+};
+
+main()
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('[sync-generator-base-models] Failed to synchronize base models:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add a backend script that scans the configured generator base-model bucket and upserts public checkpoint assets so the On-Site Generator can see new MinIO uploads
- expose the helper through an npm script and document the synchronization workflow in the README
- record the regression analysis and helper details in the changelog

## Testing
- npm --prefix backend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d06efdabe8833382807aedabae029a