### PR TITLE
Fix: auto-seed generator workflow template

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -842,3 +842,8 @@
 - **General**: Guaranteed GPU agent upgrades start from a pristine environment by tearing down any prior service before reinstalling.
 - **Technical Changes**: Extended the installer to stop and disable existing systemd units, purge `/opt/visionsuit-gpu-agent`, recreate fresh directories, drop stale unit files ahead of deployment, and documented the reset flow in the README.
 - **Data Changes**: None; adjustments operate on runtime directories only.
+
+## 158 – [Fix] Workflow auto-seeding guard
+- **General**: Prevented generator dispatches from reaching the GPU agent without a ready Comfy workflow template.
+- **Technical Changes**: Added backend checks that ensure the workflow bucket exists, upload the configured template from a local path or inline JSON when absent, and guard dispatches with descriptive errors alongside refreshed README guidance.
+- **Data Changes**: None; MinIO contents are synchronized automatically when needed.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Re-running the installer now stops and disables any existing `visionsuit-gpu-age
 VisionSuit now speaks to the GPU agent instead of probing ComfyUI directly. Point `GENERATOR_NODE_URL` in `backend/.env` at the agent root (for example `http://gpu-node:8081`)—the service advertises `GET /` and `GET /healthz` so health checks stay green. Provide the workflow location and parameter bindings via:
 
 - `GENERATOR_WORKFLOW_ID`, `GENERATOR_WORKFLOW_BUCKET`, and `GENERATOR_WORKFLOW_MINIO_KEY` (or `GENERATOR_WORKFLOW_LOCAL_PATH` / `GENERATOR_WORKFLOW_INLINE`) to tell the agent which JSON graph to load.
+- VisionSuit now auto-seeds the configured workflow into `GENERATOR_WORKFLOW_BUCKET` before every dispatch, so provide either a
+  local template path or inline JSON when rolling out a new graph to avoid 404s on the GPU node.
 - `GENERATOR_WORKFLOW_PARAMETERS` (JSON array) to map prompt/seed/CFG inputs onto workflow nodes and `GENERATOR_WORKFLOW_OVERRIDES` for fixed node tweaks.
 - `GENERATOR_OUTPUT_BUCKET` and `GENERATOR_OUTPUT_PREFIX` to control where the agent uploads rendered files (supports `{userId}` and `{jobId}` tokens).
 - `GENERATOR_CALLBACK_BASE_URL` so the backend can publish reachable callback URLs for status, completion, and failure updates (defaults to `http://127.0.0.1:4000` when unset).

--- a/backend/src/lib/storage.ts
+++ b/backend/src/lib/storage.ts
@@ -6,6 +6,7 @@ import { appConfig } from '../config';
 export const storageBuckets = {
   models: appConfig.storage.bucketModels,
   images: appConfig.storage.bucketImages,
+  generatorWorkflows: appConfig.generator.workflow.bucket,
 };
 
 const clientOptions: ClientOptions = {
@@ -22,7 +23,7 @@ if (appConfig.storage.region) {
 
 export const storageClient = new Client(clientOptions);
 
-const ensureBucket = async (bucket: string) => {
+export const ensureBucketExists = async (bucket: string) => {
   const exists = await storageClient.bucketExists(bucket);
   if (exists) {
     return;
@@ -40,7 +41,7 @@ export const initializeStorage = async () => {
 
   for (const bucket of buckets) {
     try {
-      await ensureBucket(bucket);
+      await ensureBucketExists(bucket);
     } catch (error) {
       throw new Error(`Failed to ensure MinIO bucket "${bucket}": ${(error as Error).message}`);
     }


### PR DESCRIPTION
## Summary
- ensure the backend verifies the configured generator workflow object before dispatching jobs and uploads it from local or inline templates when missing
- expose bucket creation helpers so the generator-workflows bucket is created automatically and document the auto-seeding behavior in the README
- record the safeguard in the changelog for traceability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d290a23004833393198387fdddd1f9