### PR TITLE
Fix admin model edit dialog width and tab alignment

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -686,3 +686,9 @@
 - **General**: Improved the admin workspace by widening the model edit dialog and replacing the image metadata chips with a model-focused picker.
 - **Technical Changes**: Added an XL layout modifier to the model edit dialog, wired the component to use the larger width, introduced a metadata-derived model datalist with filtering logic, updated image filter state management, and refreshed documentation to describe the new picker.
 - **Data Changes**: None.
+
+## 136 – [Fix] Model edit dialog layout tuning
+- **General**: Sharpened the Administration → Model edit dialog so the expanded layout matches the surrounding workspace.
+- **Technical Changes**: Limited extra-large edit dialogs to half-width with responsive bounds and centered the tab list for clearer navigation.
+- **Data Changes**: None.
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3412,7 +3412,9 @@ main {
 }
 
 .edit-dialog__content--xl {
-  width: min(840px, 95vw);
+  width: 50%;
+  max-width: 95vw;
+  min-width: min(420px, 95vw);
 }
 
 .model-version-dialog__header,
@@ -3520,6 +3522,7 @@ main {
 .edit-dialog__tabs {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.75rem;
   padding: 0.25rem;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- narrow the extra-large admin edit dialog to half-width with responsive bounds so it matches the workspace layout
- center the edit dialog tab strip for better balance across models, images, and other admin workflows
- log the fix in changelog entry 136 for future reference

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1321fe6f4833398cd9c9c8c16551c