### PR TITLE
Reorganize generator admin panel

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -938,3 +938,8 @@
 - **General**: Prevented concurrent GPU jobs from colliding by enforcing a single global dispatch slot while giving every member a personal queue dashboard and token-aware artifact links that open without manual authentication headers.
 - **Technical Changes**: Added queue-state locking with `activeRequestId`/`lockedAt`, centralized dispatch in a serialized `processGeneratorQueue`, scoped queue stats per user with global metrics for admins, refreshed admin/frontend displays to respect the new payload shape, and appended access tokens to generator artifact URLs. The README now highlights the serialized queue and automatic proxy authorization.
 - **Data Changes**: Introduced nullable `activeRequestId` and `lockedAt` columns on `GeneratorQueueState` to track the in-flight job and lock acquisition timestamp.
+
+## 176 – [Addition] Generator admin layout segmentation
+- **General**: Organized the generator administration console into focused sections so queue operations, error telemetry, and access controls stay easy to scan.
+- **Technical Changes**: Added a segmented sub-navigation with dedicated queue, failure log, and access panels, reset the active sub-tab when leaving the generator view, refreshed copy, styled the new controls, and updated the README to explain the streamlined workflow.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ During execution the installer:
 
 Base checkpoints for the On-Site Generator still live in the GPU worker bucket `comfyui-models`. When customizing bucket names, mirror the change inside `backend/.env` with `GENERATOR_BASE_MODEL_BUCKET` and inside `frontend/.env` via `VITE_GENERATOR_BASE_MODEL_BUCKET` so the GPU worker and download proxy continue to line up. After new checkpoints land in the bucket, open **Administration → Generator** and add an entry for each filename so the curated picker exposes only vetted models; the generator now hydrates that list from the corresponding database records automatically. For headless maintenance windows or CI pipelines the helper remains available to pre-seed the catalog explicitly:
 
+Inside the Generator administration view, the segmented **Queue & blocks**, **Failure log**, and **Access & presets** controls keep the maintenance tools organized so you can jump directly to live queue telemetry, error diagnostics, or visibility settings without scrolling.
+
 ```bash
 cd backend
 npm run generator:sync-base-models

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9944,6 +9944,65 @@ button {
   font-size: 0.85rem;
 }
 
+.generator-subnav {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 1.5rem;
+}
+
+.generator-subnav__tab {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.95rem;
+  text-align: left;
+  width: 100%;
+  appearance: none;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.generator-subnav__tab span {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.generator-subnav__tab small {
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.8rem;
+  line-height: 1.25;
+}
+
+.generator-subnav__tab:hover,
+.generator-subnav__tab:focus-visible {
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+  outline: none;
+}
+
+.generator-subnav__tab--active {
+  border-color: rgba(59, 130, 246, 0.8);
+  background: rgba(37, 99, 235, 0.2);
+  color: #f8fafc;
+}
+
+.generator-subnav__tab--active small {
+  color: rgba(191, 219, 254, 0.9);
+}
+
+@media (max-width: 720px) {
+  .generator-subnav {
+    grid-template-columns: 1fr;
+  }
+}
+
 .generator-queue__summary {
   margin-top: 1rem;
   display: grid;


### PR DESCRIPTION
## Summary
- split the Administration → Generator view into queue, failure log, and access sub-tabs with a compact selector
- add styles for the new generator sub-navigation and refresh copy within each section
- document the streamlined layout in the README and log the change in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d308bad4e883338e2688dcab62cf9d