### PR TITLE
Lock Create account button when registration is disabled

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1132,3 +1132,8 @@
 - **Reason**: Curators could lose track of private or moderated uploads because viewer-facing filters hid their own assets, and administrators needed a recovery tool to reconcile database metadata with MinIO after manual storage edits.
 - **Changes**: Relaxed gallery, asset feed, and profile queries so authenticated owners always see every model, image, and gallery entry they uploaded regardless of moderation status, visibility, or safe-mode settings. Added `backend/scripts/reindexStorage.ts` together with the `npm run storage:reindex` helper to rescan MinIO, recreate missing `StorageObject` rows, and refresh file metadata.
 
+## 209 – [Fix] Registration lock indicator
+- **Type**: Normal Change
+- **Reason**: Visitors could still open the registration dialog even after administrators disabled self-service signups, leading to confusing error toasts instead of a clear closed state.
+- **Changes**: Updated `frontend/src/App.tsx` to keep the **Create account** button visible but disabled whenever registration or maintenance mode is off-limits and surface the corresponding notice. Refreshed the README to call out the locked button behaviour so operators know what to expect when closing signups.
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
 - Guests can browse public assets, while downloads, comments, and reactions require a signed-in account (USER role or higher). Adult-tagged models and renders stay hidden from guests and from members who leave the NSFW toggle off (default) in their account settings.
+- Administrators can disable self-service signups at any time; the **Create account** control stays visible but disabled so visitors immediately understand that registrations are closed while credentialed users continue signing in.
 - Home spotlight tiles are fully interactive—click previews to jump straight into the model or gallery explorers, and tap tag chips to filter matching content instantly.
 - Gallery and model previews now ship with an intelligent two-minute cache token so browsers keep recent imagery warm while automatically reloading whenever the underlying asset changes.
 - Model detail views and the gallery lightbox now include full comment threads—model dialogs keep replies inline beneath the content, while the gallery modal tucks discussions into a collapsible side rail so the enlarged image always stays visible. Signed-in members can post feedback and react to individual responses in place.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -783,6 +783,11 @@ export const App = () => {
   const latestModels = useMemo(() => visibleModelAssets.slice(0, 5), [visibleModelAssets]);
   const latestImages = useMemo(() => visibleImageAssets.slice(0, 5), [visibleImageAssets]);
   const showAdultBadges = authUser?.showAdultContent ?? false;
+  const isRegistrationUnavailable =
+    !platformConfig.allowRegistration || platformConfig.maintenanceMode;
+  const registrationLockMessage = platformConfig.maintenanceMode
+    ? 'Maintenance mode is active. Only administrators can sign in.'
+    : 'Registration is currently disabled by administrators.';
 
   const modelTiles = latestModels.map((asset) => {
     const isAuditPlaceholder = isAuditPlaceholderForViewer(
@@ -1218,38 +1223,30 @@ export const App = () => {
                 >
                   Sign in
                 </button>
-                {platformConfig.allowRegistration && !platformConfig.maintenanceMode ? (
-                  <button
-                    type="button"
-                    className="sidebar__auth-button"
-                    onClick={() => {
-                      if (!platformConfig.allowRegistration || platformConfig.maintenanceMode) {
-                        setToast({
-                          type: 'error',
-                          message: platformConfig.maintenanceMode
-                            ? 'Maintenance mode is active. Only administrators can sign in.'
-                            : 'Registration is currently disabled by administrators.',
-                        });
-                        return;
-                      }
-                      setIsRegisterOpen(true);
-                      setRegisterError(null);
-                    }}
-                    disabled={isLoggingIn || isRegistering}
-                  >
-                    Create account
-                  </button>
-                ) : (
+                <button
+                  type="button"
+                  className="sidebar__auth-button"
+                  onClick={() => {
+                    if (isRegistrationUnavailable) {
+                      setToast({ type: 'error', message: registrationLockMessage });
+                      return;
+                    }
+                    setIsRegisterOpen(true);
+                    setRegisterError(null);
+                  }}
+                  disabled={isLoggingIn || isRegistering || isRegistrationUnavailable}
+                >
+                  Create account
+                </button>
+                {isRegistrationUnavailable ? (
                   <p
                     className={`sidebar__auth-note${
                       platformConfig.maintenanceMode ? ' sidebar__auth-note--warning' : ''
                     }`}
                   >
-                    {platformConfig.maintenanceMode
-                      ? 'Maintenance mode active. Only administrators can sign in.'
-                      : 'Registration is currently disabled.'}
+                    {registrationLockMessage}
                   </p>
-                )}
+                ) : null}
               </>
             )}
           </div>


### PR DESCRIPTION
## Summary
- disable the Create account button whenever registration or maintenance mode is closed and keep the explanatory note inline
- document the locked registration behaviour in the README to guide operators
- add changelog entry 209 covering the registration lock fix

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6eb2bbb4883338d540c2a31e3c63f