### PR TITLE
Fix generator null asset guard

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -807,3 +807,8 @@
 - **General**: Ensured the On-Site Generator trusts administrator-defined base models even when no catalog asset exists, so GPU-resident checkpoints remain selectable without extra syncing.
 - **Technical Changes**: Made generator requests tolerate missing `ModelAsset` links, derive storage paths from Administration → Generator settings, updated dispatch fallbacks, exposed the new availability in the API response, refreshed the React wizard to accept configuration-backed entries, and documented the behavior in the README.
 - **Data Changes**: Added a Prisma migration that allows `GeneratorRequest.baseModelId` to be null while preserving existing records.
+
+## 151 – [Fix] Generator base model guard (commit TBD)
+- **General**: Stopped the On-Site Generator from crashing when a configured base model lacks catalog metadata.
+- **Technical Changes**: Filtered base model asset identifiers before computing the LoRA exclusion set so null assets no longer trigger runtime errors.
+- **Data Changes**: None.

--- a/frontend/src/components/OnSiteGenerator.tsx
+++ b/frontend/src/components/OnSiteGenerator.tsx
@@ -391,7 +391,9 @@ export const OnSiteGenerator = ({ models, token, currentUser, onNotify }: OnSite
   const combinedBaseModelError = baseModelError ?? baseModelCatalogError;
 
   const loraOptions = useMemo(() => {
-    const baseModelIds = new Set(selectableBaseModels.map((entry) => entry.asset.id));
+    const baseModelIds = new Set(
+      selectableBaseModels.flatMap((entry) => (entry.asset ? [entry.asset.id] : [])),
+    );
     const selectedIds = new Set(selectedBaseModelIds);
     const candidates = models.filter((asset) => isLikelyLora(asset) && !baseModelIds.has(asset.id));
     if (candidates.length > 0) {


### PR DESCRIPTION
## Summary
- guard the generator's LoRA option filtering when base model entries do not include a linked catalog asset
- record the runtime stability improvement in changelog entry 151

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d272e851a0833396463b2e82b769ec