### PR TITLE
Fix GPU agent completion polling for ComfyUI status_str responses

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -918,3 +918,8 @@
 - **General**: Brought the GPU agent heartbeat, success, and failure callbacks in line with the generator control-plane schema so VisionSuit receives live progress, timing, and artifact metadata straight from ComfyUI runs.
 - **Technical Changes**: Added runtime tracking for prompt IDs and heartbeat counters, mapped status events onto the new state machine, enriched success payloads with artifact manifests and generation parameters, normalized failure/cancel responses with reason codes and activity snapshots, and attached idempotency keys plus S3 URLs when uploading outputs.
 - **Data Changes**: None; S3 object locations are unchanged while callbacks now carry additional descriptive fields.
+
+## 172 – [Fix] GPU agent ComfyUI status normalization
+- **General**: Prevented GPU renders from stalling after ComfyUI reported successful completions using `status_str` payloads.
+- **Technical Changes**: Normalized ComfyUI history polling to read `status_str`, raw string values, and `completed` flags so `success`/`completed` runs exit promptly while `error` states still raise failures.
+- **Data Changes**: None; status polling only interprets existing history metadata.

--- a/gpuworker/agent/app/comfyui.py
+++ b/gpuworker/agent/app/comfyui.py
@@ -93,7 +93,20 @@ class ComfyUIClient:
                 await asyncio.sleep(poll_interval)
                 continue
 
-            status = (history.get("status") or {}).get("status")
+            status_payload = history.get("status") if isinstance(history, dict) else None
+            status = None
+            completed = False
+            if isinstance(status_payload, dict):
+                raw_status = status_payload.get("status") or status_payload.get("status_str")
+                if raw_status is not None:
+                    status = str(raw_status).strip().lower()
+                completed = bool(status_payload.get("completed"))
+            elif isinstance(status_payload, str):
+                status = status_payload.strip().lower()
+
+            if completed and not status:
+                status = "success"
+
             if status in {"completed", "success"}:
                 LOGGER.info("ComfyUI job %s completed", prompt_id)
                 return history


### PR DESCRIPTION
## Summary
- normalize the GPU agent's ComfyUI history polling to read `status_str`, raw string statuses, and `completed` flags so successful jobs exit promptly
- record the fix in changelog entry 172

## Testing
- python -m compileall gpuworker/agent/app/comfyui.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f56c05c08333b877f6b9a643fea9