### PR TITLE
Fix runtime registration toggle updates

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1137,3 +1137,8 @@
 - **Reason**: Visitors could still open the registration dialog even after administrators disabled self-service signups, leading to confusing error toasts instead of a clear closed state.
 - **Changes**: Updated `frontend/src/App.tsx` to keep the **Create account** button visible but disabled whenever registration or maintenance mode is off-limits and surface the corresponding notice. Refreshed the README to call out the locked button behaviour so operators know what to expect when closing signups.
 
+## 210 – [Fix] Self-service registration toggle sync
+- **Type**: Normal Change
+- **Reason**: After administrators turned off self-service registration, the backend kept the locked state cached so re-enabling the toggle in the admin panel had no effect until the server restarted.
+- **Changes**: Refreshed `backend/src/lib/settings.ts` to update the runtime platform flags after saving admin settings and had `frontend/src/components/AdminPanel.tsx` reload the platform configuration so the registration toggle immediately applies across the interface.
+

--- a/backend/src/lib/settings.ts
+++ b/backend/src/lib/settings.ts
@@ -225,6 +225,10 @@ export const applyAdminSettings = async (settings: AdminSettings) => {
   await updateEnvFile(backendEnvPath, backendUpdates);
   await updateEnvFile(frontendEnvPath, frontendUpdates);
 
+  appConfig.platform.siteTitle = settings.general.siteTitle;
+  appConfig.platform.allowRegistration = settings.general.allowRegistration;
+  appConfig.platform.maintenanceMode = settings.general.maintenanceMode;
+
   return resolveAdminSettings();
 };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1074,6 +1074,7 @@ export const App = () => {
           rankingTiersFallback={rankingTiersFallback}
           generatorSettings={generatorSettings}
           onGeneratorSettingsUpdated={setGeneratorSettings}
+          onPlatformConfigUpdated={setPlatformConfig}
         />
       );
     }

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -21,6 +21,7 @@ import type {
   AdultSafetyKeyword,
   User,
   AdminSettings,
+  PlatformConfig,
 } from '../types/api';
 import { FilterChip } from './FilterChip';
 import { ImageAssetEditDialog } from './ImageAssetEditDialog';
@@ -110,6 +111,7 @@ interface AdminPanelProps {
   rankingTiersFallback: boolean;
   generatorSettings: GeneratorSettings | null;
   onGeneratorSettingsUpdated?: (settings: GeneratorSettings) => void;
+  onPlatformConfigUpdated?: (config: PlatformConfig) => void;
 }
 
 type AdminTab =
@@ -382,6 +384,7 @@ export const AdminPanel = ({
   rankingTiersFallback,
   generatorSettings,
   onGeneratorSettingsUpdated,
+  onPlatformConfigUpdated,
 }: AdminPanelProps) => {
   const [activeTab, setActiveTab] = useState<AdminTab>('users');
   const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
@@ -994,6 +997,17 @@ export const AdminPanel = ({
           ? 'Settings saved. Restart the backend, frontend, and GPU worker to apply connection changes.'
           : 'Settings saved successfully.',
       });
+
+      if (onPlatformConfigUpdated) {
+        try {
+          const platform = await api.getPlatformConfig();
+          onPlatformConfigUpdated(platform);
+        } catch (configError) {
+          if (process.env.NODE_ENV === 'development') {
+            console.warn('Failed to refresh platform config after settings update', configError);
+          }
+        }
+      }
     } catch (error) {
       const message = error instanceof ApiError ? error.message : 'Failed to update settings.';
       setStatus({ type: 'error', message });


### PR DESCRIPTION
## Summary
- refresh the backend runtime platform flags after saving admin settings so the registration toggle can reopen without a restart
- have the admin panel reload the platform configuration after saving to keep the UI lock state in sync
- log the fix in changelog entry 210

## Testing
- npm --prefix backend run lint
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6edef9b588333ae60e438f9a89fb5