### PR TITLE
Align adult asset filtering across explorers

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1097,3 +1097,8 @@
 - **Type**: Normal Change
 - **Reason**: Newly uploaded models stored successfully in MinIO and the database, but VisionSuit could not display or download them because the storage proxy route rejected object IDs that still contained slash characters.
 - **Changes**: Updated `buildStorageProxyUrl` in `frontend/src/lib/storage.ts` to URL-encode the full object identifier before constructing the proxy path so requests hit `/api/storage/:bucket/:objectId` with the expected payload, restoring preview and download access for fresh models.
+
+## 205 – [Fix] Adult asset visibility alignment
+- **Type**: Normal Change
+- **Reason**: Adult-rated models and renders appeared in curator profiles but disappeared from the explorers because the backend asset feeds and client-side filters hid them whenever the viewer's safe-mode toggle was off, even for the uploading curator or a logged-in administrator.
+- **Changes**: Allowed administrators and asset owners to bypass the adult-content filter in `/api/assets/models` and `/api/assets/images`, mirrored the same ownership-aware logic in `frontend/src/App.tsx`, and kept the existing restrictions for guests and non-owner viewers with safe mode enabled.

--- a/backend/src/routes/assets.ts
+++ b/backend/src/routes/assets.ts
@@ -516,7 +516,7 @@ assetsRouter.get('/models', async (req, res, next) => {
   try {
     const viewer = req.user;
     const isAdmin = viewer?.role === 'ADMIN';
-    const allowAdultContent = viewer?.showAdultContent ?? false;
+    const allowAdultContent = isAdmin ? true : viewer?.showAdultContent ?? false;
     const visibilityFilter: Prisma.ModelAssetWhereInput = isAdmin
       ? {}
       : viewer
@@ -550,7 +550,13 @@ assetsRouter.get('/models', async (req, res, next) => {
     }
 
     if (!allowAdultContent) {
-      filters.push({ isAdult: false });
+      if (viewer) {
+        filters.push({
+          OR: [{ isAdult: false }, { ownerId: viewer.id }],
+        });
+      } else {
+        filters.push({ isAdult: false });
+      }
     }
 
     let where: Prisma.ModelAssetWhereInput = {};
@@ -581,7 +587,7 @@ assetsRouter.get('/images', async (req, res, next) => {
   try {
     const viewer = req.user;
     const isAdmin = viewer?.role === 'ADMIN';
-    const allowAdultContent = viewer?.showAdultContent ?? false;
+    const allowAdultContent = isAdmin ? true : viewer?.showAdultContent ?? false;
     const visibilityFilter: Prisma.ImageAssetWhereInput = isAdmin
       ? {}
       : viewer
@@ -615,7 +621,13 @@ assetsRouter.get('/images', async (req, res, next) => {
     }
 
     if (!allowAdultContent) {
-      filters.push({ isAdult: false });
+      if (viewer) {
+        filters.push({
+          OR: [{ isAdult: false }, { ownerId: viewer.id }],
+        });
+      } else {
+        filters.push({ isAdult: false });
+      }
     }
 
     let where: Prisma.ImageAssetWhereInput = {};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,8 +84,23 @@ const serviceBadgeLabels: Record<ServiceStatusKey, string> = {
 };
 
 const filterModelAssetsForViewer = (assets: ModelAsset[], viewer?: User | null) => {
-  const allowAdult = viewer?.showAdultContent ?? false;
-  const filteredByAdult = assets.filter((asset) => allowAdult || !asset.isAdult);
+  const isAdmin = viewer?.role === 'ADMIN';
+  const allowAdult = isAdmin ? true : viewer?.showAdultContent ?? false;
+  const filteredByAdult = assets.filter((asset) => {
+    if (!asset.isAdult) {
+      return true;
+    }
+
+    if (allowAdult) {
+      return true;
+    }
+
+    if (viewer && asset.owner.id === viewer.id) {
+      return true;
+    }
+
+    return false;
+  });
 
   if (!viewer) {
     return filteredByAdult.filter((asset) => asset.moderationStatus !== 'REMOVED');
@@ -109,8 +124,23 @@ const filterModelAssetsForViewer = (assets: ModelAsset[], viewer?: User | null) 
 };
 
 const filterImageAssetsForViewer = (images: ImageAsset[], viewer?: User | null) => {
-  const allowAdult = viewer?.showAdultContent ?? false;
-  const filteredByAdult = images.filter((image) => allowAdult || !image.isAdult);
+  const isAdmin = viewer?.role === 'ADMIN';
+  const allowAdult = isAdmin ? true : viewer?.showAdultContent ?? false;
+  const filteredByAdult = images.filter((image) => {
+    if (!image.isAdult) {
+      return true;
+    }
+
+    if (allowAdult) {
+      return true;
+    }
+
+    if (viewer && image.owner.id === viewer.id) {
+      return true;
+    }
+
+    return false;
+  });
 
   if (!viewer) {
     return filteredByAdult.filter((image) => image.moderationStatus !== 'REMOVED');


### PR DESCRIPTION
## Summary
- ensure adult asset queries stay available to administrators and owners by widening the backend filters
- mirror the ownership-aware safe-mode logic on the React explorers so profile navigation surfaces adult uploads consistently
- document the visibility correction in the changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c22d1c748333ae3312d054967e1e