### PR TITLE
Fix NodeSource keyring handling in installer

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1057,3 +1057,8 @@
 - **Type**: Normal Change
 - **Reason**: Provide administrators with an immediate choice between manual launches and an automatically managed service so deployments match their operational requirements without editing system files later.
 - **Changes**: Added a startup-mode prompt to `install.sh`, provisioned an optional `visionsuit-dev.service` systemd unit with automatic enablement, emitted manual launch guidance when skipping automation, and updated the README with the new workflow.
+
+## 199 – [Fix] NodeSource keyring provisioning
+- **Type**: Normal Change
+- **Reason**: The installer failed to add the NodeSource repository on fresh systems because the ASCII-armored signing key was written without converting it into the keyring format that `apt` expects.
+- **Changes**: Updated `install.sh` to dearmor the NodeSource GPG key, ensure the keyring directory exists with the right permissions, and use optional `sudo` wrappers when writing the key and repository list.

--- a/install.sh
+++ b/install.sh
@@ -551,9 +551,21 @@ ensure_node_and_npm() {
     info "Installing Node.js 18 LTS via NodeSource"
     $sudo_cmd apt-get update
     $sudo_cmd apt-get install -y ca-certificates curl gnupg
-    $sudo_cmd mkdir -p /etc/apt/keyrings
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | $sudo_cmd tee /etc/apt/keyrings/nodesource.gpg >/dev/null
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | $sudo_cmd tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+    if [ -n "$sudo_cmd" ]; then
+      $sudo_cmd mkdir -p /etc/apt/keyrings
+    else
+      mkdir -p /etc/apt/keyrings
+    fi
+
+    if [ -n "$sudo_cmd" ]; then
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor | $sudo_cmd tee /etc/apt/keyrings/nodesource.gpg >/dev/null
+      $sudo_cmd chmod a+r /etc/apt/keyrings/nodesource.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | $sudo_cmd tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+    else
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor > /etc/apt/keyrings/nodesource.gpg
+      chmod a+r /etc/apt/keyrings/nodesource.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+    fi
     $sudo_cmd apt-get update
     $sudo_cmd apt-get install -y nodejs
   elif [ "$installer" = "brew" ]; then


### PR DESCRIPTION
## Summary
- convert the NodeSource provisioning in `install.sh` to dearmor the GPG key and set keyring permissions before adding the repository
- document the installer fix in the changelog with type, reason, and change details

## Testing
- not run (installer change only)


------
https://chatgpt.com/codex/tasks/task_e_68d69d8ff3bc8333b1f8ab98cb23d231