### PR TITLE
Fix GPU agent reservation guard

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -822,3 +822,8 @@
 - **General**: Delivered queue maintenance controls so administrators can pause/resume GPU dispatches, retry held jobs, and manage user-level generator access while curators see live queue telemetry.
 - **Technical Changes**: Added Prisma-backed queue state and blocklist models with new REST endpoints, wired admin UI controls and generator wizard banners, refreshed API helpers and styles, and taught the GPU agent to stream ComfyUI queue activity in health probes and status callbacks.
 - **Data Changes**: Added `GeneratorQueueState` and `GeneratorQueueBlock` tables plus a migration that persists queue snapshots and per-user generation blocks.
+
+## 154 – [Fix] GPU agent reservation guard
+- **General**: Restored GPU job acceptance by preventing idle agents from rejecting new dispatches with spurious conflicts.
+- **Technical Changes**: Replaced the zero-time `asyncio.wait_for` lock acquisition with an immediate lock check and acquisition to avoid TimeoutErrors when the worker is idle.
+- **Data Changes**: None.

--- a/gpuworker/agent/app/agent.py
+++ b/gpuworker/agent/app/agent.py
@@ -30,10 +30,9 @@ class GPUAgent:
     async def try_reserve_job(self) -> bool:
         """Attempt to reserve the execution lock without waiting."""
 
-        try:
-            await asyncio.wait_for(self._lock.acquire(), timeout=0)
-        except asyncio.TimeoutError:
+        if self._lock.locked():
             return False
+        await self._lock.acquire()
         return True
 
     async def run_reserved_job(self, job: DispatchEnvelope) -> Dict[str, List[str]]:


### PR DESCRIPTION
## Summary
- prevent the GPU agent from returning 409 conflicts while idle by fixing the reservation lock logic
- document the fix in the changelog

## Testing
- python -m compileall gpuworker/agent

------
https://chatgpt.com/codex/tasks/task_e_68d284d7340c8333959cecb6bb2c25c8