### PR TITLE
Verify Windows bulk importer creates model before batching images

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1072,3 +1072,13 @@
 - **Type**: Normal Change
 - **Reason**: The installer failed to add the NodeSource repository on fresh systems because the ASCII-armored signing key was written without converting it into the keyring format that `apt` expects.
 - **Changes**: Updated `install.sh` to dearmor the NodeSource GPG key, ensure the keyring directory exists with the right permissions, and use optional `sudo` wrappers when writing the key and repository list.
+
+## 200 – [Fix] Linux bulk importer response verification
+- **Change Type**: Normal Change
+- **Reason**: The Linux/macOS bulk uploader reported success even when the API skipped creating the model, leaving galleries populated with renders but no matching LoRA asset in VisionSuit.
+- **Changes**: Added asset-slug validation to `scripts/bulk_import_linux.sh` so the run aborts when the API response lacks the expected identifiers, and refreshed the README reliability note to document the cross-platform verification step.
+
+## 201 – [Fix] Windows bulk importer asset verification
+- **Change Type**: Normal Change
+- **Reason**: The Windows bulk uploader could continue batching gallery images before the API exposed the new model, leading to collections with renders but no matching LoRA asset in VisionSuit.
+- **Changes**: Updated `scripts/bulk_import_windows.ps1` to verify the model is visible via the VisionSuit API before scheduling additional image batches and adjusted the README reliability note to highlight the Windows workflow safeguard.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The PowerShell helper mirrors the Linux workflow: it authenticates, verifies adm
 
 > Tip: If `ImagesDirectory` is missing or omitted, the script now searches for preview folders that live next to each `.safetensors` file (for example `./loras/model-name.safetensors` with a sibling `./loras/model-name/`).
 
-> Reliability check: After each upload the Windows helper now queries VisionSuit for the created model and gallery entries. If the API cannot confirm the asset slug or the expected image IDs, the script aborts the run instead of silently continuing.
+> Reliability check: Both helpers validate the VisionSuit response before continuing. The Linux/macOS script requires the API to return an asset slug and gallery slug before it uploads follow-up renders, while the Windows helper now confirms the model appears in VisionSuit before it queues extra image batches and double-checks the gallery contents afterward. If either script cannot confirm the expected identifiers it aborts the run instead of silently continuing.
 
 #### Metadata overrides and defaults
 

--- a/scripts/bulk_import_windows.ps1
+++ b/scripts/bulk_import_windows.ps1
@@ -786,12 +786,12 @@ Get-ChildItem -Path $lorasRoot -Filter *.safetensors -File | ForEach-Object {
     }
   }
 
-  if ($otherImages.Count -eq 0) {
-    if (-not (Test-ModelAssetPresence -HttpClient $httpClient -ApiBase $apiBase -AssetSlug $assetSlug -Title $profile.Title)) {
-      $skipCount++
-      return
-    }
+  if (-not (Test-ModelAssetPresence -HttpClient $httpClient -ApiBase $apiBase -AssetSlug $assetSlug -Title $profile.Title)) {
+    $skipCount++
+    return
+  }
 
+  if ($otherImages.Count -eq 0) {
     $galleryCheck = Test-GalleryPresence -HttpClient $httpClient -ApiBase $apiBase -GallerySlug $gallerySlug -AssetSlug $assetSlug -ExpectedImageIds @() -Title $profile.Title
     if (-not $galleryCheck.Success) {
       $skipCount++


### PR DESCRIPTION
## Summary
- require the Windows PowerShell bulk importer to confirm the VisionSuit API lists the new model before batching additional gallery uploads
- refresh the README reliability note to explain the Windows-side safeguard
- add a changelog entry covering the Windows importer verification change

## Testing
- not run (script and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d6aebbf510833393fd6fb62c436a4b