### PR TITLE
Fix Windows bulk importer Count handling

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1152,3 +1152,8 @@
 - **Reason**: Reviewers needed a faster way to step through gallery images without repeatedly closing the lightbox or targeting small thumbnails.
 - **Changes**: Added swipe, click, and keyboard arrow navigation to the gallery image modal, introduced focus styles for the interactive lightbox surface, and documented the streamlined workflow in the README.
 
+## 212 – [Fix] Windows bulk importer single-item guard
+- **Type**: Normal Change
+- **Reason**: Windows bulk uploads that only included one LoRA or a single preview image crashed because the script attempted to read the `.Count` property from scalar file objects.
+- **Changes**: Wrapped the Windows importer’s file enumerations in arrays so lone safetensors and preview images are counted correctly, and refreshed the README Windows workflow guidance with the single-item support tip.
+

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ The script authenticates with `POST /api/auth/login`, seeds the gallery by uploa
 
 The PowerShell helper mirrors the Linux workflow: it authenticates, verifies admin privileges, stages the LoRA with a random preview, and then fans out the remaining renders in twelve-file batches until the entire collection has been imported. Health status and upload responses are validated on every step, so the run halts immediately if VisionSuit stops returning the expected asset and gallery identifiers.
 
+> **Tip:** Single-model libraries and one-image galleries are supported—the importer now treats lone safetensors and previews as proper collections so you can sanity-check uploads incrementally before scaling to larger batches.
+
 #### Metadata overrides and defaults
 
 The bulk helpers now mirror the fields exposed by the upload wizard: they populate model titles, descriptions, tags, gallery visibility, triggers, and collection targets before any files leave your machine. Each LoRA can ship its own overrides through a JSON descriptor placed either next to the `.safetensors` file (`./loras/model-name.json`) or inside the image directory (`./images/model-name/metadata.json`). Example:

--- a/scripts/bulk_import_windows.ps1
+++ b/scripts/bulk_import_windows.ps1
@@ -530,7 +530,7 @@ try {
 
   $uploadUri = ConvertTo-AbsoluteUri -BaseUri $baseUri -RelativePath '/api/uploads'
 
-  $loraFiles = Get-ChildItem -LiteralPath $lorasRoot -Filter '*.safetensors' -Recurse -File | Sort-Object FullName
+  $loraFiles = @(Get-ChildItem -LiteralPath $lorasRoot -Filter '*.safetensors' -Recurse -File | Sort-Object FullName)
   if ($loraFiles.Count -eq 0) {
     Write-Log "No LoRA safetensors found beneath '$lorasRoot'."
     return
@@ -549,9 +549,9 @@ try {
     }
 
     $allowedExtensions = @('.png', '.jpg', '.jpeg', '.webp', '.bmp')
-    $images = Get-ChildItem -LiteralPath $imageFolder -File | Where-Object {
+    $images = @(Get-ChildItem -LiteralPath $imageFolder -File | Where-Object {
       $allowedExtensions -contains ([System.IO.Path]::GetExtension($_.Name).ToLowerInvariant())
-    } | Sort-Object Name
+    } | Sort-Object Name)
     if ($images.Count -eq 0) {
       Write-Log "Skipping '$baseName' because no preview-ready images were found."
       $skipped++
@@ -559,7 +559,7 @@ try {
     }
 
     $preview = Get-Random -InputObject $images
-    $otherImages = $images | Where-Object { $_.FullName -ne $preview.FullName }
+    $otherImages = @($images | Where-Object { $_.FullName -ne $preview.FullName })
 
     $candidateMetadata = @(
       (Join-Path -Path $lora.DirectoryName -ChildPath "$baseName.json")


### PR DESCRIPTION
## Summary
- ensure the Windows bulk importer always treats Get-ChildItem results as arrays so single files expose a Count property
- document the single-model Windows workflow tip in the README
- record the normal-change entry in the changelog

## Testing
- not run (non-executable updates)


------
https://chatgpt.com/codex/tasks/task_e_68d70cbbecc8833395a047648f35cce3