### PR TITLE
Fix agent scheduler parameter handling

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1037,3 +1037,8 @@
 - **General**: Restored GPU jobs that failed when sampler and scheduler values only lived in the worker defaults.
 - **Technical Changes**: Allowed reserved workflow defaults to populate sampler and scheduler bindings, added coverage for the fallback behaviour, and refreshed the README to explain the configuration path.
 - **Data Changes**: None; runtime validation only.
+
+## 196 – [Fix] GPU agent accepts scheduler from dispatch payload
+- **General**: Prevented the GPU agent from rejecting generator jobs when the scheduler travels inside the main parameter payload instead of the legacy `extra` map.
+- **Technical Changes**: Added explicit `sampler` and `scheduler` fields to the dispatch schema, normalised them before validation, seeded the workflow context with the trimmed values, and refreshed the parameter-context regression tests to cover the direct bindings.
+- **Data Changes**: None.

--- a/gpuworker/agent/app/agent.py
+++ b/gpuworker/agent/app/agent.py
@@ -1101,6 +1101,10 @@ class GPUAgent:
             return ""
         return str(value).strip()
 
+    def _sanitize_optional_text(self, value: Optional[str]) -> Optional[str]:
+        sanitized = self._sanitize_text(value)
+        return sanitized or None
+
     def _coerce_positive_int(self, value: Any) -> Optional[int]:
         candidate = self._as_float(value)
         if candidate is None:
@@ -1181,6 +1185,8 @@ class GPUAgent:
         cfg_scale = self._require_cfg_scale(job.parameters.cfgScale)
         seed = self._normalize_seed_value(job.parameters.seed)
         resolution = self._require_resolution(job.parameters.resolution)
+        sampler = self._sanitize_optional_text(job.parameters.sampler)
+        scheduler = self._sanitize_optional_text(job.parameters.scheduler)
 
         job.parameters.prompt = prompt
         job.parameters.negativePrompt = negative
@@ -1188,6 +1194,8 @@ class GPUAgent:
         job.parameters.cfgScale = cfg_scale
         job.parameters.seed = seed
         job.parameters.resolution = resolution
+        job.parameters.sampler = sampler
+        job.parameters.scheduler = scheduler
 
         context: Dict[str, object] = {
             "prompt": prompt,
@@ -1202,6 +1210,10 @@ class GPUAgent:
             "base_model_full_path": str(base_model.cache_path),
             "loras": [entry.comfy_name for entry in loras],
         }
+        if sampler:
+            context["sampler"] = sampler
+        if scheduler:
+            context["scheduler"] = scheduler
         extra_payload = job.parameters.extra or {}
         lora_metadata = self._extract_lora_metadata(extra_payload)
         if lora_metadata:

--- a/gpuworker/agent/app/models.py
+++ b/gpuworker/agent/app/models.py
@@ -69,6 +69,8 @@ class JobParameters(BaseModel):
     seed: Optional[int] = None
     cfgScale: Optional[float] = None
     steps: Optional[int] = None
+    sampler: Optional[str] = None
+    scheduler: Optional[str] = None
     resolution: Optional[Resolution] = None
     extra: Dict[str, Any] = Field(default_factory=dict)
 

--- a/gpuworker/agent/tests/test_parameter_context.py
+++ b/gpuworker/agent/tests/test_parameter_context.py
@@ -67,14 +67,14 @@ class ParameterContextTests(unittest.TestCase):
         )
 
     def _build_job(self, extra: dict | None = None, loras: list[AssetRef] | None = None) -> DispatchEnvelope:
-        payload_extra = {"sampler": "dpmpp_2m_sde_gpu", "scheduler": "karras"}
-        if extra:
-            payload_extra.update(extra)
+        payload_extra = dict(extra) if extra else {}
         parameters = JobParameters(
             prompt="Test prompt",
             steps=60,
             cfgScale=7.5,
             resolution=Resolution(width=1024, height=1024),
+            sampler="dpmpp_2m_sde_gpu",
+            scheduler="karras",
             extra=payload_extra,
         )
         return DispatchEnvelope(
@@ -151,14 +151,14 @@ class ParameterContextTests(unittest.TestCase):
 
     def test_missing_sampler_raises_validation_failure(self) -> None:
         job = self._build_job()
-        job.parameters.extra.pop("sampler", None)
+        job.parameters.sampler = None
 
         with self.assertRaises(ValidationFailure):
             self.agent._build_parameter_context(job, self.base_resolved, [self.lora_resolved])
 
     def test_missing_scheduler_raises_validation_failure(self) -> None:
         job = self._build_job()
-        job.parameters.extra.pop("scheduler", None)
+        job.parameters.scheduler = None
 
         with self.assertRaises(ValidationFailure):
             self.agent._build_parameter_context(job, self.base_resolved, [self.lora_resolved])
@@ -168,8 +168,8 @@ class ParameterContextTests(unittest.TestCase):
         try:
             self.agent.config.workflow_defaults = {"sampler": "k_euler", "scheduler": "normal"}
             job = self._build_job()
-            job.parameters.extra.pop("sampler", None)
-            job.parameters.extra.pop("scheduler", None)
+            job.parameters.sampler = None
+            job.parameters.scheduler = None
 
             context = self.agent._build_parameter_context(job, self.base_resolved, [self.lora_resolved])
 


### PR DESCRIPTION
## Summary
- add sampler and scheduler fields to the GPU agent dispatch schema
- normalise and apply the incoming sampler and scheduler before validation
- refresh the parameter-context tests to cover the direct bindings and update the changelog

## Testing
- PYTHONPATH=. pytest gpuworker/agent/tests/test_parameter_context.py

------
https://chatgpt.com/codex/tasks/task_e_68d42f8cbc708333a24c6b0a5151cfc8