### PR TITLE
Fix Windows bulk import parameter ordering

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -198,6 +198,7 @@
 - **Technical Changes**: Migrated to `/:bucket/*`, shared handler logic, and explained the fix while awaiting final commit ID.
 - **Data Changes**: None.
 
+
 ## 040 – [Addition] Streamlined installer (da2500c)
 - **General**: Tuned the installer for production hosts with automatic IP detection.
 - **Technical Changes**: Added smart IP/port prompts, synchronized `.env` files, injected MinIO defaults, and refreshed README installation guidance.
@@ -711,3 +712,8 @@
 - **General**: Tightened moderation UX so flagged models and renders vanish for the community while creators receive a clear “In Audit” placeholder entry.
 - **Technical Changes**: Filtered flagged assets in public listings for non-admins, added shared moderation helpers, rendered audit placeholders across the home tiles, explorers, gallery detail views, and curator profiles, and refreshed README guidance.
 - **Data Changes**: None; visibility logic only.
+
+## 140 – [Fix] Windows bulk import parameter order
+- **General**: Resolved the Windows bulk import helper startup by promoting connection settings to script parameters.
+- **Technical Changes**: Converted server connection variables into the script-level `param` block so it loads before any assignments and continues defaulting directories and credentials.
+- **Data Changes**: None.

--- a/scripts/bulk_import_windows.ps1
+++ b/scripts/bulk_import_windows.ps1
@@ -7,11 +7,10 @@
   Configure the connection variables below before running the script.
 #>
 
-$ServerIp = "192.168.1.10"
-$ServerUsername = "admin@example.com"
-$ServerPort = 4000
-
 param(
+  [string]$ServerIp = "192.168.1.10",
+  [string]$ServerUsername = "admin@example.com",
+  [int]$ServerPort = 4000,
   [string]$LorasDirectory = "./loras",
   [string]$ImagesDirectory = "./images"
 )


### PR DESCRIPTION
## Summary
- convert the Windows bulk import helper to declare server connection settings in the script-level `param` block so it loads before any assignments
- keep the default directories and credentials while maintaining compatibility with existing references
- log the fix in the project changelog

## Testing
- not run (PowerShell is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d19cd47e808333989106eec694ce97