### PR TITLE
Fix GPU agent cancellation request scope

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -908,3 +908,8 @@
 - **General**: Hardened GPU job execution with strict ComfyUI asset name validation, friendlier LoRA/model naming, resumable callbacks, and a cooperative cancellation path that reports partial uploads without aborting the job.
 - **Technical Changes**: Introduced pretty-name symlink management for checkpoints and LoRAs with metadata fallbacks, invalidated and refreshed ComfyUI asset caches before submission, enforced whitelist validation via `/object_info`, added retrying callbacks and cancellation tokens, derived dynamic timeouts, captured node errors in failure callbacks, exposed `POST /jobs/cancel`, updated upload metadata plus deterministic key naming, and refreshed the sample configuration and README to document the new knobs.
 - **Data Changes**: Generator outputs now land under `comfy-outputs/{job_id}/{index}_{seed}.{ext}` with expanded object metadata (model, LoRAs, prompt, seed, steps).
+
+## 170 – [Fix] GPU agent cancel request model scope
+- **General**: Restored the GPU agent startup by providing FastAPI access to the cancellation payload schema.
+- **Technical Changes**: Moved the `CancelRequest` Pydantic model to module scope so dependency resolution succeeds when registering `/jobs/cancel`.
+- **Data Changes**: None.

--- a/gpuworker/agent/main.py
+++ b/gpuworker/agent/main.py
@@ -15,6 +15,10 @@ LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(name)s: %(message)s")
 
 
+class CancelRequest(BaseModel):
+    token: str
+
+
 def create_app() -> FastAPI:
     config_path = os.environ.get("VISION_SUITE_AGENT_CONFIG", "/etc/visionsuit-gpu-agent/config.yaml")
     config = load_config(config_path)
@@ -38,9 +42,6 @@ def create_app() -> FastAPI:
             "busy": busy,
             "activity": await agent.describe_activity(),
         }
-
-    class CancelRequest(BaseModel):
-        token: str
 
     @app.post("/jobs", status_code=202)
     async def submit_job(job: DispatchEnvelope, background_tasks: BackgroundTasks) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- move the GPU agent `CancelRequest` model to module scope so FastAPI can register the cancellation endpoint without errors
- append changelog entry 170 documenting the startup fix

## Testing
- python -m compileall gpuworker/agent

------
https://chatgpt.com/codex/tasks/task_e_68d2db711a5483338c0720afbc2661f7