### PR TITLE
Enable GPU agent callbacks and artifact tracking

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -812,3 +812,8 @@
 - **General**: Stopped the On-Site Generator from crashing when a configured base model lacks catalog metadata.
 - **Technical Changes**: Filtered base model asset identifiers before computing the LoRA exclusion set so null assets no longer trigger runtime errors.
 - **Data Changes**: None.
+
+## 152 – [Addition] Generator callback pipeline
+- **General**: Enabled VisionSuit to receive live GPU agent status updates, capture generated artifacts, and surface finished renders directly in the On-Site Generator history.
+- **Technical Changes**: Added configurable callback base URLs, new generator callback endpoints, Prisma-backed artifact persistence, refreshed mapper logic, and front-end history enhancements with artifact galleries and failure messaging.
+- **Data Changes**: Introduced the `GeneratorArtifact` table and new `GeneratorRequest` columns for callback state (`errorReason`, `outputBucket`, `outputPrefix`).

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ VisionSuit now speaks to the GPU agent instead of probing ComfyUI directly. Poin
 - `GENERATOR_WORKFLOW_ID`, `GENERATOR_WORKFLOW_BUCKET`, and `GENERATOR_WORKFLOW_MINIO_KEY` (or `GENERATOR_WORKFLOW_LOCAL_PATH` / `GENERATOR_WORKFLOW_INLINE`) to tell the agent which JSON graph to load.
 - `GENERATOR_WORKFLOW_PARAMETERS` (JSON array) to map prompt/seed/CFG inputs onto workflow nodes and `GENERATOR_WORKFLOW_OVERRIDES` for fixed node tweaks.
 - `GENERATOR_OUTPUT_BUCKET` and `GENERATOR_OUTPUT_PREFIX` to control where the agent uploads rendered files (supports `{userId}` and `{jobId}` tokens).
+- `GENERATOR_CALLBACK_BASE_URL` so the backend can publish reachable callback URLs for status, completion, and failure updates (defaults to `http://127.0.0.1:4000` when unset).
 
-Once those values are set, every `POST /api/generator/requests` submission queues a dispatch envelope with the selected base models, LoRA adapters, and prompt metadata. The GPU agent receives the full base-model roster alongside the primary checkpoint so it can stage or audit every curated option up front. If the GPU agent reports a busy state VisionSuit marks the request as `pending`; accepted jobs flip to `queued` and surface in the history list immediately.
+Once those values are set, every `POST /api/generator/requests` submission queues a dispatch envelope with the selected base models, LoRA adapters, and prompt metadata. The GPU agent receives the full base-model roster alongside the primary checkpoint so it can stage or audit every curated option up front. If the GPU agent reports a busy state VisionSuit marks the request as `pending`; accepted jobs flip to `queued` and surface in the history list immediately. When the agent executes the job it now posts back to `/api/generator/requests/:id/callbacks/status` as phases progress, `/completion` once artifacts land in MinIO, and `/failure` if the run aborts—VisionSuit records those transitions, stores returned object keys, and surfaces finished renders directly in the On-Site Generator history.
 
 ## Development Workflow
 

