### PR TITLE
Preserve sanitized LoRA context for GPU agent

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -968,3 +968,8 @@
 - **General**: Threaded the bundled SDXL workflow through a dedicated LoRA loader so generator jobs can target curated adapters without manual graph edits.
 - **Technical Changes**: Inserted a `LoraLoader` node into `backend/generator-workflows/default.json`, bound its filename and strength inputs to `primary_lora_*` parameters, taught the dispatcher to surface those values from request selections, and covered the new context builder with node-based unit tests plus README guidance.
 - **Data Changes**: None.
+
+## 182 – [Fix] Sanitized LoRA parameter propagation
+- **General**: Ensured generator jobs feed ComfyUI the sanitized LoRA adapter name and intended strength so queued renders honor the on-site selections.
+- **Technical Changes**: Preserved normalized LoRA filenames in the agent context, derived primary strength values from request metadata, exposed the raw payloads under `loras_metadata`, ignored conflicting extras, and added unit coverage that verifies the workflow payload binds the sanitized adapter and strengths.
+- **Data Changes**: None.

--- a/gpuworker/agent/tests/test_parameter_context.py
+++ b/gpuworker/agent/tests/test_parameter_context.py
@@ -1,0 +1,124 @@
+import copy
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from gpuworker.agent.app.agent import GPUAgent, ResolvedAsset
+from gpuworker.agent.app.models import (
+    AssetRef,
+    DispatchEnvelope,
+    JobParameters,
+    OutputSpec,
+    UserContext,
+    WorkflowParameterBinding,
+    WorkflowRef,
+)
+from gpuworker.agent.app.workflow import build_workflow_payload
+
+
+class InlineWorkflowLoader:
+    def load(self, job: DispatchEnvelope):  # noqa: D401 - simple stub
+        return copy.deepcopy(job.workflow.inline)
+
+
+class ParameterContextTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.agent = GPUAgent.__new__(GPUAgent)
+        self.agent.config = SimpleNamespace(workflow_defaults={"sampler": "euler"})
+        self.base_asset_ref = AssetRef(bucket="models", key="checkpoints/base.safetensors")
+        self.base_resolved = ResolvedAsset(
+            asset=self.base_asset_ref,
+            cache_path=Path("/models/base.safetensors"),
+            comfy_name="base.safetensors",
+            symlink_path=Path("/models/base.safetensors"),
+            downloaded=False,
+            link_created=False,
+        )
+        self.lora_asset_ref = AssetRef(bucket="models", key="loras/my-lora.safetensors")
+        self.lora_resolved = ResolvedAsset(
+            asset=self.lora_asset_ref,
+            cache_path=Path("/loras/my-lora.safetensors"),
+            comfy_name="my-lora.safetensors",
+            symlink_path=Path("/loras/my-lora.safetensors"),
+            downloaded=False,
+            link_created=False,
+        )
+        self.workflow_ref = WorkflowRef(
+            id="inline",
+            inline={
+                "1": {"class_type": "CheckpointLoaderSimple", "inputs": {"ckpt_name": ""}},
+                "2": {
+                    "class_type": "LoraLoader",
+                    "inputs": {"lora_name": "", "strength_model": 0.0, "strength_clip": 0.0},
+                },
+            },
+        )
+
+    def _build_job(self, extra: dict | None = None) -> DispatchEnvelope:
+        parameters = JobParameters(prompt="Test prompt", extra=extra or {})
+        return DispatchEnvelope(
+            jobId="job-1",
+            user=UserContext(id="user-1", username="tester"),
+            workflow=self.workflow_ref,
+            baseModel=self.base_asset_ref,
+            loras=[self.lora_asset_ref],
+            parameters=parameters,
+            output=OutputSpec(bucket="outputs", prefix="jobs/job-1"),
+            workflowParameters=[
+                WorkflowParameterBinding(parameter="primary_lora_name", node=2, path="inputs.lora_name"),
+                WorkflowParameterBinding(
+                    parameter="primary_lora_strength_model", node=2, path="inputs.strength_model"
+                ),
+                WorkflowParameterBinding(
+                    parameter="primary_lora_strength_clip", node=2, path="inputs.strength_clip"
+                ),
+            ],
+        )
+
+    def test_primary_lora_metadata_preserved_and_bound(self) -> None:
+        extra = {
+            "loras": [
+                {
+                    "id": "lora-1",
+                    "filename": "loras/My-Lora.safetensors",
+                    "key": "loras/my-lora.safetensors",
+                    "strength": 0.85,
+                }
+            ],
+            "primary_lora_name": "../unsanitized-path.safetensors",
+            "primary_lora_strength_model": 3,
+            "misc": "value",
+        }
+        job = self._build_job(extra)
+
+        context = self.agent._build_parameter_context(job, self.base_resolved, [self.lora_resolved])
+
+        self.assertEqual(context["loras"], ["my-lora.safetensors"])
+        self.assertIn("loras_metadata", context)
+        self.assertIsNot(context["loras_metadata"], job.parameters.extra["loras"])
+        self.assertEqual(context["loras_metadata"], job.parameters.extra["loras"])
+        self.assertEqual(context["primary_lora_name"], "my-lora.safetensors")
+        self.assertEqual(context["primary_lora_strength_model"], 0.85)
+        self.assertEqual(context["primary_lora_strength_clip"], 0.85)
+        self.assertEqual(context["misc"], "value")
+        self.assertEqual(context["sampler"], "euler")
+
+        payload = build_workflow_payload(InlineWorkflowLoader(), job, context)
+        lora_inputs = payload["2"]["inputs"]
+        self.assertEqual(lora_inputs["lora_name"], "my-lora.safetensors")
+        self.assertEqual(lora_inputs["strength_model"], 0.85)
+        self.assertEqual(lora_inputs["strength_clip"], 0.85)
+
+    def test_primary_lora_defaults_when_metadata_missing(self) -> None:
+        job = self._build_job()
+
+        context = self.agent._build_parameter_context(job, self.base_resolved, [self.lora_resolved])
+
+        self.assertEqual(context["primary_lora_name"], "my-lora.safetensors")
+        self.assertEqual(context["primary_lora_strength_model"], 1.0)
+        self.assertEqual(context["primary_lora_strength_clip"], 1.0)
+        self.assertNotIn("loras_metadata", context)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep sanitized LoRA filenames in the GPU agent parameter context and expose raw metadata separately
- derive the primary LoRA name and strengths from request extras while ignoring conflicting overrides
- cover the new behaviour with unit tests that confirm workflow bindings receive the sanitized adapter and strengths

## Testing
- python -m unittest discover -s gpuworker/agent/tests -p 'test_*.py'


------
https://chatgpt.com/codex/tasks/task_e_68d31d0da2c483339dcbec67b2bcf9bb