### PR TITLE
feat: support multi-base generator requests

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -792,3 +792,13 @@
 - **General**: Restored backend startups by removing the hard dependency on the external Undici package.
 - **Technical Changes**: Replaced the generator agent client with a fetch-based helper that wraps network failures and dropped the Undici dependency from the backend package manifest.
 - **Data Changes**: None.
+
+## 037 – [Addition] Multi-base generator payloads
+- **General**: Reworked the On-Site Generator to select multiple curated base models via a checkbox matrix so members can bundle several checkpoints with a single request.
+- **Technical Changes**: Added a `baseModelSelections` JSON column plus migration, updated generator routes and dispatcher to persist and forward the full base-model roster, refreshed API typings, and rebuilt the wizard with a matrix UI, richer preview, review summaries, and history badges that surface every selected model.
+- **Data Changes**: New Prisma migration adds the nullable `baseModelSelections` column to `GeneratorRequest` for storing the curated base-model bundle.
+
+## 149 – [Fix] On-Site generator base-model checkboxes
+- **General**: Restored the generator wizard’s base-model picker so curators can toggle curated checkpoints via an accessible checkbox matrix before dispatching jobs.
+- **Technical Changes**: Replaced the button-based cards with labelled checkboxes, refreshed the styling to accommodate the new control layout, and noted the checkbox matrix in the README for up-to-date operator guidance.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - **Self-service account management** – Sidebar account settings let curators update their display name, bio, and password, now proxy uploaded avatars (PNG/JPG/WebP ≤ 5 MB) through the API, and automatically reroute legacy MinIO avatar links so external domains never surface `127.0.0.1` references.
 - **Guided three-step upload wizard** – Collects metadata, files, and review feedback with validation, drag & drop, and live responses from the production-ready `POST /api/uploads` endpoint.
 - **Data-driven explorers** – Fast filters and full-text search across LoRA assets and galleries, complete with tag badges, five-column tiles, and seamless infinite scrolling with active filter indicators.
-- **On-Site Generator hub** – Role-aware wizard that mirrors the admin-curated base-model labels from Administration → Generator, lists the matching database checkpoints, lets curators compose prompts, mix LoRAs, tap trigger suggestions straight into the prompt box, pick dimensions, and enqueue generation jobs while preserving per-user history.
+- **On-Site Generator hub** – Role-aware wizard that mirrors the admin-curated base-model labels from Administration → Generator, exposes them in a checkbox matrix, lists the matching database checkpoints, lets curators compose prompts, mix LoRAs, tap trigger suggestions straight into the prompt box, pick dimensions, and enqueue generation jobs while preserving per-user history.
 - **Curator spotlight profiles** – Dedicated profile view with avatars, rank progression, bios, and live listings of every model and collection uploaded by the curator, reachable from any curator name across the interface.
 - **Versioned modelcards** – Dedicated model dialogs with inline descriptions, quick switches between safetensor versions, in-place editing for curators/admins, an integrated flow for uploading new revisions including preview handling, and admin tooling to promote or retire revisions.
 - **Governed storage pipeline** – Direct MinIO ingestion with automatic tagging, secure download proxying via the backend, audit trails, and guardrails for file size (≤ 2 GB) and batch limits (≤ 12 files).
@@ -139,7 +139,7 @@ VisionSuit now speaks to the GPU agent instead of probing ComfyUI directly. Poin
 - `GENERATOR_WORKFLOW_PARAMETERS` (JSON array) to map prompt/seed/CFG inputs onto workflow nodes and `GENERATOR_WORKFLOW_OVERRIDES` for fixed node tweaks.
 - `GENERATOR_OUTPUT_BUCKET` and `GENERATOR_OUTPUT_PREFIX` to control where the agent uploads rendered files (supports `{userId}` and `{jobId}` tokens).
 
-Once those values are set, every `POST /api/generator/requests` submission queues a dispatch envelope with the selected base model, LoRA adapters, and prompt metadata. If the GPU agent reports a busy state VisionSuit marks the request as `pending`; accepted jobs flip to `queued` and surface in the history list immediately.
+Once those values are set, every `POST /api/generator/requests` submission queues a dispatch envelope with the selected base models, LoRA adapters, and prompt metadata. The GPU agent receives the full base-model roster alongside the primary checkpoint so it can stage or audit every curated option up front. If the GPU agent reports a busy state VisionSuit marks the request as `pending`; accepted jobs flip to `queued` and surface in the history list immediately.
 
 ## Development Workflow
 

--- a/backend/prisma/migrations/20250923090925_generator_multi_base_models/migration.sql
+++ b/backend/prisma/migrations/20250923090925_generator_multi_base_models/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GeneratorRequest" ADD COLUMN "baseModelSelections" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -319,6 +319,7 @@ model GeneratorRequest {
   id             String                @id @default(cuid())
   userId         String
   baseModelId    String
