### PR TITLE
Ensure owners can always view uploads and add storage reindexer

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1127,3 +1127,8 @@
 - **Reason**: Windows bulk imports failed immediately after authentication because the script passed multiple `-Path` parameters while collecting metadata candidates.
 - **Details**: Updated the candidate metadata collection to evaluate each `Join-Path` call individually so only a single `-Path` parameter is supplied per invocation.
 
+## 208 – [Enhancement] Owner visibility and storage reindexer
+- **Type**: Normal Change
+- **Reason**: Curators could lose track of private or moderated uploads because viewer-facing filters hid their own assets, and administrators needed a recovery tool to reconcile database metadata with MinIO after manual storage edits.
+- **Changes**: Relaxed gallery, asset feed, and profile queries so authenticated owners always see every model, image, and gallery entry they uploaded regardless of moderation status, visibility, or safe-mode settings. Added `backend/scripts/reindexStorage.ts` together with the `npm run storage:reindex` helper to rescan MinIO, recreate missing `StorageObject` rows, and refresh file metadata.
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 - Curators can edit and delete their own models, collections, and images directly from the explorers (each destructive action ships with a “Nicht umkehrbar ist wenn gelöscht wird. weg ist weg.” warning), while administrators continue to see controls for every entry.
 - Manual collection linking lets curators attach their own galleries to models from the detail view, while administrators can pair any collection when moderation requires intervention.
 - Administrators can toggle the On-Site Generator between an **Admin only** preview phase and a **Members & curators** rollout from the Administration → Generator tab, curate the exact database-backed base-model list consumed by the wizard without touching storage manifests, and monitor or cancel running jobs from the active queue when renders stall.
-- Private uploads remain hidden from other curators; the administration workspace now surfaces every model, gallery, and image for admins by default, and the token-aware storage proxy streams private previews directly in the browser for moderation. The **Audit** toggle on curator profiles remains available for targeted spot checks.
+- Private uploads remain hidden from other curators; the administration workspace now surfaces every model, gallery, and image for admins by default, and the token-aware storage proxy streams private previews directly in the browser for moderation. Creators always see their complete upload history regardless of moderation status, visibility, or safe-mode toggles so personal galleries never look incomplete. The **Audit** toggle on curator profiles remains available for targeted spot checks.
 - Signed-in users can open the **Account settings** dialog from the sidebar to adjust profile details or rotate their password in a single modal workflow.
 - Administration workspace now presents models and images in lightweight thumbnail grids with one-click detail pages, inline visibility toggles, ranking controls (weights, tiers, and user resets), persistent bulk tools tuned for six-figure libraries, multi-step onboarding with permission previews, dialog-driven actions to edit assets, upload or rename model versions, remove secondary revisions, **and a dedicated Moderation tab** that lists every flagged asset for approve/remove workflows. Model and image edit dialogs now ship with tabbed flows (details, prompting, metadata, ownership) plus right-rail summaries for instant context, and ranking inputs immediately cache typed values so the tab stays responsive while backend refreshes complete. Image archive filters add a dedicated model picker with type-ahead suggestions sourced from stored metadata so curators can audit renders tied to specific checkpoints in seconds.
 - Flagged models and renders are hidden from members and curators; creators get a lightweight “In Audit” placeholder while administrators continue to see clear previews and can approve or remove them while leaving the required audit note that will power the upcoming notification center.
@@ -278,6 +278,17 @@ Use `scripts/migrate_mylora_to_visionsuit.py` to pull an existing MyLora library
 - Optional `--visibility public` publishes the migrated models instantly; omit it to stage imports as private drafts.
 
 The script logs into MyLora, walks the grid API in batches, downloads each safetensor and its preview images, then creates matching VisionSuit model entries with categories and tags preserved as labels. Existing VisionSuit models are skipped automatically to avoid duplicates when a run is interrupted or repeated.
+
+### Storage reindexer
+
+Run the storage reindexer whenever MinIO and the database fall out of sync (for example after restoring buckets or importing files by hand):
+
+```bash
+cd backend
+npm run storage:reindex
+```
+
+The helper scans every model, model version, gallery cover, image, and curator avatar reference, verifies that the corresponding MinIO object exists, and creates or refreshes matching `StorageObject` entries with the latest size and content-type metadata. Missing objects are reported with the source reference so you can replace or relink files quickly.
 
 ### Backend service
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "prisma:studio": "prisma studio",
     "seed": "ts-node --transpile-only prisma/seed.ts",
     "create-admin": "ts-node --transpile-only scripts/createAdmin.ts",
