### PR TITLE
Fix ComfyUI checkpoint binding payload

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -888,3 +888,8 @@
 - **General**: Hardened GPU agent workflow submissions with upfront validation and clearer ComfyUI error messages so 400 responses highlight misformatted prompts instead of failing silently.
 - **Technical Changes**: Added API-format checks that detect legacy editor exports, enforced required node fields, and surfaced ComfyUI response bodies when `/prompt` rejects a payload. Documented the export requirements in the README for operators.
 - **Data Changes**: None; validation affects in-flight dispatch payloads only.
+
+## 167 – [Fix] ComfyUI checkpoint payload normalization
+- **General**: Ensured generator submissions reference ComfyUI checkpoints using the filename expected by the API.
+- **Technical Changes**: Adjusted the GPU agent workflow context so `base_model_path` resolves to the checkpoint filename while exposing the absolute path separately for diagnostics.
+- **Data Changes**: None.

--- a/gpuworker/agent/app/agent.py
+++ b/gpuworker/agent/app/agent.py
@@ -152,7 +152,8 @@ class GPUAgent:
             "seed": job.parameters.seed,
             "cfg_scale": job.parameters.cfgScale,
             "steps": job.parameters.steps,
-            "base_model_path": str(base_model_path),
+            "base_model_path": base_model_path.name,
+            "base_model_full_path": str(base_model_path),
             "loras": [str(path) for path in lora_paths],
         }
         if job.parameters.resolution:


### PR DESCRIPTION
## Summary
- ensure the GPU agent sends the checkpoint filename when binding `base_model_path` so ComfyUI receives the expected `ckpt_name`
- retain the absolute path as a separate workflow parameter for diagnostics
- document the fix in the repository changelog

## Testing
- python -m compileall gpuworker/agent

------
https://chatgpt.com/codex/tasks/task_e_68d2c81c8ce083338a9865013af8c50e