### PR TITLE
Fix Windows bulk importer compatibility with legacy PowerShell

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -717,3 +717,8 @@
 - **General**: Resolved the Windows bulk import helper startup by promoting connection settings to script parameters.
 - **Technical Changes**: Converted server connection variables into the script-level `param` block so it loads before any assignments and continues defaulting directories and credentials.
 - **Data Changes**: None.
+
+## 141 – [Fix] Windows bulk importer resiliency
+- **General**: Ensured the Windows bulk upload helper works on legacy shells and locates image previews stored alongside each LoRA.
+- **Technical Changes**: Added a `System.Net.Http` assembly bootstrap for Windows PowerShell 5.1, resolved absolute paths for the source folders, introduced sibling image folder discovery, tightened image filtering, and guarded disposable cleanup.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The script authenticates with `POST /api/auth/login`, then uploads the LoRA and 
 ### Windows (PowerShell)
 
 1. Edit `$ServerIp`, `$ServerUsername`, and `$ServerPort` at the head of `scripts/bulk_import_windows.ps1`.
-2. Launch the script from PowerShell 7+ (pwsh). Enter your VisionSuit password when prompted or expose it via `VISIONSUIT_PASSWORD`.
+2. Launch the script from PowerShell 7+ (`pwsh`) or Windows PowerShell 5.1. The helper auto-loads the required `System.Net.Http` types so legacy shells work without manual assembly tweaks. Enter your VisionSuit password when prompted or expose it via `VISIONSUIT_PASSWORD`.
 3. Run the importer with optional overrides for the source folders:
 
    ```powershell
@@ -177,6 +177,8 @@ The script authenticates with `POST /api/auth/login`, then uploads the LoRA and 
    ```
 
 The PowerShell helper mirrors the Linux workflow: it logs in once, picks a random preview, trims excessive renders, and posts the bundle directly to the VisionSuit API for processing.
+
+> Tip: If `ImagesDirectory` is missing or omitted, the script now searches for preview folders that live next to each `.safetensors` file (for example `./loras/model-name.safetensors` with a sibling `./loras/model-name/`).
 
 ### Backend service
 


### PR DESCRIPTION
## Summary
- load System.Net.Http for Windows PowerShell 5.1 and guard disposable cleanup in the bulk import script
- resolve absolute source directories, fall back to sibling preview folders, and tighten preview filtering
- document the new behavior in the README and log the fix in the changelog

## Testing
- not run (PowerShell is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d1a16783688333934d6888bbdb747f