### PR TITLE
Add installer startup mode selection

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1047,3 +1047,8 @@
 - **General**: Ensured on-site generator jobs feed positive prompts and negatives into their intended SDXL text encoders so ComfyUI receives the right conditioning.
 - **Technical Changes**: Bound both global and local text fields for the positive and negative CLIP nodes in the default workflow parameter map and expanded the GPU agent regression test to verify the mirrored bindings.
 - **Data Changes**: None.
+
+## 198 – [Feature] Installer startup mode selection
+- **Type**: Normal Change
+- **Reason**: Provide administrators with an immediate choice between manual launches and an automatically managed service so deployments match their operational requirements without editing system files later.
+- **Changes**: Added a startup-mode prompt to `install.sh`, provisioned an optional `visionsuit-dev.service` systemd unit with automatic enablement, emitted manual launch guidance when skipping automation, and updated the README with the new workflow.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ During execution the installer:
 4. Provisions MinIO credentials, configures buckets, and launches the `visionsuit-minio` container.
 5. Offers optional execution of `npm run prisma:migrate`, `npm run seed`, and `npm run create-admin` for initial data.
 
+At launch the installer now asks whether VisionSuit should stay in manual mode or be supervised by systemd. Picking the automatic path writes `/etc/systemd/system/visionsuit-dev.service`, wires in the detected host and port values, reloads systemd, and enables the unit immediately so the stack comes online in the background. Opting for manual control skips the unit creation and prints the exact `HOST=<ip> BACKEND_PORT=<port> FRONTEND_PORT=<port> ./dev-start.sh` command to run whenever you want to launch the stack.
+
 Base checkpoints for the On-Site Generator still live in the GPU worker bucket `comfyui-models`. When customizing bucket names, mirror the change inside `backend/.env` with `GENERATOR_BASE_MODEL_BUCKET` and inside `frontend/.env` via `VITE_GENERATOR_BASE_MODEL_BUCKET` so the GPU worker and download proxy continue to line up. After new checkpoints land in the bucket, open **Administration → Generator** and add an entry for each filename so the curated picker exposes only vetted models; the generator now hydrates that list from the corresponding database records automatically. For headless maintenance windows or CI pipelines the helper remains available to pre-seed the catalog explicitly:
 
 Inside the Generator administration view, the segmented **Queue & blocks**, **Failure log**, and **Access & presets** controls keep the maintenance tools organized so you can jump directly to live queue telemetry, error diagnostics, or visibility settings without scrolling.


### PR DESCRIPTION
## Summary
- prompt the install script for manual or automatic VisionSuit startup right after dependency checks
- provision an optional systemd unit when automatic mode is selected and fall back to explicit manual launch guidance otherwise
- document the new workflow in the README and changelog

## Testing
- bash -n install.sh

------
https://chatgpt.com/codex/tasks/task_e_68d698e8849483339cb4431b08381e6f