### PR TITLE
Align GPU LoRA staging with manifest primary name

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -988,3 +988,8 @@
 - **General**: Captured every GPU dispatch for troubleshooting with persistent manifests and status timelines.
 - **Technical Changes**: Added structured job logging inside `GPUAgent`, wrote manifest/event helpers with cancellation hooks, introduced regression tests, and refreshed GPU agent documentation plus configuration comments.
 - **Data Changes**: Stores JSON manifests and JSONL event logs under `<outputs>/logs/<jobId>/` on the GPU node.
+
+## 186 – [Fix] Manifest-aligned LoRA staging
+- **General**: Ensured the GPU worker delivers primary LoRA adapters to ComfyUI under the manifest-declared filename so dispatch logs and runtime bindings stay consistent.
+- **Technical Changes**: Sanitized and applied the `primary_lora_name` override while materializing cached LoRAs, updated parameter-context expectations, and refreshed README guidance on the rename flow.
+- **Data Changes**: None; cached files continue to download from the same MinIO objects.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ VisionSuit now speaks to the GPU agent instead of probing ComfyUI directly. Poin
 - VisionSuit now auto-seeds the configured workflow into `GENERATOR_WORKFLOW_BUCKET` before every dispatch, so provide either a
   local template path or inline JSON when rolling out a new graph to avoid 404s on the GPU node.
 - Prompt, sampler, and resolution bindings are pre-wired for the bundled workflow—only override `GENERATOR_WORKFLOW_PARAMETERS` when publishing a custom node layout.
-- The default graph injects a `LoraLoader` between the checkpoint and sampler; VisionSuit maps LoRA selections onto `primary_lora_name`, `primary_lora_strength_model`, and `primary_lora_strength_clip` so the loader node receives the chosen adapter and strength values automatically.
+- The default graph injects a `LoraLoader` between the checkpoint and sampler; VisionSuit maps LoRA selections onto `primary_lora_name`, `primary_lora_strength_model`, and `primary_lora_strength_clip` so the loader node receives the chosen adapter and strength values automatically. The GPU agent renames the staged primary LoRA to the manifest-provided `primary_lora_name` (after sanitizing the path) before submitting the workflow so ComfyUI always receives the expected filename.
 - `GENERATOR_WORKFLOW_PARAMETERS` (JSON array) to map prompt/seed/CFG inputs onto workflow nodes and `GENERATOR_WORKFLOW_OVERRIDES` for fixed node tweaks.
 - `GENERATOR_OUTPUT_BUCKET` and `GENERATOR_OUTPUT_PREFIX` to control where the agent uploads rendered files (supports `{userId}` and `{jobId}` tokens).
 - `GENERATOR_CALLBACK_BASE_URL` so the backend can publish reachable callback URLs for status, completion, and failure updates (defaults to `http://127.0.0.1:4000` when unset).


### PR DESCRIPTION
## Summary
- apply the manifest `primary_lora_name` when staging the first LoRA so ComfyUI receives the expected filename
- adjust the parameter-context unit test and README guidance to reflect the manifest-driven rename
- record the manifest alignment in changelog entry 186

## Testing
- PYTHONPATH=/workspace/VisionSuit pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c5226fcc833382ea89ccb9ebf01f