### PR TITLE
Fix GPU agent import path

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -777,3 +777,8 @@
 - **General**: Introduced a managed GPU agent package that executes VisionSIOt dispatches on the ComfyUI node and reports results back to VisionSuit.
 - **Technical Changes**: Added the FastAPI-based agent with workflow templating, MinIO sync, callback handling, installer, systemd unit, configuration sample, and refreshed documentation across the GPU worker and root README files.
 - **Data Changes**: None; runtime configuration only.
+
+## 034 – [Fix] GPU agent service import path
+- **General**: Restored the freshly installed GPU agent so the systemd service boots without module import failures.
+- **Technical Changes**: Switched the FastAPI entrypoint to absolute imports, updated the systemd unit to launch `uvicorn main:app`, and refreshed the README guidance for manual runs.
+- **Data Changes**: None.

--- a/gpuworker/agent/README.md
+++ b/gpuworker/agent/README.md
@@ -130,11 +130,11 @@ The agent exposes two HTTP endpoints:
 
 ## Running manually
 
-The daemon binds to port `8081` by default. To run it manually inside a shell (for example during development) point the configuration variable to a local YAML file and execute uvicorn:
+The daemon binds to port `8081` by default. To run it manually inside a shell (for example during development) change into the agent directory, point the configuration variable to a local YAML file, and execute uvicorn:
 
 ```bash
 VISION_SUITE_AGENT_CONFIG=./config/config.example.yaml \
-  uvicorn gpuworker.agent.main:app --host 0.0.0.0 --port 8081 --reload
+  uvicorn main:app --host 0.0.0.0 --port 8081 --reload
 ```
 
 ## Removal

--- a/gpuworker/agent/config/visionsuit-gpu-agent.service
+++ b/gpuworker/agent/config/visionsuit-gpu-agent.service
@@ -9,7 +9,7 @@ User=visionsuit
 Group=visionsuit
 WorkingDirectory=/opt/visionsuit-gpu-agent
 Environment="VISION_SUITE_AGENT_CONFIG=/etc/visionsuit-gpu-agent/config.yaml"
-ExecStart=/opt/visionsuit-gpu-agent/venv/bin/uvicorn gpuworker.agent.main:app --host 0.0.0.0 --port 8081
+ExecStart=/opt/visionsuit-gpu-agent/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8081
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=20

--- a/gpuworker/agent/main.py
+++ b/gpuworker/agent/main.py
@@ -6,9 +6,9 @@ from typing import Any, Dict
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException
 
-from .app.agent import GPUAgent
-from .app.config import load_config
-from .app.models import DispatchEnvelope
+from app.agent import GPUAgent
+from app.config import load_config
+from app.models import DispatchEnvelope
 
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(name)s: %(message)s")
@@ -54,5 +54,5 @@ app = create_app()
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run("gpuworker.agent.main:app", host="0.0.0.0", port=8081, reload=False)
+    uvicorn.run("main:app", host="0.0.0.0", port=8081, reload=False)
 


### PR DESCRIPTION
## Summary
- switch the FastAPI entrypoint to absolute imports so the module loads without packaging the agent
- update the systemd service and documentation to launch uvicorn against `main:app`
- append a changelog entry covering the GPU agent service fix

## Testing
- python -m compileall gpuworker/agent


------
https://chatgpt.com/codex/tasks/task_e_68d2554ac1a483338e959afc018d9c41