### PR TITLE
Fix moderation report relations

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -731,3 +731,8 @@
 - **General**: Ensured the Windows bulk upload helper works on legacy shells and locates image previews stored alongside each LoRA.
 - **Technical Changes**: Added a `System.Net.Http` assembly bootstrap for Windows PowerShell 5.1, resolved absolute paths for the source folders, introduced sibling image folder discovery, tightened image filtering, and guarded disposable cleanup.
 - **Data Changes**: None.
+
+## 143 – [Fix] Moderation reports schema wiring
+- **General**: Restored the moderation queue so admins can review flagged assets without API errors.
+- **Technical Changes**: Added moderation report mappers, regenerated the Prisma client, and taught the API to return reporter summaries for flagged models.
+- **Data Changes**: Introduced `ModelModerationReport` and `ImageModerationReport` tables with cascading foreign keys.

--- a/backend/prisma/migrations/20250923120000_add_moderation_reports/migration.sql
+++ b/backend/prisma/migrations/20250923120000_add_moderation_reports/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "ModelModerationReport" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "modelId" TEXT NOT NULL,
+    "reporterId" TEXT NOT NULL,
+    "reason" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ModelModerationReport_modelId_fkey" FOREIGN KEY ("modelId") REFERENCES "ModelAsset" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ModelModerationReport_reporterId_fkey" FOREIGN KEY ("reporterId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "ImageModerationReport" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "imageId" TEXT NOT NULL,
+    "reporterId" TEXT NOT NULL,
+    "reason" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ImageModerationReport_imageId_fkey" FOREIGN KEY ("imageId") REFERENCES "ImageAsset" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "ImageModerationReport_reporterId_fkey" FOREIGN KEY ("reporterId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "ModelModerationReport_modelId_idx" ON "ModelModerationReport"("modelId");
+CREATE INDEX "ImageModerationReport_imageId_idx" ON "ImageModerationReport"("imageId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -62,6 +62,8 @@ model User {
   flaggedImages ImageAsset[] @relation("ImageAssetFlagger")
   moderationActions ModerationLog[] @relation("ModerationLogActor")
   moderationNotices ModerationLog[] @relation("ModerationLogRecipient")
+  modelModerationReports ModelModerationReport[]
+  imageModerationReports ImageModerationReport[]
 }
 
 model Gallery {
@@ -104,6 +106,7 @@ model ModelAsset {
   flaggedAt    DateTime?
   flaggedById  String?
   flaggedBy    User?        @relation("ModelAssetFlagger", fields: [flaggedById], references: [id])
+  moderationReports ModelModerationReport[]
 }
 
 model ModelVersion {
@@ -150,6 +153,7 @@ model ImageAsset {
   flaggedAt      DateTime?
   flaggedById    String?
   flaggedBy      User?           @relation("ImageAssetFlagger", fields: [flaggedById], references: [id])
+  moderationReports ImageModerationReport[]
 }
 
 model ImageLike {
@@ -339,6 +343,32 @@ model ModerationLog {
   targetUser    User?                  @relation("ModerationLogRecipient", fields: [targetUserId], references: [id])
   createdAt     DateTime               @default(now())
   @@index([entityType, entityId])
+}
+
+model ModelModerationReport {
+  id         String   @id @default(cuid())
+  modelId    String
+  reporterId String
+  reason     String?
+  createdAt  DateTime @default(now())
+
+  model    ModelAsset @relation(fields: [modelId], references: [id], onDelete: Cascade)
+  reporter User       @relation(fields: [reporterId], references: [id], onDelete: Cascade)
+
+  @@index([modelId])
+}
+
+model ImageModerationReport {
+  id         String   @id @default(cuid())
+  imageId    String
+  reporterId String
+  reason     String?
+  createdAt  DateTime @default(now())
+
+  image    ImageAsset @relation(fields: [imageId], references: [id], onDelete: Cascade)
+  reporter User       @relation(fields: [reporterId], references: [id], onDelete: Cascade)
+
+  @@index([imageId])
 }
 
 model RankTier {

--- a/backend/src/lib/mappers/model.ts
+++ b/backend/src/lib/mappers/model.ts
@@ -1,4 +1,4 @@
-import { Prisma, ModelAsset, ModelVersion, Tag, User } from '@prisma/client';
+import { Prisma, ModelAsset, ModelModerationReport, ModelVersion, Tag, User } from '@prisma/client';
 
 import { resolveStorageLocation } from '../storage';
 
@@ -7,6 +7,20 @@ export type HydratedModelAsset = ModelAsset & {
   owner: Pick<User, 'id' | 'displayName' | 'email'>;
   flaggedBy?: Pick<User, 'id' | 'displayName' | 'email'> | null;
   versions: ModelVersion[];
+  moderationReports?: (ModelModerationReport & {
+    reporter: Pick<User, 'id' | 'displayName' | 'email'>;
+  })[];
+};
+
+export type MappedModerationReport = {
+  id: string;
+  reason: string | null;
+  createdAt: string;
+  reporter: {
+    id: string;
+    displayName: string;
+    email: string;
+  };
 };
 
 export type MappedModelVersion = {
@@ -179,5 +193,19 @@ export const mapModelAsset = (asset: HydratedModelAsset) => {
           email: asset.flaggedBy.email,
         }
       : null,
+    ...(asset.moderationReports
+      ? {
+          moderationReports: asset.moderationReports.map<MappedModerationReport>((report) => ({
+            id: report.id,
+            reason: report.reason ?? null,
+            createdAt: report.createdAt.toISOString(),
+            reporter: {
+              id: report.reporter.id,
+              displayName: report.reporter.displayName,
+              email: report.reporter.email,
+            },
+          })),
+        }
+      : {}),
   };
 };


### PR DESCRIPTION
## Summary
- add Prisma relations for stored model and image moderation reports with a migration
- extend the model mapper to expose moderation report summaries for the admin queue
- document the fix in the project changelog

## Testing
- npm run prisma:generate
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a2b60bc4833399c12f531682af43