### PR TITLE
Fix GPU agent installer permissions

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -852,3 +852,8 @@
 - **General**: Eliminated missing-workflow dispatch failures by shipping a default ComfyUI graph and automatic MinIO seeding.
 - **Technical Changes**: Added `backend/generator-workflows/default.json`, taught the backend to fall back to the bundled template and default parameter bindings, updated the GPU agent to mutate legacy node layouts, refreshed environment samples, and documented the workflow behavior in the README.
 - **Data Changes**: Seeds `generator-workflows/default.json` into MinIO on demand; no database schema updates.
+
+## 160 – [Fix] GPU agent permission automation (commit TBD)
+- **General**: Eliminated permission errors on the GPU agent by provisioning access during installation.
+- **Technical Changes**: Added configurable service user variables, templated the systemd unit, automatically applied ACLs to ComfyUI directories, and refreshed the GPU agent README with override guidance.
+- **Data Changes**: None; filesystem ACL updates only.

--- a/gpuworker/agent/README.md
+++ b/gpuworker/agent/README.md
@@ -47,12 +47,15 @@ sudo ./installer/install.sh
 The installer performs the following steps:
 
 1. Creates the service directories `/opt/visionsuit-gpu-agent` and `/etc/visionsuit-gpu-agent`.
-2. Adds the system user `visionsuit` if it does not yet exist.
+2. Adds the system user `visionsuit` (override with `AGENT_USER`/`AGENT_GROUP`) if it does not yet exist.
 3. Copies the agent sources, creates a Python virtual environment, and installs the required dependencies.
 4. Places a default configuration at `/etc/visionsuit-gpu-agent/config.yaml` (update the MinIO credentials, endpoints, and workflow defaults before starting the service).
-5. Installs the `visionsuit-gpu-agent.service` unit into systemd and enables it immediately.
+5. Grants ACL access for the agent user to the configured ComfyUI model, LoRA, output, workflow, and temp directories so downloads and uploads succeed without running the daemon as root.
+6. Installs the `visionsuit-gpu-agent.service` unit into systemd and enables it immediately.
 
 > **Tip:** Set the MinIO access key, secret key, bucket names, and ComfyUI API URL in `/etc/visionsuit-gpu-agent/config.yaml` before dispatching jobs.
+
+If you prefer to re-use an existing service account (for example the `comfyui` user created by the worker installer), export `AGENT_USER=<existing-user>` and optionally `AGENT_GROUP=<existing-group>` before running the installer. The ACL step honours these variables and will extend permissions for that account instead of creating `visionsuit`.
 
 ## Configuration
 

--- a/gpuworker/agent/config/visionsuit-gpu-agent.service
+++ b/gpuworker/agent/config/visionsuit-gpu-agent.service
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=visionsuit
-Group=visionsuit
+User=@AGENT_USER@
+Group=@AGENT_GROUP@
 WorkingDirectory=/opt/visionsuit-gpu-agent
 Environment="VISION_SUITE_AGENT_CONFIG=/etc/visionsuit-gpu-agent/config.yaml"
 ExecStart=/opt/visionsuit-gpu-agent/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8081


### PR DESCRIPTION
## Summary
- add configurable agent user/group defaults in the GPU agent installer and template the systemd unit
- auto-detect ComfyUI paths from the config to grant ACL permissions and document the override options
- record the permission automation in the changelog

## Testing
- bash -n gpuworker/agent/installer/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2a2385214833382e7ccdea9838d12