+  baseModelSelections Json?
   prompt         String
   negativePrompt String?
   seed           String?

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9076,6 +9076,168 @@ button {
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
 }
 
+.generator-base-matrix {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.generator-base-matrix__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.generator-base-matrix__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #f8fafc;
+}
+
+.generator-base-matrix__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.9rem;
+}
+
+.generator-base-matrix__count {
+  margin: 0;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.2);
+  color: #bfdbfe;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.generator-base-matrix__status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.generator-base-matrix__error {
+  color: #fecaca;
+}
+
+.generator-base-matrix__empty {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(148, 163, 184, 0.75);
+  text-align: center;
+}
+
+.generator-base-matrix__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.generator-base-matrix__card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.generator-base-matrix__checkbox {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 0.1rem;
+}
+
+.generator-base-matrix__checkbox input {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin: 0;
+  accent-color: #60a5fa;
+  cursor: pointer;
+}
+
+.generator-base-matrix__checkbox input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+  border-radius: 6px;
+}
+
+.generator-base-matrix__details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.generator-base-matrix__card:hover {
+  border-color: rgba(59, 130, 246, 0.5);
+  transform: translateY(-2px);
+}
+
+.generator-base-matrix__card:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+
+.generator-base-matrix__card--active {
+  border-color: rgba(59, 130, 246, 0.65);
+  box-shadow: 0 12px 28px rgba(29, 78, 216, 0.25);
+}
+
+.generator-base-matrix__name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.generator-base-matrix__type {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.generator-base-matrix__meta {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.generator-base-matrix__version {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.generator-base-matrix__missing {
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(30, 41, 59, 0.65);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.generator-base-matrix__missing p {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.generator-base-matrix__missing ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.generator-base-matrix__missing li {
+  margin: 0.25rem 0;
+}
+
 .generator-preview {
   display: grid;
   grid-template-columns: 200px minmax(0, 1fr);
@@ -9126,6 +9288,41 @@ button {
   margin: 0;
   font-size: 1.2rem;
   color: #f8fafc;
+}
+
+.generator-preview__selection-count {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.generator-preview__selection-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.generator-preview__selection-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(59, 130, 246, 0.18);
+}
+
+.generator-preview__selection-list li span {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.generator-preview__selection-list li small {
+  font-size: 0.75rem;
+  color: rgba(191, 219, 254, 0.85);
 }
 
 .generator-preview__details dl {
@@ -9471,6 +9668,35 @@ button {
   font-weight: 600;
 }
 
+.generator-review__base-models {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.generator-review__base-models li {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.55rem 0.8rem;
+  border-radius: 12px;
+  background: rgba(59, 130, 246, 0.18);
+}
+
+.generator-review__base-models li span {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.generator-review__base-models li small {
+  font-size: 0.75rem;
+  color: rgba(191, 219, 254, 0.85);
+}
+
 .generator-review__loras {
   list-style: none;
   padding: 0;
@@ -9619,6 +9845,31 @@ button {
   margin: 0;
   font-weight: 600;
   color: rgba(226, 232, 240, 0.9);
+}
+
+.generator-history__base-models {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.generator-history__base-models li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.generator-history__base-models li span {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.generator-history__base-models li small {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
 }
 
 .generator-history__loras {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   GeneratorAccessMode,
   GeneratorBaseModelConfig,
   GeneratorBaseModelOption,
+  GeneratorBaseModelType,
   GeneratorRequestSummary,
   GeneratorSettings,
   ImageAsset,
@@ -71,7 +72,7 @@ interface UpdateGalleryPayload {
 }
 
 interface CreateGeneratorRequestPayload {
-  baseModelId: string;
+  baseModels: { id: string; name: string; type: GeneratorBaseModelType }[];
   prompt: string;
   negativePrompt?: string | null;
   seed?: string | null;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -102,6 +102,15 @@ export interface GeneratorBaseModelOption extends GeneratorBaseModelConfig {
   isMissing: boolean;
 }
 
+export interface GeneratorRequestBaseModelSelection {
+  id: string;
+  name: string;
+  type?: GeneratorBaseModelType | null;
+  title?: string | null;
+  slug?: string | null;
+  version?: string | null;
+}
+
 export interface GeneratorSettings {
   id?: string | number;
   accessMode: GeneratorAccessMode;
@@ -128,6 +137,7 @@ export interface GeneratorRequestSummary {
   width: number;
   height: number;
   loras: GeneratorRequestLoRASelection[];
+  baseModels: GeneratorRequestBaseModelSelection[];
   baseModel: {
     id: string;
     title: string;


### PR DESCRIPTION
## Summary
- replace the on-site generator's base-model dropdown with a checkbox matrix that supports multi-select and surfaces richer previews/history details
- persist the selected roster in a new GeneratorRequest.baseModelSelections column, extend the API payloads, and forward the full base-model list to the GPU agent
- document the multi-base workflow and update styles/types accordingly

## Testing
- npm --prefix backend run lint
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2624007dc8333b70c231165a26f71