### PR TITLE
feat: auto install node during setup

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -158,6 +158,11 @@
 - **Technical Changes**: Made metadata fields optional in types, guarded lightbox and card rendering with optional chaining, and documented the resilience improvement.
 - **Data Changes**: None.
 
+## 033 – [Fix] Automated Node.js provisioning (commit TBD)
+- **Type**: Normal Change
+- **Reason**: The installer aborted on fresh systems without Node.js even though the setup flow is expected to prepare every prerequisite automatically.
+- **Changes**: Added an `ensure_node_and_npm` helper that provisions Node.js 18 LTS via NodeSource on Debian/Ubuntu or Homebrew on macOS, updated the README prerequisites, and confirmed npm availability before continuing.
+
 ## 033 – [Addition] Adult prompt keyword safety
 - **General**: Introduced configurable prompt keywords so adult detection inspects metadata instead of relying on user-assigned tags.
 - **Technical Changes**: Added the `AdultSafetyKeyword` Prisma model and migration, exposed keyword CRUD endpoints with updated backend detection logic, refreshed the admin safety panel UI plus API client and styles for keyword management, and documented the workflow in the README.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For real-time assistance, join the [VisionSuit Support Discord](https://discord.
 
 Ensure the following tools are available on the target host:
 
-- Node.js 22 LTS (includes npm)
+- Node.js 22 LTS (includes npm). The installer offers to provision Node.js 18 LTS automatically when it detects `apt-get` or Homebrew.
 - Python 3 (utility scripts used by the installer)
 - Docker Engine with a running daemon
 - Docker Compose plugin or the legacy `docker-compose` binary


### PR DESCRIPTION
## Summary
- add an installation helper that provisions Node.js and npm via NodeSource or Homebrew when missing
- update the README prerequisites to reflect automatic Node.js setup support
- log the installer enhancement in the changelog

## Testing
- bash -n install.sh

------
https://chatgpt.com/codex/tasks/task_e_68d69bceaac883338eb7897c647c0395