### PR TITLE
Sanitize generator settings payload

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -646,3 +646,8 @@
 - **General**: Empowered administrators to curate the generator’s base-model list directly from the dashboard so members see only vetted checkpoints.
 - **Technical Changes**: Extended Prisma generator settings with a JSON base-model collection, updated the settings and base-model routes to serve the curated definitions, refreshed the admin generator form with add/remove controls, and taught the On-Site Generator to consume the new payload with inline availability warnings.
 - **Data Changes**: `GeneratorSettings` now persists the configured base models as structured JSON entries, enabling future edits without additional tables.
+
+## 128 – Generator settings recovery
+- **General**: Stopped the admin generator settings view from crashing when legacy rows contain invalid JSON.
+- **Technical Changes**: Added a sanitization fallback for generator settings, retrying reads after normalizing bad `baseModels` payloads.
+- **Data Changes**: Automatically rewrites malformed generator `baseModels` entries to an empty array when encountered.


### PR DESCRIPTION
## Summary
- normalize generator settings reads by cleaning invalid `baseModels` payloads before retrying
- add a SQLite-safe sanitization helper to rewrite malformed generator settings rows
- log the recovery behaviour in changelog entry 040

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0837bfebc8333af61cb380b5b3350