### PR TITLE
Fix GPU agent LoRA filename handling

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -827,3 +827,8 @@
 - **General**: Restored GPU job acceptance by preventing idle agents from rejecting new dispatches with spurious conflicts.
 - **Technical Changes**: Replaced the zero-time `asyncio.wait_for` lock acquisition with an immediate lock check and acquisition to avoid TimeoutErrors when the worker is idle.
 - **Data Changes**: None.
+
+## 155 – [Fix] LoRA filename restoration (commit TBD)
+- **General**: Ensured GPU jobs load MinIO-hosted LoRAs by storing them under their dispatched filenames instead of opaque IDs.
+- **Technical Changes**: Added filename lookup logic sourced from job extras, renamed legacy cached assets, removed stale UUID downloads, and documented the lifecycle update.
+- **Data Changes**: None; filesystem layout only.

--- a/gpuworker/agent/README.md
+++ b/gpuworker/agent/README.md
@@ -6,7 +6,7 @@ The VisionSuit GPU Agent turns a ComfyUI render node into a managed worker that 
 
 - **Single-job enforcement** – The agent processes exactly one job at a time and immediately rejects additional submissions with HTTP 409 so VisionSIOt can preserve the queue discipline.
 - **Workflow templating** – Supports inline workflows, on-disk templates, or MinIO-hosted JSON and applies node overrides or parameter bindings defined in the dispatch envelope.
-- **Managed asset lifecycle** – Caches base checkpoints permanently, downloads job-scoped LoRAs or auxiliary models on demand, and removes ephemeral assets once the render completes.
+- **Managed asset lifecycle** – Caches base checkpoints permanently, downloads job-scoped LoRAs or auxiliary models on demand, saves them using the filenames provided by the dispatch payload even when MinIO stores UUID object keys, and removes ephemeral assets once the render completes.
 - **MinIO integration** – Pulls missing models from MinIO before execution and pushes rendered files back to user-specific prefixes with prompt metadata embedded as object metadata.
 - **Callback hooks** – Emits optional status, completion, and failure callbacks to VisionSIOt or VisionSuit so UIs can surface progress.
 


### PR DESCRIPTION
## Summary
- resolve LoRA downloads to dispatch-provided filenames and rename legacy UUID caches
- mention the filename-aware download flow in the GPU agent README
- log changelog entry 155 describing the fix

## Testing
- python -m compileall gpuworker/agent

------
https://chatgpt.com/codex/tasks/task_e_68d288b23c6c8333a9bfc16316a0ef2b