### PR TITLE
Fix moderation dialog busy-state guard

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -741,3 +741,8 @@
 - **General**: Elevated the Linux and Windows bulk import helpers with an admin-only, two-pass workflow that uploads LoRA weights with a random preview before streaming every gallery render in follow-up batches.
 - **Technical Changes**: Split the scripts into model and gallery upload stages, enforced administrator role detection, chunked gallery uploads to bypass the per-request file limit, and refreshed the README with the updated flow and requirements.
 - **Data Changes**: None.
+
+## 145 – [Fix] Moderation dialog initialization guard
+- **General**: Prevented the Administration → Moderation dialog from crashing when opening a flagged asset for review.
+- **Technical Changes**: Hoisted the moderation action matcher into a memoized callback so busy-state checks run after initialization instead of reading an uninitialized const.
+- **Data Changes**: None; runtime state handling only.

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -469,6 +469,13 @@ export const AdminPanel = ({
           { updatedAt: selectedModerationAsset.asset.updatedAt, cacheKey: selectedModerationAsset.asset.id },
         ) ?? selectedModerationAsset.asset.storagePath
     : null;
+  const moderationActionMatches = useCallback(
+    (entity: 'model' | 'image', action: 'approve' | 'remove', id: string) =>
+      moderationAction?.entity === entity &&
+      moderationAction?.action === action &&
+      moderationAction?.id === id,
+    [moderationAction],
+  );
   const isModerationApproveBusy = selectedModerationAsset
     ? moderationActionMatches(selectedModerationAsset.entity, 'approve', selectedModerationAsset.asset.id)
     : false;
@@ -580,15 +587,6 @@ export const AdminPanel = ({
   }, [activeTab, fetchModerationQueue]);
 
   const resetStatus = () => setStatus(null);
-
-  const moderationActionMatches = (
-    entity: 'model' | 'image',
-    action: 'approve' | 'remove',
-    id: string,
-  ) =>
-    moderationAction?.entity === entity &&
-    moderationAction?.action === action &&
-    moderationAction?.id === id;
 
   const handleApproveModel = async (model: ModelAsset) => {
     resetStatus();


### PR DESCRIPTION
## Summary
- hoist the admin moderation busy-state matcher into a callback so the dialog no longer reads it before initialization
- keep moderation approval/removal buttons responsive without runtime reference errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1abf9f5c48333ade71862d72b02ee