--- a/backend/prisma/migrations/20250923102644_generator_callback_pipeline/migration.sql
+++ b/backend/prisma/migrations/20250923102644_generator_callback_pipeline/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable
+ALTER TABLE "GeneratorRequest" ADD COLUMN "errorReason" TEXT;
+ALTER TABLE "GeneratorRequest" ADD COLUMN "outputBucket" TEXT;
+ALTER TABLE "GeneratorRequest" ADD COLUMN "outputPrefix" TEXT;
+
+-- CreateTable
+CREATE TABLE "GeneratorArtifact" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "requestId" TEXT NOT NULL,
+    "bucket" TEXT NOT NULL,
+    "objectKey" TEXT NOT NULL,
+    "storagePath" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GeneratorArtifact_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "GeneratorRequest" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "GeneratorArtifact_requestId_idx" ON "GeneratorArtifact"("requestId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -329,11 +329,28 @@ model GeneratorRequest {
   height         Int
   loraSelections Json?
   status         String               @default("draft")
+  errorReason    String?
+  outputBucket   String?
+  outputPrefix   String?
   createdAt      DateTime             @default(now())
   updatedAt      DateTime             @updatedAt
 
   user      User        @relation(fields: [userId], references: [id])
   baseModel ModelAsset? @relation(fields: [baseModelId], references: [id])
+  artifacts GeneratorArtifact[]
+}
+
+model GeneratorArtifact {
+  id          String   @id @default(cuid())
+  requestId   String
+  bucket      String
+  objectKey   String
+  storagePath String
+  createdAt   DateTime @default(now())
+
+  request GeneratorRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
+
+  @@index([requestId])
 }
 
 model ModerationLog {

--- a/backend/src/lib/generator/dispatcher.ts
+++ b/backend/src/lib/generator/dispatcher.ts
@@ -361,6 +361,15 @@ export const dispatchGeneratorRequest = async (
     workflowParameters: [...appConfig.generator.workflow.parameters],
   };
 
+  const callbackBase = appConfig.generator.callbacks.baseUrl.replace(/\/$/, '');
+  if (callbackBase) {
+    envelope.callbacks = {
+      status: `${callbackBase}/api/generator/requests/${request.id}/callbacks/status`,
+      completion: `${callbackBase}/api/generator/requests/${request.id}/callbacks/completion`,
+      failure: `${callbackBase}/api/generator/requests/${request.id}/callbacks/failure`,
+    };
+  }
+
   if (request.negativePrompt !== undefined) {
     envelope.parameters.negativePrompt = request.negativePrompt;
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9906,6 +9906,90 @@ button {
   font-size: 0.85rem;
 }
 
+.generator-history__failure {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+  font-size: 0.9rem;
+}
+
+.generator-history__artifacts {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.generator-history__artifacts h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.generator-history__artifacts-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.generator-history__artifacts-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.generator-history__artifact-link {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.generator-history__artifact-link img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.generator-history__artifact-link--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 0.5rem;
+  color: rgba(148, 163, 184, 0.85);
+  text-align: center;
+  font-size: 0.8rem;
+}
+
+.generator-history__artifact-name {
+  font-size: 0.75rem;
+  text-align: center;
+  color: rgba(148, 163, 184, 0.85);
+  word-break: break-word;
+}
+
+.generator-history__artifacts-empty {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
 @media (max-width: 1100px) {
   .generator__layout {
     grid-template-columns: 1fr;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -132,9 +132,19 @@ export interface GeneratorRequestLoRASelection {
   slug?: string | null;
 }
 
+export interface GeneratorRequestArtifactSummary {
+  id: string;
+  bucket: string;
+  objectKey: string;
+  storagePath: string;
+  url?: string | null;
+  createdAt: string;
+}
+
 export interface GeneratorRequestSummary {
   id: string;
   status: string;
+  errorReason?: string | null;
   prompt: string;
   negativePrompt?: string | null;
   seed?: string | null;
@@ -144,6 +154,7 @@ export interface GeneratorRequestSummary {
   height: number;
   loras: GeneratorRequestLoRASelection[];
   baseModels: GeneratorRequestBaseModelSelection[];
+  artifacts: GeneratorRequestArtifactSummary[];
   baseModel: {
     id: string;
     title: string;
@@ -158,6 +169,10 @@ export interface GeneratorRequestSummary {
     id: string;
     displayName: string;
     role: UserRole;
+  };
+  output: {
+    bucket: string;
+    prefix: string | null;
   };
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- add generator callback configuration, schema updates, and agent dispatch hooks so VisionSuit can record GPU agent status and outputs
- expose callback endpoints that persist artifacts, update request status, and surface errors while keeping README guidance current
- refresh On-Site Generator history UI and types to show returned artifacts and failure reasons with supporting styling

## Testing
- npm run lint (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d274c0471c8333811479890eb70944