### PR TITLE
Integrate GPU agent dispatch with backend

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -782,3 +782,8 @@
 - **General**: Restored the freshly installed GPU agent so the systemd service boots without module import failures.
 - **Technical Changes**: Switched the FastAPI entrypoint to absolute imports, updated the systemd unit to launch `uvicorn main:app`, and refreshed the README guidance for manual runs.
 - **Data Changes**: None.
+
+## 035 – [Addition] GPU agent integration bridge
+- **General**: Wired VisionSuit's on-site generator to the GPU agent so dispatches share a consistent envelope and health probes target the new service.
+- **Technical Changes**: Added a root health endpoint to the FastAPI agent, introduced a TypeScript agent client and dispatcher, updated generator routes to submit jobs and manage busy/error states, refreshed admin health checks, expanded configuration/env parsing for workflows and output buckets, and documented the handshake in the README.
+- **Data Changes**: None.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "minio": "^8.0.6",
         "morgan": "^1.10.1",
         "multer": "^2.0.2",
+        "undici": "^6.21.3",
         "zod": "^4.1.9"
       },
       "devDependencies": {
@@ -2922,6 +2923,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "minio": "^8.0.6",
     "morgan": "^1.10.1",
     "multer": "^2.0.2",
+    "undici": "^6.21.3",
     "zod": "^4.1.9"
   },
   "devDependencies": {

--- a/backend/src/lib/generator/agentClient.ts
+++ b/backend/src/lib/generator/agentClient.ts
@@ -1,0 +1,191 @@
+import { request as undiciRequest } from 'undici';
+
+export type AgentCacheStrategy = 'persistent' | 'ephemeral';
+
+export interface AgentAssetRef {
+  bucket: string;
+  key: string;
+  cacheStrategy?: AgentCacheStrategy;
+  checksum?: string | null;
+}
+
+export interface AgentWorkflowRef {
+  id: string;
+  version?: string | null;
+  bucket?: string | null;
+  minioKey?: string | null;
+  localPath?: string | null;
+  inline?: unknown;
+}
+
+export interface AgentOutputSpec {
+  bucket: string;
+  prefix: string;
+}
+
+export interface AgentWorkflowMutation {
+  node: number;
+  path: string;
+  value: unknown;
+}
+
+export interface AgentWorkflowParameterBinding {
+  parameter: string;
+  node: number;
+  path: string;
+}
+
+export interface AgentCallbackConfig {
+  status?: string;
+  completion?: string;
+  failure?: string;
+}
+
+export interface AgentResolution {
+  width: number;
+  height: number;
+}
+
+export interface AgentJobParameters {
+  prompt: string;
+  negativePrompt?: string | null;
+  seed?: number | null;
+  cfgScale?: number | null;
+  steps?: number | null;
+  resolution?: AgentResolution;
+  extra?: Record<string, unknown>;
+}
+
+export interface AgentDispatchEnvelope {
+  jobId: string;
+  user: {
+    id: string;
+    username: string;
+  };
+  workflow: AgentWorkflowRef;
+  baseModel: AgentAssetRef;
+  loras: AgentAssetRef[];
+  parameters: AgentJobParameters;
+  output: AgentOutputSpec;
+  priority?: string | null;
+  requestedAt?: string | null;
+  workflowOverrides?: AgentWorkflowMutation[];
+  workflowParameters?: AgentWorkflowParameterBinding[];
+  callbacks?: AgentCallbackConfig;
+}
+
+export interface AgentHealthPayload {
+  status: string;
+  busy: boolean;
+  raw?: unknown;
+}
+
+export type SubmitJobStatus = 'accepted' | 'busy';
+
+export interface SubmitJobResult {
+  status: SubmitJobStatus;
+  response?: unknown;
+  statusCode: number;
+}
+
+export class AgentRequestError extends Error {
+  constructor(message: string, readonly statusCode?: number, readonly responseBody?: string) {
+    super(message);
+    this.name = 'AgentRequestError';
+  }
+}
+
+export class GeneratorAgentClient {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    const trimmed = baseUrl.trim();
+    if (!trimmed) {
+      throw new Error('GPU agent base URL must not be empty.');
+    }
+
+    const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+    this.baseUrl = withScheme.replace(/\/+$/, '');
+  }
+
+  private buildUrl(path: string): string {
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    return `${this.baseUrl}${normalizedPath}`;
+  }
+
+  async getHealth(): Promise<AgentHealthPayload> {
+    const target = this.buildUrl('/healthz');
+    const response = await undiciRequest(target, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+      },
+    });
+
+    const { statusCode } = response;
+    const bodyText = await response.body.text();
+    let payload: unknown = null;
+
+    if (bodyText) {
+      try {
+        payload = JSON.parse(bodyText);
+      } catch (error) {
+        throw new AgentRequestError('GPU agent health endpoint returned invalid JSON.', statusCode, bodyText);
+      }
+    }
+
+    if (statusCode >= 200 && statusCode < 300 && payload && typeof payload === 'object') {
+      const record = payload as { status?: unknown; busy?: unknown };
+      return {
+        status: typeof record.status === 'string' ? record.status : 'ok',
+        busy: Boolean(record.busy),
+        raw: payload,
+      };
+    }
+
+    throw new AgentRequestError(
+      `GPU agent health check failed with status ${statusCode}.`,
+      statusCode,
+      bodyText ?? undefined,
+    );
+  }
+
+  async submitJob(payload: AgentDispatchEnvelope): Promise<SubmitJobResult> {
+    const target = this.buildUrl('/jobs');
+    const response = await undiciRequest(target, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const { statusCode } = response;
+    const bodyText = await response.body.text();
+    let parsed: unknown = null;
+
+    if (bodyText) {
+      try {
+        parsed = JSON.parse(bodyText);
+      } catch (error) {
+        // Leave parsed as null; body may be empty or non-JSON.
+      }
+    }
+
+    if (statusCode === 202) {
+      return { status: 'accepted', response: parsed ?? bodyText, statusCode };
+    }
+
+    if (statusCode === 409) {
+      return { status: 'busy', response: parsed ?? bodyText, statusCode };
+    }
+
+    throw new AgentRequestError(
+      `GPU agent rejected job submission with status ${statusCode}.`,
+      statusCode,
+      bodyText ?? undefined,
+    );
+  }
+}
+

