### PR TITLE
Fix generator base-model parsing

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -651,3 +651,8 @@
 - **General**: Stopped the admin generator settings view from crashing when legacy rows contain invalid JSON.
 - **Technical Changes**: Added a sanitization fallback for generator settings, retrying reads after normalizing bad `baseModels` payloads.
 - **Data Changes**: Automatically rewrites malformed generator `baseModels` entries to an empty array when encountered.
+
+## 129 – Generator base-model JSON parsing
+- **General**: Restored the On-Site Generator base-model list so curated admin entries surface for users again.
+- **Technical Changes**: Normalized generator settings reads to decode string and buffer payloads before schema validation, keeping alignment with the stored database format and logging parse failures for diagnostics.
+- **Data Changes**: None; existing generator settings rows are read without mutation.


### PR DESCRIPTION
## Summary
- normalize generator settings base-model payloads so JSON strings and buffers are parsed correctly
- reuse a helper when reading stored base-model arrays and keep Prisma updates type-safe
- document the recovery in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0f60fdef0833380725111d792a6de