### PR TITLE
Add generator queue clearing control and reset GPU agent installer

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -832,3 +832,13 @@
 - **General**: Ensured GPU jobs load MinIO-hosted LoRAs by storing them under their dispatched filenames instead of opaque IDs.
 - **Technical Changes**: Added filename lookup logic sourced from job extras, renamed legacy cached assets, removed stale UUID downloads, and documented the lifecycle update.
 - **Data Changes**: None; filesystem layout only.
+
+## 156 – [Addition] Queue clearing administration control (commit TBD)
+- **General**: Empowered administrators to flush the active GPU queue directly from the Administration → Generator screen when dispatches need a clean slate.
+- **Technical Changes**: Added a secured backend clear action that marks pending jobs as cancelled, folded cancellations into queue metrics, exposed the capability via the API client, surfaced a dedicated UI control with dynamic success messaging, and updated generator history to explain cleared requests.
+- **Data Changes**: None; existing queue records are only reclassified when the action runs.
+
+## 157 – [Fix] GPU agent reinstall reset (commit TBD)
+- **General**: Guaranteed GPU agent upgrades start from a pristine environment by tearing down any prior service before reinstalling.
+- **Technical Changes**: Extended the installer to stop and disable existing systemd units, purge `/opt/visionsuit-gpu-agent`, recreate fresh directories, drop stale unit files ahead of deployment, and documented the reset flow in the README.
+- **Data Changes**: None; adjustments operate on runtime directories only.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ A remote ComfyUI render node can be prepared independently of the VisionSuit sta
 
 Alongside the ComfyUI runtime you can deploy the VisionSuit GPU agent to broker jobs from VisionSIOt. The agent lives in [`gpuworker/agent`](gpuworker/agent/README.md) and installs via `sudo ./gpuworker/agent/installer/install.sh`, which copies the FastAPI service to `/opt/visionsuit-gpu-agent`, provisions a Python virtual environment, and enables the `visionsuit-gpu-agent` systemd unit. Configure `/etc/visionsuit-gpu-agent/config.yaml` with MinIO credentials, bucket names, workflow defaults, and the ComfyUI API URL. VisionSIOt submits dispatch envelopes to `POST /jobs`; the agent enforces single-job execution, hydrates workflows, syncs missing models from MinIO, invokes ComfyUI, uploads outputs to the requested bucket, and notifies VisionSuit through the optional status/completion/failure callbacks.
 
+Re-running the installer now stops and disables any existing `visionsuit-gpu-agent` service, removes the previous systemd unit, and recreates `/opt/visionsuit-gpu-agent` from scratch before staging the updated release so upgrades land on a clean slate.
+
 #### VisionSuit ↔ GPU agent handshake
 
 VisionSuit now speaks to the GPU agent instead of probing ComfyUI directly. Point `GENERATOR_NODE_URL` in `backend/.env` at the agent root (for example `http://gpu-node:8081`)—the service advertises `GET /` and `GET /healthz` so health checks stay green. Provide the workflow location and parameter bindings via:

--- a/frontend/src/components/OnSiteGenerator.tsx
+++ b/frontend/src/components/OnSiteGenerator.tsx
@@ -1260,6 +1260,8 @@ export const OnSiteGenerator = ({ models, token, currentUser, onNotify }: OnSite
         {history.map((request) => {
           const createdAt = new Date(request.createdAt);
           const normalizedStatus = request.status.toLowerCase();
+          const isFailureStatus = ['failed', 'error', 'cancelled'].includes(normalizedStatus);
+          const failureLabel = normalizedStatus === 'cancelled' ? 'Cleared' : 'Failure';
           const historyBaseModels =
             request.baseModels.length > 0
               ? request.baseModels
@@ -1334,9 +1336,11 @@ export const OnSiteGenerator = ({ models, token, currentUser, onNotify }: OnSite
               ) : (
                 <p className="generator-history__loras-empty">No LoRA adapters</p>
               )}
-              {['failed', 'error'].includes(normalizedStatus) ? (
+              {isFailureStatus ? (
                 <p className="generator-history__failure">
-                  {request.errorReason ? `Failure: ${request.errorReason}` : 'Failure: reason not provided.'}
+                  {request.errorReason
+                    ? `${failureLabel}: ${request.errorReason}`
+                    : `${failureLabel}: reason not provided.`}
                 </p>
               ) : null}
               {request.artifacts.length > 0 ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -369,6 +369,15 @@ const retryGeneratorQueue = (token: string) =>
     token,
   );
 
+const clearGeneratorQueue = (token: string) =>
+  request<GeneratorQueueResponse>(
+    '/api/generator/queue/actions/clear',
+    {
+      method: 'POST',
+    },
+    token,
+  );
+
 const blockGeneratorUser = (token: string, payload: { userId: string; reason?: string }) =>
   request<GeneratorQueueResponse>(
     '/api/generator/queue/blocks',
@@ -426,6 +435,7 @@ export const api = {
   pauseGeneratorQueue,
   resumeGeneratorQueue,
   retryGeneratorQueue,
+  clearGeneratorQueue,
   blockGeneratorUser,
   unblockGeneratorUser,
   createGeneratorRequest,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -230,6 +230,9 @@ export interface GeneratorQueueResponse {
     busy: number;
     errors: { id: string; message: string }[];
   };
+  cleared?: {
+    removed: number;
+  };
 }
 
 export interface UserProfileModelSummary {

--- a/gpuworker/agent/installer/install.sh
+++ b/gpuworker/agent/installer/install.sh
@@ -17,6 +17,27 @@ if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
   exit 1
 fi
 
+if command -v systemctl >/dev/null 2>&1; then
+  if systemctl list-unit-files | grep -E "^${SERVICE_NAME}[[:space:]]" >/dev/null 2>&1; then
+    echo "Stopping existing ${SERVICE_NAME} instance (if running)"
+    if systemctl is-active --quiet "${SERVICE_NAME}"; then
+      systemctl stop "${SERVICE_NAME}"
+    fi
+    echo "Disabling ${SERVICE_NAME}"
+    systemctl disable "${SERVICE_NAME}" >/dev/null 2>&1 || true
+  fi
+fi
+
+if [[ -f "${SYSTEMD_DIR}/${SERVICE_NAME}" ]]; then
+  echo "Removing existing systemd unit ${SYSTEMD_DIR}/${SERVICE_NAME}"
+  rm -f "${SYSTEMD_DIR}/${SERVICE_NAME}"
+fi
+
+if [[ -d "${AGENT_ROOT}" ]]; then
+  echo "Removing existing agent directory ${AGENT_ROOT}"
+  rm -rf "${AGENT_ROOT}"
+fi
+
 install -d -o root -g root "${AGENT_ROOT}" "${CONFIG_DIR}"
 install -d -o root -g root "${AGENT_ROOT}/workflows" "${AGENT_ROOT}/tmp"
 


### PR DESCRIPTION
## Summary
- add an authenticated queue clear action that cancels pending jobs and surfaces a matching admin control with refreshed history messaging
- fold cancelled jobs into queue statistics and extend the API typings for optional clear results
- hard reset the GPU agent installer before redeploying and document the reinstall flow in the README, alongside changelog updates

## Testing
- npm run lint (backend)
- npm run lint (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d28a7435748333a0c8721fa72791a8