### PR TITLE
Disable caching for authenticated API responses

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1082,3 +1082,13 @@
 - **Change Type**: Normal Change
 - **Reason**: The Windows bulk uploader could continue batching gallery images before the API exposed the new model, leading to collections with renders but no matching LoRA asset in VisionSuit.
 - **Changes**: Updated `scripts/bulk_import_windows.ps1` to verify the model is visible via the VisionSuit API before scheduling additional image batches and adjusted the README reliability note to highlight the Windows workflow safeguard.
+
+## 202 – [Fix] Windows bulk importer visibility wait extension
+- **Type**: Normal Change
+- **Reason**: The Windows bulk uploader still aborted for successful imports because the API sometimes needs more than 30 seconds to surface a freshly created model, causing the verification loop to fail.
+- **Changes**: Increased the verification retry budget in `scripts/bulk_import_windows.ps1` to ten attempts with capped exponential backoff (roughly 90 seconds) and refreshed the README reliability note to document the longer wait window.
+
+## 203 – [Fix] Authenticated asset queries bypass HTTP caches
+- **Type**: Normal Change
+- **Reason**: Windows bulk imports continued to fail on fresh installations because cached `GET /api/assets/models` responses returned HTTP 304 without the new model payload, preventing the verification loop from ever seeing the uploaded asset.
+- **Changes**: Disabled Express ETags and applied no-store cache headers to all `/api` responses so authenticated clients always receive fresh payloads, and extended the README reliability note to explain the cache-busting behaviour.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The PowerShell helper mirrors the Linux workflow: it authenticates, verifies adm
 
 > Tip: If `ImagesDirectory` is missing or omitted, the script now searches for preview folders that live next to each `.safetensors` file (for example `./loras/model-name.safetensors` with a sibling `./loras/model-name/`).
 
-> Reliability check: Both helpers validate the VisionSuit response before continuing. The Linux/macOS script requires the API to return an asset slug and gallery slug before it uploads follow-up renders, while the Windows helper now confirms the model appears in VisionSuit before it queues extra image batches and double-checks the gallery contents afterward. If either script cannot confirm the expected identifiers it aborts the run instead of silently continuing.
+> Reliability check: Both helpers validate the VisionSuit response before continuing. The Linux/macOS script requires the API to return an asset slug and gallery slug before it uploads follow-up renders, while the Windows helper now keeps polling for up to a minute and a half to confirm the model appears in VisionSuit before it queues extra image batches and double-checks the gallery contents afterward. The API disables HTTP caching for authenticated `/api` traffic so freshly uploaded assets surface immediately even on clean servers; if either script cannot confirm the expected identifiers it aborts the run instead of silently continuing.
 
 #### Metadata overrides and defaults
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,8 @@ import { router } from './routes';
 export const createApp = () => {
   const app = express();
 
+  app.disable('etag');
+
   app.use(cors());
   app.use(express.json({ limit: '10mb' }));
   app.use(express.urlencoded({ extended: true }));
@@ -22,6 +24,13 @@ export const createApp = () => {
       timestamp: new Date().toISOString(),
       environment: appConfig.env,
     });
+  });
+
+  app.use('/api', (_req, res, next) => {
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Expires', '0');
+    next();
   });
 
   app.use('/api', attachOptionalUser);

--- a/scripts/bulk_import_windows.ps1
+++ b/scripts/bulk_import_windows.ps1
@@ -317,7 +317,7 @@ function Test-ModelAssetPresence {
   }
 
   $endpoint = "$ApiBase/assets/models"
-  $maxAttempts = 5
+  $maxAttempts = 10
   $delaySeconds = 2
 
   for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
@@ -332,7 +332,7 @@ function Test-ModelAssetPresence {
       }
 
       Start-Sleep -Seconds $delaySeconds
-      $delaySeconds = [Math]::Min($delaySeconds * 2, 10)
+      $delaySeconds = [Math]::Min($delaySeconds * 2, 12)
       continue
     }
 
