### PR TITLE
Fix model explorer edit dialog owner list

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -692,3 +692,8 @@
 - **Technical Changes**: Limited extra-large edit dialogs to half-width with responsive bounds and centered the tab list for clearer navigation.
 - **Data Changes**: None.
 
+## 137 – [Fix] Model edit dialog ownership fallback
+- **General**: Prevented the model edit dialog from crashing when opened via the explorer by guaranteeing owner options are always available.
+- **Technical Changes**: Made the dialog tolerate missing owner lists by defaulting to an empty array and wired the asset explorer to pass its curated owner options into the component.
+- **Data Changes**: None.
+

--- a/frontend/src/components/AssetExplorer.tsx
+++ b/frontend/src/components/AssetExplorer.tsx
@@ -1918,6 +1918,7 @@ export const AssetExplorer = ({
           onClose={() => setEditDialogOpen(false)}
           model={activeAsset}
           token={authToken ?? null}
+          owners={ownerOptions}
           onSuccess={(updated) => {
             onAssetUpdated?.(updated);
             setVersionFeedback('Model details updated.');

--- a/frontend/src/components/ModelAssetEditDialog.tsx
+++ b/frontend/src/components/ModelAssetEditDialog.tsx
@@ -10,7 +10,7 @@ interface ModelAssetEditDialogProps {
   model: ModelAsset;
   token: string | null | undefined;
   onSuccess?: (updated: ModelAsset) => void;
-  owners: { id: string; label: string }[];
+  owners?: { id: string; label: string }[];
 }
 
 const parseTags = (value: string) =>
@@ -64,7 +64,7 @@ export const ModelAssetEditDialog = ({
   model,
   token,
   onSuccess,
-  owners,
+  owners = [],
 }: ModelAssetEditDialogProps) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');


### PR DESCRIPTION
## Summary
- make the model edit dialog resilient to missing owner lists by defaulting to an empty collection
- pass the curated owner options from the model explorer into the dialog so explorer edits keep ownership selectors populated
- document the regression fix in the project changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d13a5db8ec83339d2ec4dab28309ca