-    "generator:sync-base-models": "ts-node --transpile-only scripts/syncGeneratorBaseModels.ts"
+    "generator:sync-base-models": "ts-node --transpile-only scripts/syncGeneratorBaseModels.ts",
+    "storage:reindex": "ts-node --transpile-only scripts/reindexStorage.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.16.2",

--- a/backend/scripts/reindexStorage.ts
+++ b/backend/scripts/reindexStorage.ts
@@ -1,0 +1,262 @@
+import { prisma } from '../src/lib/prisma';
+import { resolveStorageLocation, storageClient } from '../src/lib/storage';
+
+const extractMetaValue = (meta: Record<string, string> | undefined, keys: string[]) => {
+  if (!meta) {
+    return null;
+  }
+
+  for (const key of keys) {
+    const value = meta[key];
+    if (value && value.length > 0) {
+      return value;
+    }
+
+    const lowerKey = key.toLowerCase();
+    const normalized = Object.keys(meta).find((entry) => entry.toLowerCase() === lowerKey);
+    if (normalized) {
+      const resolved = meta[normalized];
+      if (resolved && resolved.length > 0) {
+        return resolved;
+      }
+    }
+  }
+
+  return null;
+};
+
+type ReferenceDetail = {
+  sourceType: string;
+  sourceId: string;
+  field: string;
+  rawValue: string;
+};
+
+type StorageReference = {
+  bucket: string;
+  objectName: string;
+  details: ReferenceDetail[];
+};
+
+const references = new Map<string, StorageReference>();
+
+const registerReference = (detail: ReferenceDetail) => {
+  const resolved = resolveStorageLocation(detail.rawValue);
+  if (!resolved.bucket || !resolved.objectName) {
+    return;
+  }
+
+  const key = `${resolved.bucket}/${resolved.objectName}`;
+  const existing = references.get(key);
+
+  if (existing) {
+    existing.details.push(detail);
+    return;
+  }
+
+  references.set(key, {
+    bucket: resolved.bucket,
+    objectName: resolved.objectName,
+    details: [detail],
+  });
+};
+
+const collectReferences = async () => {
+  const [models, images, galleries, users] = await Promise.all([
+    prisma.modelAsset.findMany({
+      select: {
+        id: true,
+        storagePath: true,
+        previewImage: true,
+        versions: {
+          select: {
+            id: true,
+            storagePath: true,
+            previewImage: true,
+          },
+        },
+      },
+    }),
+    prisma.imageAsset.findMany({
+      select: {
+        id: true,
+        storagePath: true,
+      },
+    }),
+    prisma.gallery.findMany({
+      select: {
+        id: true,
+        coverImage: true,
+      },
+    }),
+    prisma.user.findMany({
+      select: {
+        id: true,
+        avatarUrl: true,
+      },
+    }),
+  ]);
+
+  for (const model of models) {
+    if (model.storagePath) {
+      registerReference({
+        sourceType: 'model',
+        sourceId: model.id,
+        field: 'storagePath',
+        rawValue: model.storagePath,
+      });
+    }
+    if (model.previewImage) {
+      registerReference({
+        sourceType: 'model',
+        sourceId: model.id,
+        field: 'previewImage',
+        rawValue: model.previewImage,
+      });
+    }
+
+    for (const version of model.versions) {
+      if (version.storagePath) {
+        registerReference({
+          sourceType: 'modelVersion',
+          sourceId: version.id,
+          field: 'storagePath',
+          rawValue: version.storagePath,
+        });
+      }
+      if (version.previewImage) {
+        registerReference({
+          sourceType: 'modelVersion',
+          sourceId: version.id,
+          field: 'previewImage',
+          rawValue: version.previewImage,
+        });
+      }
+    }
+  }
+
+  for (const image of images) {
+    if (image.storagePath) {
+      registerReference({
+        sourceType: 'image',
+        sourceId: image.id,
+        field: 'storagePath',
+        rawValue: image.storagePath,
+      });
+    }
+  }
+
+  for (const gallery of galleries) {
+    if (gallery.coverImage) {
+      registerReference({
+        sourceType: 'gallery',
+        sourceId: gallery.id,
+        field: 'coverImage',
+        rawValue: gallery.coverImage,
+      });
+    }
+  }
+
+  for (const user of users) {
+    if (user.avatarUrl) {
+      registerReference({
+        sourceType: 'user',
+        sourceId: user.id,
+        field: 'avatarUrl',
+        rawValue: user.avatarUrl,
+      });
+    }
+  }
+};
+
+const syncStorageObject = async (reference: StorageReference) => {
+  const detail = reference.details[0];
+  try {
+    const stat = await storageClient.statObject(reference.bucket, reference.objectName);
+    const size = BigInt(stat.size);
+    const contentType = extractMetaValue(stat.metaData, ['content-type', 'Content-Type']);
+    const originalName =
+      extractMetaValue(stat.metaData, ['original-name', 'x-amz-meta-original-name', 'filename']) ?? null;
+
+    const existing = await prisma.storageObject.findUnique({ where: { id: reference.objectName } });
+
+    if (!existing) {
+      await prisma.storageObject.create({
+        data: {
+          id: reference.objectName,
+          bucket: reference.bucket,
+          objectName: reference.objectName,
+          size,
+          contentType: contentType ?? null,
+          originalName,
+        },
+      });
+      return 'created' as const;
+    }
+
+    const normalizedOriginalName = originalName ?? existing.originalName ?? null;
+    const normalizedContentType = contentType ?? existing.contentType ?? null;
+    const needsUpdate =
+      existing.bucket !== reference.bucket ||
+      existing.objectName !== reference.objectName ||
+      (existing.size ? existing.size.toString() : null) !== size.toString() ||
+      existing.contentType !== normalizedContentType ||
+      existing.originalName !== normalizedOriginalName;
+
+    if (!needsUpdate) {
+      return 'skipped' as const;
+    }
+
+    await prisma.storageObject.update({
+      where: { id: existing.id },
+      data: {
+        bucket: reference.bucket,
+        objectName: reference.objectName,
+        size,
+        contentType: normalizedContentType,
+        originalName: normalizedOriginalName,
+      },
+    });
+    return 'updated' as const;
+  } catch (error) {
+    console.error(
+      `Missing object ${reference.bucket}/${reference.objectName} (referenced by ${detail.sourceType} ${detail.sourceId} ${detail.field}): ${(error as Error).message}`,
+    );
+    return 'missing' as const;
+  }
+};
+
+const main = async () => {
+  await collectReferences();
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+  let missing = 0;
+
+  for (const reference of references.values()) {
+    const result = await syncStorageObject(reference);
+    if (result === 'created') {
+      created += 1;
+    } else if (result === 'updated') {
+      updated += 1;
+    } else if (result === 'skipped') {
+      skipped += 1;
+    } else {
+      missing += 1;
+    }
+  }
+
+  console.log(
+    `Reindex complete. Processed ${references.size} storage references (created: ${created}, updated: ${updated}, unchanged: ${skipped}, missing: ${missing}).`,
+  );
+};
+
+main()
+  .catch((error) => {
+    console.error('Reindex failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/lib/mappers/gallery.ts
+++ b/backend/src/lib/mappers/gallery.ts
@@ -187,7 +187,12 @@ export const mapGallery = (
     isUnderModeration: hasFlaggedEntry,
     entries: gallery.entries
       .filter((entry) => {
+        const ownsAsset = entry.asset ? entry.asset.ownerId === viewerId : false;
+        const ownsImage = entry.image ? entry.image.ownerId === viewerId : false;
+        const viewerOwnsEntry = ownsAsset || ownsImage;
+
         const adultAllowed =
+          viewerOwnsEntry ||
           allowAdultContent ||
           ((entry.asset ? !entry.asset.isAdult : true) && (entry.image ? !entry.image.isAdult : true));
 
@@ -200,14 +205,14 @@ export const mapGallery = (
         }
 
         const assetVisible = entry.asset
-          ? entry.asset.moderationStatus !== ModerationStatus.REMOVED &&
-            (!entry.asset.isAdult || allowAdultContent) &&
-            (entry.asset.moderationStatus !== ModerationStatus.FLAGGED || isAdmin || entry.asset.ownerId === viewerId)
+          ? (ownsAsset || entry.asset.moderationStatus !== ModerationStatus.REMOVED) &&
+            (!entry.asset.isAdult || allowAdultContent || ownsAsset) &&
+            (entry.asset.moderationStatus !== ModerationStatus.FLAGGED || isAdmin || ownsAsset)
           : false;
         const imageVisible = entry.image
-          ? entry.image.moderationStatus !== ModerationStatus.REMOVED &&
-            (!entry.image.isAdult || allowAdultContent) &&
-            (entry.image.moderationStatus !== ModerationStatus.FLAGGED || isAdmin || entry.image.ownerId === viewerId)
+          ? (ownsImage || entry.image.moderationStatus !== ModerationStatus.REMOVED) &&
+            (!entry.image.isAdult || allowAdultContent || ownsImage) &&
+            (entry.image.moderationStatus !== ModerationStatus.FLAGGED || isAdmin || ownsImage)
           : false;
 
         const canViewAsset = assetVisible
@@ -217,20 +222,22 @@ export const mapGallery = (
           ? canViewResource(viewer, entry.image!.ownerId, entry.image!.isPublic, options)
           : false;
 
-        return canViewAsset || canViewImage;
+        return canViewAsset || canViewImage || viewerOwnsEntry;
       })
       .map((entry) => {
         const modelStorage = entry.asset ? resolveStorageLocation(entry.asset.storagePath) : null;
         const modelPreview = entry.asset ? resolveStorageLocation(entry.asset.previewImage) : null;
+        const ownsAsset = entry.asset ? entry.asset.ownerId === viewerId : false;
+        const ownsImage = entry.image ? entry.image.ownerId === viewerId : false;
         const assetVisible = entry.asset
-          ? entry.asset.moderationStatus !== ModerationStatus.REMOVED &&
-            (!entry.asset.isAdult || allowAdultContent) &&
-            (entry.asset.moderationStatus !== ModerationStatus.FLAGGED || isAdmin || entry.asset.ownerId === viewerId)
+          ? (ownsAsset || entry.asset.moderationStatus !== ModerationStatus.REMOVED) &&
+            (!entry.asset.isAdult || allowAdultContent || ownsAsset) &&
+            (entry.asset.moderationStatus !== ModerationStatus.FLAGGED || isAdmin || ownsAsset)
           : false;
         const imageVisible = entry.image
-          ? entry.image.moderationStatus !== ModerationStatus.REMOVED &&
-            (!entry.image.isAdult || allowAdultContent) &&
-            (entry.image.moderationStatus !== ModerationStatus.FLAGGED || isAdmin || entry.image.ownerId === viewerId)
+          ? (ownsImage || entry.image.moderationStatus !== ModerationStatus.REMOVED) &&
+            (!entry.image.isAdult || allowAdultContent || ownsImage) &&
+            (entry.image.moderationStatus !== ModerationStatus.FLAGGED || isAdmin || ownsImage)
           : false;
         const canViewAsset = assetVisible
           ? canViewResource(viewer, entry.asset!.ownerId, entry.asset!.isPublic, options)

--- a/backend/src/routes/assets.ts
+++ b/backend/src/routes/assets.ts
@@ -517,36 +517,27 @@ assetsRouter.get('/models', async (req, res, next) => {
     const viewer = req.user;
     const isAdmin = viewer?.role === 'ADMIN';
     const allowAdultContent = isAdmin ? true : viewer?.showAdultContent ?? false;
-    const visibilityFilter: Prisma.ModelAssetWhereInput = isAdmin
-      ? {}
-      : viewer
-        ? {
-            AND: [
-              { moderationStatus: { not: ModerationStatus.REMOVED } },
-              {
-                OR: [
-                  { ownerId: viewer.id },
-                  {
-                    AND: [
-                      { isPublic: true },
-                      { moderationStatus: ModerationStatus.ACTIVE },
-                    ],
-                  },
-                ],
-              },
-            ],
-          }
-        : {
-            AND: [
-              { isPublic: true },
-              { moderationStatus: ModerationStatus.ACTIVE },
-            ],
-          };
-
     const filters: Prisma.ModelAssetWhereInput[] = [];
 
-    if (Object.keys(visibilityFilter).length > 0) {
-      filters.push(visibilityFilter);
+    if (!isAdmin) {
+      if (viewer) {
+        filters.push({
+          OR: [
+            { ownerId: viewer.id },
+            {
+              AND: [
+                { isPublic: true },
+                { moderationStatus: ModerationStatus.ACTIVE },
+              ],
+            },
+          ],
+        });
+      } else {
+        filters.push({
+          isPublic: true,
+          moderationStatus: ModerationStatus.ACTIVE,
+        });
+      }
     }
 
     if (!allowAdultContent) {
@@ -588,36 +579,27 @@ assetsRouter.get('/images', async (req, res, next) => {
     const viewer = req.user;
     const isAdmin = viewer?.role === 'ADMIN';
     const allowAdultContent = isAdmin ? true : viewer?.showAdultContent ?? false;
-    const visibilityFilter: Prisma.ImageAssetWhereInput = isAdmin
-      ? {}
-      : viewer
-        ? {
-            AND: [
-              { moderationStatus: { not: ModerationStatus.REMOVED } },
-              {
-                OR: [
-                  { ownerId: viewer.id },
-                  {
-                    AND: [
-                      { isPublic: true },
-                      { moderationStatus: ModerationStatus.ACTIVE },
-                    ],
-                  },
-                ],
-              },
-            ],
-          }
-        : {
-            AND: [
-              { isPublic: true },
-              { moderationStatus: ModerationStatus.ACTIVE },
-            ],
-          };
-
     const filters: Prisma.ImageAssetWhereInput[] = [];
 
-    if (Object.keys(visibilityFilter).length > 0) {
-      filters.push(visibilityFilter);
+    if (!isAdmin) {
+      if (viewer) {
+        filters.push({
+          OR: [
+            { ownerId: viewer.id },
+            {
+              AND: [
+                { isPublic: true },
+                { moderationStatus: ModerationStatus.ACTIVE },
+              ],
+            },
+          ],
+        });
+      } else {
+        filters.push({
+          isPublic: true,
+          moderationStatus: ModerationStatus.ACTIVE,
+        });
+      }
     }
 
     if (!allowAdultContent) {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -226,13 +226,18 @@ usersRouter.get('/:id/profile', async (req, res, next) => {
     const isAuditView = Boolean(viewer && viewer.role === 'ADMIN' && wantsAudit);
     const isAdmin = viewer?.role === 'ADMIN';
     const includePrivate = isAuditView || isAdmin || viewer?.id === id;
+    const includeRemoved = viewer?.id === id;
     const canViewFlagged = isAdmin || viewer?.id === id;
-    const modelModerationFilter: Prisma.ModelAssetWhereInput = canViewFlagged
-      ? { moderationStatus: { not: ModerationStatus.REMOVED } }
-      : { moderationStatus: ModerationStatus.ACTIVE };
-    const imageModerationFilter: Prisma.ImageAssetWhereInput = canViewFlagged
-      ? { moderationStatus: { not: ModerationStatus.REMOVED } }
-      : { moderationStatus: ModerationStatus.ACTIVE };
+    const modelModerationFilter: Prisma.ModelAssetWhereInput = includeRemoved
+      ? {}
+      : canViewFlagged
+        ? { moderationStatus: { not: ModerationStatus.REMOVED } }
+        : { moderationStatus: ModerationStatus.ACTIVE };
+    const imageModerationFilter: Prisma.ImageAssetWhereInput = includeRemoved
+      ? {}
+      : canViewFlagged
+        ? { moderationStatus: { not: ModerationStatus.REMOVED } }
+        : { moderationStatus: ModerationStatus.ACTIVE };
 
     const likeWhere: Prisma.ImageLikeWhereInput = includePrivate
       ? { image: { ownerId: id } }


### PR DESCRIPTION
## Summary
- relax gallery, model, image, and profile queries so creators always see their own uploads regardless of moderation status, visibility, or safe-mode filters
- add a TypeScript MinIO reindex helper plus npm script and documentation updates for recovering missing StorageObject metadata
- refresh the changelog and README to capture the new visibility behaviour and storage maintenance flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6e09e01f48333bc33e45299a2b54b