### PR TITLE
Fix Windows bulk importer metadata candidate evaluation

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1117,3 +1117,8 @@
 - **Type**: Normal Change
 - **Reason**: The Windows bulk uploader aborted before authenticating when `ServerBaseUrl` already ended in `/api`, doubling the VisionSuit routes during the `/api/meta/status` probe and returning HTTP 404 even though the server was healthy.
 - **Changes**: Taught `ConvertTo-AbsoluteUri` in `scripts/bulk_import_windows.ps1` to deduplicate overlapping path segments and adjusted the README so administrators know they can paste either the site root or API endpoint without tripping the health check.
+## 034 – [Fix] Windows bulk import metadata lookup
+- **Change Type**: Normal Change
+- **Reason**: Windows bulk imports failed immediately after authentication because the script passed multiple `-Path` parameters while collecting metadata candidates.
+- **Details**: Updated the candidate metadata collection to evaluate each `Join-Path` call individually so only a single `-Path` parameter is supplied per invocation.
+

--- a/scripts/bulk_import_windows.ps1
+++ b/scripts/bulk_import_windows.ps1
@@ -522,9 +522,9 @@ try {
     $otherImages = $images | Where-Object { $_.FullName -ne $preview.FullName }
 
     $candidateMetadata = @(
-      Join-Path -Path $lora.DirectoryName -ChildPath "$baseName.json",
-      Join-Path -Path $lorasRoot -ChildPath "$baseName.json",
-      Join-Path -Path $imageFolder -ChildPath 'metadata.json'
+      (Join-Path -Path $lora.DirectoryName -ChildPath "$baseName.json")
+      (Join-Path -Path $lorasRoot -ChildPath "$baseName.json")
+      (Join-Path -Path $imageFolder -ChildPath 'metadata.json')
     ) | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }
     $metadataPath = $null
     foreach ($candidate in $candidateMetadata) {


### PR DESCRIPTION
## Summary
- ensure the Windows bulk importer builds metadata candidate paths with separate Join-Path invocations so PowerShell no longer binds `-Path` twice
- document the change in the changelog

## Testing
- not run (PowerShell tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6db87f80483339ad9536623562f44