### PR TITLE
Fix backend GPU agent client fetch handling

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -787,3 +787,8 @@
 - **General**: Wired VisionSuit's on-site generator to the GPU agent so dispatches share a consistent envelope and health probes target the new service.
 - **Technical Changes**: Added a root health endpoint to the FastAPI agent, introduced a TypeScript agent client and dispatcher, updated generator routes to submit jobs and manage busy/error states, refreshed admin health checks, expanded configuration/env parsing for workflows and output buckets, and documented the handshake in the README.
 - **Data Changes**: None.
+
+## 036 – [Fix] GPU agent client fetch fallback
+- **General**: Restored backend startups by removing the hard dependency on the external Undici package.
+- **Technical Changes**: Replaced the generator agent client with a fetch-based helper that wraps network failures and dropped the Undici dependency from the backend package manifest.
+- **Data Changes**: None.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,7 +19,6 @@
         "minio": "^8.0.6",
         "morgan": "^1.10.1",
         "multer": "^2.0.2",
-        "undici": "^6.21.3",
         "zod": "^4.1.9"
       },
       "devDependencies": {
@@ -2923,15 +2922,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,6 @@
     "minio": "^8.0.6",
     "morgan": "^1.10.1",
     "multer": "^2.0.2",
-    "undici": "^6.21.3",
     "zod": "^4.1.9"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- replace the generator agent client transport with the built-in `fetch`, wrapping connection failures in a dedicated helper
- remove the Undici runtime dependency from the backend package manifest now that the client uses native fetch
- document the fix in the repository changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d25ea47d7883339c9be25d6c6b351b