@@ -343,7 +343,7 @@ function Test-ModelAssetPresence {
       }
 
       Start-Sleep -Seconds $delaySeconds
-      $delaySeconds = [Math]::Min($delaySeconds * 2, 10)
+      $delaySeconds = [Math]::Min($delaySeconds * 2, 12)
       continue
     }
 
@@ -375,7 +375,7 @@ function Test-ModelAssetPresence {
     if ($attempt -lt $maxAttempts) {
       Write-Log "Model '$Title' with slug '$AssetSlug' not visible yet (attempt $attempt/$maxAttempts); retrying in $delaySeconds second(s)."
       Start-Sleep -Seconds $delaySeconds
-      $delaySeconds = [Math]::Min($delaySeconds * 2, 10)
+      $delaySeconds = [Math]::Min($delaySeconds * 2, 12)
     }
     else {
       Write-Log "Model '$Title' with slug '$AssetSlug' was not found in VisionSuit after $maxAttempts verification attempts."
@@ -407,7 +407,7 @@ function Test-GalleryPresence {
   }
 
   $endpoint = "$ApiBase/galleries"
-  $maxAttempts = 5
+  $maxAttempts = 10
   $delaySeconds = 2
 
   for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
@@ -422,7 +422,7 @@ function Test-GalleryPresence {
       }
 
       Start-Sleep -Seconds $delaySeconds
-      $delaySeconds = [Math]::Min($delaySeconds * 2, 10)
+      $delaySeconds = [Math]::Min($delaySeconds * 2, 12)
       continue
     }
 
@@ -433,7 +433,7 @@ function Test-GalleryPresence {
       }
 
       Start-Sleep -Seconds $delaySeconds
-      $delaySeconds = [Math]::Min($delaySeconds * 2, 10)
+      $delaySeconds = [Math]::Min($delaySeconds * 2, 12)
       continue
     }
 
@@ -461,7 +461,7 @@ function Test-GalleryPresence {
       if ($attempt -lt $maxAttempts) {
         Write-Log "Gallery '$GallerySlug' for '$Title' not visible yet (attempt $attempt/$maxAttempts); retrying in $delaySeconds second(s)."
         Start-Sleep -Seconds $delaySeconds
-        $delaySeconds = [Math]::Min($delaySeconds * 2, 10)
+        $delaySeconds = [Math]::Min($delaySeconds * 2, 12)
         continue
       }
 
@@ -489,7 +489,7 @@ function Test-GalleryPresence {
       if ($attempt -lt $maxAttempts) {
         Write-Log "Gallery '$GallerySlug' does not list model slug '$AssetSlug' yet (attempt $attempt/$maxAttempts); retrying in $delaySeconds second(s)."
         Start-Sleep -Seconds $delaySeconds
-        $delaySeconds = [Math]::Min($delaySeconds * 2, 10)
+        $delaySeconds = [Math]::Min($delaySeconds * 2, 12)
         continue
       }
 
@@ -520,7 +520,7 @@ function Test-GalleryPresence {
         if ($attempt -lt $maxAttempts) {
           Write-Log "Gallery '$GallerySlug' is missing $($expected.Count - $expectedMatches) of $($expected.Count) uploaded image(s) (attempt $attempt/$maxAttempts); retrying in $delaySeconds second(s)."
           Start-Sleep -Seconds $delaySeconds
-          $delaySeconds = [Math]::Min($delaySeconds * 2, 10)
+          $delaySeconds = [Math]::Min($delaySeconds * 2, 12)
           continue
         }
 


### PR DESCRIPTION
## Summary
- disable Express ETags and force no-store cache headers on all /api responses so authenticated clients always see fresh model lists
- note the anti-caching behaviour in the bulk importer reliability guidance and document the change in the changelog

## Testing
- npm --prefix backend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b6be7914833383a8ffbe35e32a09