### PR TITLE
Add LoRA loader binding to default workflow

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -963,3 +963,8 @@
 - **General**: Prevented artifact imports from buffering massive generator renders so detail-page onboarding stays responsive.
 - **Technical Changes**: Added a 32 MiB streaming guard that only hydrates metadata when safe, skips buffer hydration for oversized files, and preserves adult-content checks using request data fallbacks while keeping gallery creation intact.
 - **Data Changes**: None.
+
+## 181 – [Addition] Default workflow LoRA loader wiring
+- **General**: Threaded the bundled SDXL workflow through a dedicated LoRA loader so generator jobs can target curated adapters without manual graph edits.
+- **Technical Changes**: Inserted a `LoraLoader` node into `backend/generator-workflows/default.json`, bound its filename and strength inputs to `primary_lora_*` parameters, taught the dispatcher to surface those values from request selections, and covered the new context builder with node-based unit tests plus README guidance.
+- **Data Changes**: None.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ VisionSuit now speaks to the GPU agent instead of probing ComfyUI directly. Poin
 - VisionSuit now auto-seeds the configured workflow into `GENERATOR_WORKFLOW_BUCKET` before every dispatch, so provide either a
   local template path or inline JSON when rolling out a new graph to avoid 404s on the GPU node.
 - Prompt, sampler, and resolution bindings are pre-wired for the bundled workflow—only override `GENERATOR_WORKFLOW_PARAMETERS` when publishing a custom node layout.
+- The default graph injects a `LoraLoader` between the checkpoint and sampler; VisionSuit maps LoRA selections onto `primary_lora_name`, `primary_lora_strength_model`, and `primary_lora_strength_clip` so the loader node receives the chosen adapter and strength values automatically.
 - `GENERATOR_WORKFLOW_PARAMETERS` (JSON array) to map prompt/seed/CFG inputs onto workflow nodes and `GENERATOR_WORKFLOW_OVERRIDES` for fixed node tweaks.
 - `GENERATOR_OUTPUT_BUCKET` and `GENERATOR_OUTPUT_PREFIX` to control where the agent uploads rendered files (supports `{userId}` and `{jobId}` tokens).
 - `GENERATOR_CALLBACK_BASE_URL` so the backend can publish reachable callback URLs for status, completion, and failure updates (defaults to `http://127.0.0.1:4000` when unset).

--- a/backend/generator-workflows/default.json
+++ b/backend/generator-workflows/default.json
@@ -8,10 +8,26 @@
     }
   },
   "2": {
+    "class_type": "LoraLoader",
+    "inputs": {
+      "model": [
+        "1",
+        0
+      ],
+      "clip": [
+        "1",
+        1
+      ],
+      "lora_name": "",
+      "strength_model": 1,
+      "strength_clip": 1
+    }
+  },
+  "3": {
     "class_type": "CLIPTextEncodeSDXL",
     "inputs": {
       "clip": [
-        "1",
+        "2",
         1
       ],
       "width": 1024,
@@ -24,11 +40,11 @@
       "text_l": ""
     }
   },