--- a/backend/src/lib/generator/dispatcher.ts
+++ b/backend/src/lib/generator/dispatcher.ts
@@ -1,0 +1,280 @@
+import path from 'node:path';
+
+import { appConfig } from '../../config';
+import {
+  AgentDispatchEnvelope,
+  AgentRequestError,
+  GeneratorAgentClient,
+} from './agentClient';
+import { prisma } from '../prisma';
+import { resolveStorageLocation } from '../storage';
+
+interface DispatchableGeneratorRequest {
+  id: string;
+  prompt: string;
+  negativePrompt: string | null;
+  seed: string | null;
+  guidanceScale: number | null;
+  steps: number | null;
+  width: number;
+  height: number;
+  loraSelections: unknown;
+  user: {
+    id: string;
+    displayName: string | null;
+    email: string | null;
+  };
+  baseModel: {
+    id: string;
+    title: string;
+    storagePath: string;
+  };
+}
+
+type StoredLoraSelection = {
+  id: string;
+  strength: number | null;
+  title: string | null;
+  slug: string | null;
+};
+
+export type DispatchStatus = 'queued' | 'busy' | 'skipped' | 'error';
+
+export interface DispatchResult {
+  status: DispatchStatus;
+  message?: string;
+}
+
+const parseSeed = (value: string | null | undefined): number | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const normalizeUsername = (user: DispatchableGeneratorRequest['user']): string => {
+  const displayName = user.displayName?.trim();
+  if (displayName) {
+    return displayName;
+  }
+
+  const email = user.email?.trim();
+  if (email) {
+    return email;
+  }
+
+  return user.id;
+};
+
+const parseLoraSelections = (value: unknown): StoredLoraSelection[] => {
+  if (!value) {
+    return [];
+  }
+
+  const raw = typeof value === 'string' ? (() => {
+    try {
+      return JSON.parse(value) as unknown;
+    } catch (error) {
+      return [];
+    }
+  })() : value;
+
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const selections: StoredLoraSelection[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+
+    const record = entry as Record<string, unknown>;
+    const id = typeof record.id === 'string' ? record.id : null;
+    if (!id) {
+      continue;
+    }
+
+    selections.push({
+      id,
+      strength: typeof record.strength === 'number' ? record.strength : null,
+      title: typeof record.title === 'string' ? record.title : null,
+      slug: typeof record.slug === 'string' ? record.slug : null,
+    });
+  }
+
+  return selections;
+};
+
+const buildOutputPrefix = (request: DispatchableGeneratorRequest): string => {
+  const template = appConfig.generator.output.prefixTemplate || 'generated/{userId}/{jobId}';
+  return template.replace(/\{userId\}/g, request.user.id).replace(/\{jobId\}/g, request.id);
+};
+
+const buildWorkflowReference = () => {
+  const { workflow } = appConfig.generator;
+
+  const ref: AgentDispatchEnvelope['workflow'] = {
+    id: workflow.id,
+    version: workflow.version ?? null,
+    bucket: workflow.bucket ?? null,
+    minioKey: workflow.minioKey ?? null,
+    localPath: workflow.localPath ?? null,
+    inline: workflow.inline,
+  };
+
+  if (!ref.minioKey && !ref.localPath && typeof ref.inline === 'undefined') {
+    throw new Error('Generator workflow configuration must provide minioKey, localPath, or inline payload.');
+  }
+
+  return ref;
+};
+
+export const dispatchGeneratorRequest = async (
+  request: DispatchableGeneratorRequest,
+): Promise<DispatchResult> => {
+  const generatorNodeUrl = appConfig.network.generatorNodeUrl.trim();
+  if (!generatorNodeUrl) {
+    return { status: 'skipped', message: 'Generator node URL not configured.' };
+  }
+
+  const baseModelLocation = resolveStorageLocation(request.baseModel.storagePath);
+  if (!baseModelLocation.bucket || !baseModelLocation.objectName) {
+    return { status: 'error', message: 'Base model is missing an accessible storage location.' };
+  }
+
+  const selections = parseLoraSelections(request.loraSelections);
+  const loraIds = selections.map((entry) => entry.id);
+
+  let loraAssets: Array<{ id: string; storagePath: string | null }> = [];
+  if (loraIds.length > 0) {
+    loraAssets = await prisma.modelAsset.findMany({
+      where: { id: { in: loraIds } },
+      select: { id: true, storagePath: true },
+    });
+  }
+
+  const lorasForAgent: AgentDispatchEnvelope['loras'] = [];
+  const loraExtraPayload: Array<Record<string, unknown>> = [];
+  const missingLoras: string[] = [];
+
+  for (const selection of selections) {
+    const asset = loraAssets.find((entry) => entry.id === selection.id);
+    if (!asset || !asset.storagePath) {
+      missingLoras.push(selection.id);
+      continue;
+    }
+
+    const location = resolveStorageLocation(asset.storagePath);
+    if (!location.bucket || !location.objectName) {
+      missingLoras.push(selection.id);
+      continue;
+    }
+
+    lorasForAgent.push({
+      bucket: location.bucket,
+      key: location.objectName,
+      cacheStrategy: 'ephemeral',
+    });
+
+    loraExtraPayload.push({
+      id: selection.id,
+      title: selection.title ?? null,
+      slug: selection.slug ?? null,
+      strength: selection.strength ?? null,
+      bucket: location.bucket,
+      key: location.objectName,
+      filename: path.basename(location.objectName),
+    });
+  }
+
+  if (missingLoras.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn('Generator request is missing LoRA assets:', missingLoras.join(', '));
+  }
+
+  const envelope: AgentDispatchEnvelope = {
+    jobId: request.id,
+    user: {
+      id: request.user.id,
+      username: normalizeUsername(request.user),
+    },
+    workflow: buildWorkflowReference(),
+    baseModel: {
+      bucket: baseModelLocation.bucket,
+      key: baseModelLocation.objectName,
+      cacheStrategy: 'persistent',
+    },
+    loras: lorasForAgent,
+    parameters: {
+      prompt: request.prompt,
+      resolution: {
+        width: request.width,
+        height: request.height,
+      },
+    },
+    output: {
+      bucket: appConfig.generator.output.bucket,
+      prefix: buildOutputPrefix(request),
+    },
+    workflowOverrides: [...appConfig.generator.workflow.overrides],
+    workflowParameters: [...appConfig.generator.workflow.parameters],
+  };
+
+  if (request.negativePrompt !== undefined) {
+    envelope.parameters.negativePrompt = request.negativePrompt;
+  }
+
+  const seed = parseSeed(request.seed);
+  if (typeof seed === 'number') {
+    envelope.parameters.seed = seed;
+  }
+
+  if (request.guidanceScale !== null && request.guidanceScale !== undefined) {
+    envelope.parameters.cfgScale = request.guidanceScale;
+  }
+
+  if (request.steps !== null && request.steps !== undefined) {
+    envelope.parameters.steps = request.steps;
+  }
+
+  if (loraExtraPayload.length > 0) {
+    envelope.parameters.extra = {
+      ...(envelope.parameters.extra ?? {}),
+      loras: loraExtraPayload,
+    };
+  }
+
+  if (envelope.parameters.extra && Object.keys(envelope.parameters.extra).length === 0) {
+    delete envelope.parameters.extra;
+  }
+
+  const client = new GeneratorAgentClient(generatorNodeUrl);
+
+  try {
+    const response = await client.submitJob(envelope);
+    if (response.status === 'accepted') {
+      return { status: 'queued' };
+    }
+
+    if (response.status === 'busy') {
+      return { status: 'busy', message: 'GPU agent is currently processing another job.' };
+    }
+
+    return { status: 'error', message: 'Unexpected GPU agent response.' };
+  } catch (error) {
+    if (error instanceof AgentRequestError) {
+      return { status: 'error', message: error.message };
+    }
+
+    return { status: 'error', message: (error as Error).message };
+  }
+};
+

