### PR TITLE
Align generator callbacks with GPU agent and add bucket bootstrapper

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -923,3 +923,8 @@
 - **General**: Prevented GPU renders from stalling after ComfyUI reported successful completions using `status_str` payloads.
 - **Technical Changes**: Normalized ComfyUI history polling to read `status_str`, raw string values, and `completed` flags so `success`/`completed` runs exit promptly while `error` states still raise failures.
 - **Data Changes**: None; status polling only interprets existing history metadata.
+
+## 173 – [Addition] GPU agent callback route-back
+- **General**: Enabled VisionSuit to accept the GPU agent's state-machine callbacks and bundled a helper to provision the MinIO buckets required for round-trip generations.
+- **Technical Changes**: Extended the generator callback schemas to consume `job_id`/`state` payloads, mapped agent states onto VisionSuit statuses with queue activity persistence, normalised completion artifact manifests, reconciled failure reasons, and shipped `backend/scripts/setupGeneratorBuckets.ts` to auto-create model, workflow, and output buckets.
+- **Data Changes**: None; existing generator request and artifact records now reuse the uploaded bucket/key pairs reported by the agent.

--- a/backend/scripts/setupGeneratorBuckets.ts
+++ b/backend/scripts/setupGeneratorBuckets.ts
@@ -1,0 +1,90 @@
+import { Client } from 'minio';
+
+import { appConfig } from '../src/config';
+
+const normalizeBucketName = (candidate?: string | null): string | null => {
+  if (!candidate) {
+    return null;
+  }
+
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.replace(/^s3:\/\//i, '').replace(/\/+$/, '');
+};
+
+const bucketEntries = [
+  { name: appConfig.storage.bucketModels, description: 'Model catalog assets' },
+  { name: appConfig.storage.bucketImages, description: 'User-uploaded imagery' },
+  { name: appConfig.generator.output.bucket, description: 'Generator output artifacts' },
+  { name: appConfig.generator.workflow.bucket, description: 'Generator workflow templates' },
+];
+
+const normalizedBaseModelBucket = normalizeBucketName(appConfig.generator.baseModelBucket);
+if (normalizedBaseModelBucket) {
+  bucketEntries.push({ name: normalizedBaseModelBucket, description: 'GPU base model repository' });
+}
+
+const uniqueBuckets = bucketEntries.reduce<Array<{ name: string; description: string }>>((accumulator, entry) => {
+  const normalized = normalizeBucketName(entry.name);
+  if (!normalized) {
+    return accumulator;
+  }
+
+  if (accumulator.some((existing) => existing.name === normalized)) {
+    return accumulator;
+  }
+
+  accumulator.push({ name: normalized, description: entry.description });
+  return accumulator;
+}, []);
+
+if (uniqueBuckets.length === 0) {
+  // eslint-disable-next-line no-console
+  console.log('No buckets configured – exiting.');
+  process.exit(0);
+}
+
+const client = new Client({
+  endPoint: appConfig.storage.endpoint,
+  port: appConfig.storage.port,
+  useSSL: appConfig.storage.useSSL,
+  accessKey: appConfig.storage.accessKey,
+  secretKey: appConfig.storage.secretKey,
+  region: appConfig.storage.region ?? undefined,
+});
+
+const ensureBucket = async (bucket: { name: string; description: string }) => {
+  const exists = await client.bucketExists(bucket.name);
+  if (exists) {
+    // eslint-disable-next-line no-console
+    console.log(`✔ Bucket "${bucket.name}" already exists (${bucket.description}).`);
+    return;
+  }
+
+  if (appConfig.storage.region) {
+    await client.makeBucket(bucket.name, appConfig.storage.region);
+  } else {
+    await client.makeBucket(bucket.name);
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`➕ Created bucket "${bucket.name}" (${bucket.description}).`);
+};
+
+const run = async () => {
+  for (const bucket of uniqueBuckets) {
+    try {
+      await ensureBucket(bucket);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to ensure bucket "${bucket.name}":`, error);
+      process.exitCode = 1;
+      return;
+    }
+  }
+};
+
+void run();


### PR DESCRIPTION
## Summary
- expand the generator callback schemas to accept the GPU agent's job_id/state payloads and map them onto VisionSuit statuses
- persist activity snapshots, normalize completion artifacts, and capture failure reasons while updating queue state
- add a MinIO bootstrap script and README guidance for creating model, workflow, and output buckets; log the changes in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2f84749708333acc73ffe84674aa5