-  "3": {
+  "4": {
     "class_type": "CLIPTextEncodeSDXL",
     "inputs": {
       "clip": [
-        "1",
+        "2",
         1
       ],
       "width": 1024,
@@ -41,7 +57,7 @@
       "text_l": "low quality, blurry, distorted anatomy, watermark"
     }
   },
-  "4": {
+  "5": {
     "class_type": "EmptyLatentImage",
     "inputs": {
       "width": 1024,
@@ -49,23 +65,23 @@
       "batch_size": 1
     }
   },
-  "5": {
+  "6": {
     "class_type": "KSampler",
     "inputs": {
       "model": [
-        "1",
-        0
-      ],
-      "positive": [
         "2",
         0
       ],
-      "negative": [
+      "positive": [
         "3",
         0
       ],
-      "latent_image": [
+      "negative": [
         "4",
+        0
+      ],
+      "latent_image": [
+        "5",
         0
       ],
       "seed": 123456789,
@@ -76,11 +92,11 @@
       "denoise": 1
     }
   },
-  "6": {
+  "7": {
     "class_type": "VAEDecode",
     "inputs": {
       "samples": [
-        "5",
+        "6",
         0
       ],
       "vae": [
@@ -89,11 +105,11 @@
       ]
     }
   },
-  "7": {
+  "8": {
     "class_type": "SaveImage",
     "inputs": {
       "images": [
-        "6",
+        "7",
         0
       ],
       "filename_prefix": "generated/default"

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "lint": "tsc --noEmit",
+    "test": "node --test --require ts-node/register ./test/loraContext.test.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:studio": "prisma studio",

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -227,17 +227,20 @@ const parseWorkflowOverrides = (value: string | undefined): AgentWorkflowMutatio
 
 const defaultWorkflowParameterBindings: AgentWorkflowParameterBinding[] = [
   { parameter: 'base_model_path', node: 1, path: 'inputs.ckpt_name' },
-  { parameter: 'prompt', node: 2, path: 'inputs.text_g' },
-  { parameter: 'prompt', node: 2, path: 'inputs.text_l' },
-  { parameter: 'negative_prompt', node: 3, path: 'inputs.text_g' },
-  { parameter: 'negative_prompt', node: 3, path: 'inputs.text_l' },
-  { parameter: 'width', node: 4, path: 'inputs.width' },
-  { parameter: 'height', node: 4, path: 'inputs.height' },
-  { parameter: 'seed', node: 5, path: 'inputs.seed' },
-  { parameter: 'steps', node: 5, path: 'inputs.steps' },
-  { parameter: 'cfg_scale', node: 5, path: 'inputs.cfg' },
-  { parameter: 'sampler', node: 5, path: 'inputs.sampler_name' },
-  { parameter: 'scheduler', node: 5, path: 'inputs.scheduler' },
+  { parameter: 'primary_lora_name', node: 2, path: 'inputs.lora_name' },
+  { parameter: 'primary_lora_strength_model', node: 2, path: 'inputs.strength_model' },
+  { parameter: 'primary_lora_strength_clip', node: 2, path: 'inputs.strength_clip' },
+  { parameter: 'prompt', node: 3, path: 'inputs.text_g' },
+  { parameter: 'prompt', node: 3, path: 'inputs.text_l' },
+  { parameter: 'negative_prompt', node: 4, path: 'inputs.text_g' },
+  { parameter: 'negative_prompt', node: 4, path: 'inputs.text_l' },
+  { parameter: 'width', node: 5, path: 'inputs.width' },
+  { parameter: 'height', node: 5, path: 'inputs.height' },
+  { parameter: 'seed', node: 6, path: 'inputs.seed' },
+  { parameter: 'steps', node: 6, path: 'inputs.steps' },
+  { parameter: 'cfg_scale', node: 6, path: 'inputs.cfg' },
+  { parameter: 'sampler', node: 6, path: 'inputs.sampler_name' },
+  { parameter: 'scheduler', node: 6, path: 'inputs.scheduler' },
 ];
 
 const resolveWorkflowTemplatePath = (): string | undefined => {

--- a/backend/src/lib/generator/dispatcher.ts
+++ b/backend/src/lib/generator/dispatcher.ts
@@ -1,11 +1,8 @@
 import path from 'node:path';
 
 import { appConfig } from '../../config';
-import {
-  AgentDispatchEnvelope,
-  AgentRequestError,
-  GeneratorAgentClient,
-} from './agentClient';
+import { AgentDispatchEnvelope, AgentRequestError, GeneratorAgentClient } from './agentClient';
+import { mergeLoraExtras } from './loraContext';
 import { prisma } from '../prisma';
 import { ensureBucketExists, resolveStorageLocation, storageClient } from '../storage';
 
@@ -482,7 +479,7 @@ export const dispatchGeneratorRequest = async (
     envelope.parameters.extra = {
       ...(envelope.parameters.extra ?? {}),
       ...(baseModelExtraPayload.length > 0 ? { baseModels: baseModelExtraPayload } : {}),
-      ...(loraExtraPayload.length > 0 ? { loras: loraExtraPayload } : {}),
+      ...mergeLoraExtras(selections, loraExtraPayload),
     };
   }
 

--- a/backend/src/lib/generator/loraContext.ts
+++ b/backend/src/lib/generator/loraContext.ts
@@ -1,0 +1,77 @@
+import path from 'node:path';
+
+export type LoraSelectionForContext = { strength: number | null | undefined };
+export type LoraExtraForContext = Record<string, unknown>;
+
+const normalizeStrength = (value: number | null | undefined): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 1;
+  }
+
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+
+  const clamped = Math.max(-2, Math.min(2, value));
+  return Number.parseFloat(clamped.toFixed(2));
+};
+
+const extractFilename = (payload: LoraExtraForContext): string | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const filenameRaw = payload.filename;
+  if (typeof filenameRaw === 'string' && filenameRaw.trim().length > 0) {
+    const normalized = path.basename(filenameRaw.trim());
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
+  const keyRaw = payload.key;
+  if (typeof keyRaw === 'string' && keyRaw.trim().length > 0) {
+    const normalized = path.basename(keyRaw.trim());
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+
+  return null;
+};
+
+export const derivePrimaryLoraContext = (
+  selections: LoraSelectionForContext[],
+  payloads: LoraExtraForContext[],
+): Record<string, unknown> => {
+  if (!Array.isArray(payloads) || payloads.length === 0) {
+    return {};
+  }
+
+  const firstPayload = payloads[0];
+  if (!firstPayload) {
+    return {};
+  }
+
+  const filename = extractFilename(firstPayload);
+  if (!filename) {
+    return {};
+  }
+
+  const firstSelection = selections[0];
+  const strength = normalizeStrength(firstSelection?.strength ?? null);
+
+  return {
+    primary_lora_name: filename,
+    primary_lora_strength_model: strength,
+    primary_lora_strength_clip: strength,
+  };
+};
+
+export const mergeLoraExtras = (
+  selections: LoraSelectionForContext[],
+  payloads: LoraExtraForContext[],
+): Record<string, unknown> => ({
+  ...(payloads.length > 0 ? { loras: payloads } : {}),
+  ...derivePrimaryLoraContext(selections, payloads),
+});

--- a/backend/test/loraContext.test.ts
+++ b/backend/test/loraContext.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { derivePrimaryLoraContext, mergeLoraExtras } from '../src/lib/generator/loraContext';
+
+test('derivePrimaryLoraContext surfaces filename and strengths for the first LoRA selection', () => {
+  const selections = [{ strength: 0.85 }];
+  const payloads = [{ filename: 'models/loras/hero-lora.safetensors', key: 'loras/hero-lora.safetensors' }];
+
+  const context = derivePrimaryLoraContext(selections, payloads);
+
+  assert.deepEqual(context, {
+    primary_lora_name: 'hero-lora.safetensors',
+    primary_lora_strength_model: 0.85,
+    primary_lora_strength_clip: 0.85,
+  });
+});
+
+test('derivePrimaryLoraContext falls back to object key when filename is missing', () => {
+  const selections = [{ strength: 1.2 }];
+  const payloads = [{ key: 'loras/custom/subdir/my-lora.safetensors' }];
+
+  const context = derivePrimaryLoraContext(selections, payloads);
+
+  assert.deepEqual(context, {
+    primary_lora_name: 'my-lora.safetensors',
+    primary_lora_strength_model: 1.2,
+    primary_lora_strength_clip: 1.2,
+  });
+});
+
+test('derivePrimaryLoraContext returns an empty object when no payloads are provided', () => {
+  const context = derivePrimaryLoraContext([{ strength: 0.5 }], []);
+  assert.deepEqual(context, {});
+});
+
+test('mergeLoraExtras retains the payload list alongside derived context', () => {
+  const selections = [{ strength: 0.6 }];
+  const payloads = [{ filename: 'loras/paired.safetensors', key: 'loras/paired.safetensors' }];
+
+  const context = mergeLoraExtras(selections, payloads);
+
+  assert.deepEqual(context, {
+    loras: payloads,
+    primary_lora_name: 'paired.safetensors',
+    primary_lora_strength_model: 0.6,
+    primary_lora_strength_clip: 0.6,
+  });
+});


### PR DESCRIPTION
## Summary
- insert a LoraLoader node into the bundled SDXL workflow and update downstream wiring
- bind the loader inputs to new primary_lora_* parameters, surface them from dispatch, and cover the logic with unit tests
- document the default LoRA bindings in the README and append the changelog entry

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d386a13a1c8333841d35a123c51891