--- a/backend/src/routes/meta.ts
+++ b/backend/src/routes/meta.ts
@@ -1,112 +1,58 @@
-import { request as httpRequest } from 'node:http';
-import { request as httpsRequest } from 'node:https';
-import { URL } from 'node:url';
-
 import { Router } from 'express';
 
 import { prisma } from '../lib/prisma';
 import { storageBuckets, storageClient } from '../lib/storage';
 import { appConfig } from '../config';
+import { AgentRequestError, GeneratorAgentClient } from '../lib/generator/agentClient';
 
 type ServiceHealthStatus = 'online' | 'offline' | 'degraded';
-
-const buildGpuHealthUrl = (rawValue: string): URL | null => {
-  const trimmed = rawValue.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  let base: URL;
-  try {
-    if (/^https?:\/\//i.test(trimmed)) {
-      base = new URL(trimmed);
-    } else {
-      base = new URL(`http://${trimmed}`);
-    }
-  } catch (error) {
-    if (process.env.NODE_ENV === 'development') {
-      // eslint-disable-next-line no-console
-      console.warn('Failed to parse GPU node URL:', error);
-    }
-    return null;
-  }
-
-  if (!base.port) {
-    base.port = base.protocol === 'https:' ? '443' : '8188';
-  }
-
-  const normalizedPath = base.pathname && base.pathname !== '/' ? base.pathname.replace(/\/$/, '') : '';
-  base.pathname = `${normalizedPath}/system_stats`.replace(/\/{2,}/g, '/');
-  return base;
-};
-
-const probeGpuNode = async (target: URL): Promise<{ status: ServiceHealthStatus; message: string }> =>
-  new Promise((resolve) => {
-    const client = target.protocol === 'https:' ? httpsRequest : httpRequest;
-
-    const request = client(
-      {
-        hostname: target.hostname,
-        port: target.port,
-        path: target.pathname + target.search,
-        method: 'GET',
-        timeout: 3500,
-      },
-      (response) => {
-        const { statusCode } = response;
-        response.resume();
-
-        if (statusCode && statusCode >= 200 && statusCode < 300) {
-          resolve({ status: 'online', message: 'GPU node reachable.' });
-          return;
-        }
-
-        resolve({
-          status: 'degraded',
-          message: `GPU node responded with status ${statusCode ?? 0}.`,
-        });
-      },
-    );
-
-    request.on('timeout', () => {
-      request.destroy(new Error('GPU node request timed out.'));
-    });
-
-    request.on('error', (error) => {
-      resolve({ status: 'offline', message: `GPU node unreachable: ${error.message}` });
-    });
-
-    request.end();
-  });
 
 const getGpuNodeStatus = async (): Promise<{ status: ServiceHealthStatus; message: string }> => {
   const target = appConfig.network.generatorNodeUrl.trim();
   if (!target) {
     return {
       status: 'offline',
-      message: 'GPU node not configured yet.',
-    };
-  }
-
-  const url = buildGpuHealthUrl(target);
-  if (!url) {
-    return {
-      status: 'offline',
-      message: 'GPU node address is invalid. Update the connection settings.',
+      message: 'GPU agent not configured yet.',
     };
   }
 
   try {
-    return await probeGpuNode(url);
+    const client = new GeneratorAgentClient(target);
+    const health = await client.getHealth();
+    if (health.busy) {
+      return {
+        status: 'degraded',
+        message: 'GPU agent online but currently processing a job.',
+      };
+    }
+
+    return {
+      status: 'online',
+      message: 'GPU agent online and ready.',
+    };
   } catch (error) {
     if (process.env.NODE_ENV === 'development') {
       // eslint-disable-next-line no-console
-      console.warn('GPU node probe failed:', error);
+      console.warn('GPU agent probe failed:', error);
+    }
+
+    if (error instanceof AgentRequestError) {
+      return {
+        status: 'offline',
+        message: `GPU agent health probe failed: ${error.message}`,
+      };
+    }
+
+    if (error instanceof Error) {
+      return {
+        status: 'offline',
+        message: `GPU agent unreachable: ${error.message}`,
+      };
     }
 
     return {
       status: 'offline',
-      message: 'GPU node did not respond to the health probe.',
+      message: 'GPU agent did not respond to the health probe.',
     };
   }
 };

