### PR TITLE
Prevent GPU agent workflow path permission errors

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -857,3 +857,8 @@
 - **General**: Eliminated permission errors on the GPU agent by provisioning access during installation.
 - **Technical Changes**: Added configurable service user variables, templated the systemd unit, automatically applied ACLs to ComfyUI directories, and refreshed the GPU agent README with override guidance.
 - **Data Changes**: None; filesystem ACL updates only.
+
+## 161 – [Fix] GPU agent workflow isolation
+- **General**: Prevented remote GPU workers from crashing when VisionSuit dispatched workflows with backend-only filesystem paths.
+- **Technical Changes**: Added an opt-in `GENERATOR_WORKFLOW_EXPOSE_LOCAL_PATH` flag, defaulted dispatch envelopes to MinIO-hosted templates, and documented the new control in the README.
+- **Data Changes**: None; configuration defaults only.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ VisionSuit now speaks to the GPU agent instead of probing ComfyUI directly. Poin
 
 - `GENERATOR_WORKFLOW_ID`, `GENERATOR_WORKFLOW_BUCKET`, and `GENERATOR_WORKFLOW_MINIO_KEY` (or `GENERATOR_WORKFLOW_LOCAL_PATH` / `GENERATOR_WORKFLOW_INLINE`) to tell the agent which JSON graph to load.
 - A starter SDXL workflow ships at [`backend/generator-workflows/default.json`](backend/generator-workflows/default.json); when no custom `GENERATOR_WORKFLOW_LOCAL_PATH` is provided the backend uploads this template to MinIO automatically.
+- `GENERATOR_WORKFLOW_EXPOSE_LOCAL_PATH` defaults to `false` so dispatch envelopes always reference the MinIO object; set it to `true` only when the GPU agent can read the same filesystem path (for example on a co-located host).
 - VisionSuit now auto-seeds the configured workflow into `GENERATOR_WORKFLOW_BUCKET` before every dispatch, so provide either a
   local template path or inline JSON when rolling out a new graph to avoid 404s on the GPU node.
 - Prompt, sampler, and resolution bindings are pre-wired for the bundled workflow—only override `GENERATOR_WORKFLOW_PARAMETERS` when publishing a custom node layout.

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -262,6 +262,7 @@ const resolveWorkflowTemplatePath = (): string | undefined => {
 };
 
 const resolvedWorkflowLocalPath = resolveWorkflowTemplatePath();
+const exposeLocalWorkflowPath = toBoolean(process.env.GENERATOR_WORKFLOW_EXPOSE_LOCAL_PATH, false);
 const parsedWorkflowParameterBindings = parseWorkflowParameterBindings(process.env.GENERATOR_WORKFLOW_PARAMETERS);
 const workflowParameterBindings =
   parsedWorkflowParameterBindings.length > 0 ? parsedWorkflowParameterBindings : defaultWorkflowParameterBindings;
@@ -337,6 +338,7 @@ export const appConfig = {
       bucket: process.env.GENERATOR_WORKFLOW_BUCKET?.trim() || 'generator-workflows',
       minioKey: process.env.GENERATOR_WORKFLOW_MINIO_KEY?.trim() || 'default.json',
       localPath: resolvedWorkflowLocalPath ?? undefined,
+      exposeLocalPath: exposeLocalWorkflowPath,
       inline: parseJsonValue(process.env.GENERATOR_WORKFLOW_INLINE, 'GENERATOR_WORKFLOW_INLINE'),
       parameters: workflowParameterBindings,
       overrides: workflowOverrides,

--- a/backend/src/lib/generator/dispatcher.ts
+++ b/backend/src/lib/generator/dispatcher.ts
@@ -267,7 +267,7 @@ const buildWorkflowReference = () => {
     version: workflow.version ?? null,
     bucket: workflow.bucket ?? null,
     minioKey: workflow.minioKey ?? null,
-    localPath: workflow.localPath ?? null,
+    localPath: workflow.exposeLocalPath ? workflow.localPath ?? null : null,
     inline: workflow.inline,
   };
 


### PR DESCRIPTION
## Summary
- add a configuration flag so generator dispatches no longer leak backend-only workflow paths to the GPU agent by default
- continue seeding the workflow template to MinIO while allowing optional local-path exposure when the agent shares the filesystem
- document the new environment variable and log the fix in the changelog

## Testing
- npm --prefix backend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2a57a44408333b1c4e35de7325aca