--- a/gpuworker/agent/README.md
+++ b/gpuworker/agent/README.md
@@ -68,8 +68,9 @@ The installer performs the following steps:
 
 ## API contract
 
-The agent exposes two HTTP endpoints:
+The agent exposes lightweight HTTP endpoints:
 
+- `GET /` – Health summary for platform probes. Returns `{ "status": "ok", "service": "VisionSuit GPU Agent", "busy": false }` when idle.
 - `GET /healthz` – Returns `{ "status": "ok", "busy": false }` when idle. `busy` becomes `true` while a job is running.
 - `POST /jobs` – Accepts a JSON payload that follows the dispatch envelope designed for VisionSIOt. When the agent is idle the endpoint returns HTTP 202 and starts the background job. If the agent is already running a job the endpoint returns HTTP 409.
 

--- a/gpuworker/agent/main.py
+++ b/gpuworker/agent/main.py
@@ -27,6 +27,15 @@ def create_app() -> FastAPI:
         busy = agent.is_busy()
         return {"status": "ok", "busy": busy}
 
+    @app.get("/")
+    async def root() -> Dict[str, Any]:
+        busy = agent.is_busy()
+        return {
+            "status": "ok",
+            "service": "VisionSuit GPU Agent",
+            "busy": busy,
+        }
+
     @app.post("/jobs", status_code=202)
     async def submit_job(job: DispatchEnvelope, background_tasks: BackgroundTasks) -> Dict[str, Any]:
         if not await agent.try_reserve_job():


### PR DESCRIPTION
## Summary
- add a reusable GPU agent client and dispatcher so generator requests submit jobs with workflow metadata and update their status
- expose a root health endpoint on the FastAPI agent while refreshing backend health probes and configuration parsing for workflow/output settings
- document the VisionSuit ↔ GPU agent handshake and record the change in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2572666b0833392bf25c81f4191cb