### PR TITLE
Document NSFW deployment plan progress

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -163,6 +163,11 @@
 - **Technical Changes**: Made metadata fields optional in types, guarded lightbox and card rendering with optional chaining, and documented the resilience improvement.
 - **Data Changes**: None.
 
+## 033 – [Change] NSFW deployment progress tracking
+- **Type**: Normal Change
+- **Reason**: Needed to translate the NSFW rollout blueprint into an actionable checklist with highlighted open questions before implementation begins.
+- **Change**: Converted the NSFW deployment plan into status-aware checklists, tagged unresolved dependencies with explicit questions, and kept remaining tasks pending for future execution.
+
 ## 033 – [Addition] NSFW moderation deployment plan (commit TBD)
 - **Type of Change**: Normal Change
 - **Why**: Document the roadmap required to replace the legacy keyword-only NSFW filter with a multi-signal, self-hosted system.

--- a/docs/nsfw-deployment-plan.md
+++ b/docs/nsfw-deployment-plan.md
@@ -13,22 +13,22 @@ Flag LoRA models that are likely to contain explicit content by examining their 
 - Optional auxiliary strings: prompt snippets, training notes, or creator-provided warnings.
 
 ### Processing Steps
-1. **Metadata Extraction**
-   - Extend the backend ingestion worker so that LoRA uploads normalize the two frequency tables into a canonical lowercase key/value array (`tag` → `count`).
-   - Persist the normalized arrays in the LoRA metadata JSON for re-use by moderation tooling and search.
-2. **Heuristic Evaluation**
-   - Iterate over the normalized tag list and compute:
-     - `adultScore = Σ count(tag) for tag ∈ NSFW_FILTER_TERMS`.
-     - `minorScore = Σ count(tag) for tag ∈ MINOR_FILTER_TERMS`.
-     - `beastScore = Σ count(tag) for tag ∈ BESTIALITY_FILTER_TERMS`.
-   - Compare each score against configurable thresholds (defaults below) to determine the moderation outcome.
-3. **Outcome Mapping**
-   - `adultScore ≥ 15` → mark LoRA as `adult=true` but keep it visible for curator/admin review.
-   - `minorScore ≥ 1` or `beastScore ≥ 1` → place LoRA in the **Moderation** queue immediately and block community visibility until an administrator overrides it.
-   - Otherwise leave `adult=false` and let downstream checks (image previews, user flags) provide additional signals.
+- [ ] **Metadata Extraction**
+  - [ ] Extend the backend ingestion worker so that LoRA uploads normalize the two frequency tables into a canonical lowercase key/value array (`tag` → `count`).
+  - [ ] Persist the normalized arrays in the LoRA metadata JSON for re-use by moderation tooling and search.
+- [ ] **Heuristic Evaluation**
+  - [ ] Iterate over the normalized tag list and compute:
+    - [ ] `adultScore = Σ count(tag) for tag ∈ NSFW_FILTER_TERMS`.
+    - [ ] `minorScore = Σ count(tag) for tag ∈ MINOR_FILTER_TERMS`.
+    - [ ] `beastScore = Σ count(tag) for tag ∈ BESTIALITY_FILTER_TERMS`.
+  - [ ] Compare each score against configurable thresholds (defaults below) to determine the moderation outcome.
+- [ ] **Outcome Mapping**
+  - [ ] `adultScore ≥ 15` → mark LoRA as `adult=true` but keep it visible for curator/admin review.
+  - [ ] `minorScore ≥ 1` or `beastScore ≥ 1` → place LoRA in the **Moderation** queue immediately and block community visibility until an administrator overrides it.
+  - [ ] Otherwise leave `adult=false` and let downstream checks (image previews, user flags) provide additional signals.
 
 ### Default Filter Lists
-These seed lists should be stored as JSON under `config/nsfw-metadata-filters.json` so administrators can tune them in the UI.
+- [ ] Store these seed lists as JSON under `config/nsfw-metadata-filters.json` so administrators can tune them in the UI.
 
 **NSFW_FILTER_TERMS**
 ```
@@ -46,9 +46,9 @@ These seed lists should be stored as JSON under `config/nsfw-metadata-filters.js
 ```
 
 ### Threshold Tuning
-- Expose three numeric sliders (`adultThreshold`, `minorThreshold`, `beastThreshold`) in the Administration → Safety panel.
-- Persist overrides in the same configuration JSON and trigger `scheduleAdultKeywordRecalculation` so existing LoRAs inherit new rules.
-- Include a preview table that shows the number of stored LoRAs that currently exceed each threshold for quick calibration.
+- [ ] Expose three numeric sliders (`adultThreshold`, `minorThreshold`, `beastThreshold`) in the Administration → Safety panel.
+- [ ] Persist overrides in the same configuration JSON and trigger `scheduleAdultKeywordRecalculation` so existing LoRAs inherit new rules.
+- [ ] Include a preview table that shows the number of stored LoRAs that currently exceed each threshold for quick calibration.
 
 ## 2. OpenCV Image Analysis Pipeline
 
@@ -56,91 +56,95 @@ These seed lists should be stored as JSON under `config/nsfw-metadata-filters.js
 Analyze uploaded images on-premise and mark explicit content automatically while tolerating swimwear or lingerie that covers primary anatomy.
 
 ### Processing Stages
-1. **Pre-processing**
-   - Resize the input to a working resolution (longest edge ≤ 1,280 px) while maintaining aspect ratio.
-   - Convert to HSV and YCrCb color spaces for robust skin-tone detection under varied lighting.
-2. **Skin Region Estimation**
-   - Apply color range masks in HSV and YCrCb; intersect the masks and clean them with morphological opening/closing.
-   - Compute the ratio of skin pixels to total pixels and extract connected components for body-part analysis.
-3. **Pose & Region Checks**
-   - Run a lightweight pose estimator (e.g., OpenCV’s BlazePose or MediaPipe integration) to detect torso keypoints.
-   - Evaluate coverage heuristics:
-     - Large contiguous skin regions that include both torso and hip keypoints with minimal high-contrast clothing edges → candidate for full nudity.
-     - High skin ratio limited to limbs or head without torso exposure → treat as non-blocking.
-4. **Swimwear vs. Full Nudity**
-   - Use edge density and color variance inside detected torso regions to infer clothing coverage: bikinis, lingerie, tattoos, and patterned fabric introduce strong contrast edges along straps and waistbands, while pure skin regions with low variance suggest nudity.
-   - Feed the torso crop into a lightweight ONNX-hosted CNN (`nude_vs_swimwear.onnx`, MobileNetV3-small backbone) to reinforce the heuristic. The model should return calibrated probabilities for `nude`, `swimwear`, and `ambiguous` so skin-tone and edge-based heuristics remain advisory rather than the sole decision makers.
-   - Maintain thresholds (combine heuristic + model outputs):
-     - `skinRatio ≥ 0.35`, `coverageScore ≤ 0.25`, **and** `P(nude) - P(swimwear) ≥ 0.2` → flag as `adult=true` (full nudity).
-     - `skinRatio ≥ 0.2` with either `coverageScore > 0.25` **or** `P(swimwear) ≥ 0.45` → mark as `suggestive` but keep `adult=false` for bikini-tier content.
-     - When the CNN returns `ambiguous`, down-rank the adult score slightly and surface a "Needs review" soft flag so moderators can adjudicate unusual cases (body paint, lingerie sets, cosplay armor, etc.).
-5. **Disallowed Content Detection**
-   - Scan prompts, filenames, and tag metadata for minor/bestiality keywords (reuse the lists above).
-   - Incorporate a CNN classifier (e.g., MobileNet-based) fine-tuned for `minor` and `bestiality` cues; run it locally via ONNX Runtime on the CPU.
-   - Add context disambiguation rules for terms such as `teen`, `schoolgirl`, and `schoolboy`:
-     - Require co-occurring maturity markers (e.g., `adult`, `cosplay`, `college`) or explicit age metadata before treating the content as safe.
-     - When textual context is neutral but imagery is suggestive, down-rank the result into a manual review bucket rather than a hard block to avoid false positives on age-play or cosplay LoRAs.
-   - Any positive match marks the image with `moderationFlag=BLOCKED` and suppresses public visibility.
-6. **Result Storage**
-   - Serialize results into image metadata (e.g., `nsfw.adultScore`, `nsfw.suggestiveScore`, `nsfw.moderationFlag`).
-   - Expose these fields to `determineAdultForImage` so the updated filter can combine them with textual signals.
+- [ ] **Pre-processing**
+  - [ ] Resize the input to a working resolution (longest edge ≤ 1,280 px) while maintaining aspect ratio.
+  - [ ] Convert to HSV and YCrCb color spaces for robust skin-tone detection under varied lighting.
+- [ ] **Skin Region Estimation**
+  - [ ] Apply color range masks in HSV and YCrCb; intersect the masks and clean them with morphological opening/closing.
+  - [ ] Compute the ratio of skin pixels to total pixels and extract connected components for body-part analysis.
+- [ ] **Pose & Region Checks**
+  - [ ] Run a lightweight pose estimator (e.g., OpenCV’s BlazePose or MediaPipe integration) to detect torso keypoints.
+  - [ ] Evaluate coverage heuristics:
+    - [ ] Large contiguous skin regions that include both torso and hip keypoints with minimal high-contrast clothing edges → candidate for full nudity.
+    - [ ] High skin ratio limited to limbs or head without torso exposure → treat as non-blocking.
+- [ ] **Swimwear vs. Full Nudity**
+  - [ ] Use edge density and color variance inside detected torso regions to infer clothing coverage: bikinis, lingerie, tattoos, and patterned fabric introduce strong contrast edges along straps and waistbands, while pure skin regions with low variance suggest nudity.
+  - [?] Feed the torso crop into a lightweight ONNX-hosted CNN (`nude_vs_swimwear.onnx`, MobileNetV3-small backbone) to reinforce the heuristic. The model should return calibrated probabilities for `nude`, `swimwear`, and `ambiguous` so skin-tone and edge-based heuristics remain advisory rather than the sole decision makers.
+    - Question: Do we already maintain a labeled dataset or existing checkpoint to produce `nude_vs_swimwear.onnx`, or is a new training effort required?
+  - [ ] Maintain thresholds (combine heuristic + model outputs):
+    - [ ] `skinRatio ≥ 0.35`, `coverageScore ≤ 0.25`, **and** `P(nude) - P(swimwear) ≥ 0.2` → flag as `adult=true` (full nudity).
+    - [ ] `skinRatio ≥ 0.2` with either `coverageScore > 0.25` **or** `P(swimwear) ≥ 0.45` → mark as `suggestive` but keep `adult=false` for bikini-tier content.
+    - [ ] When the CNN returns `ambiguous`, down-rank the adult score slightly and surface a "Needs review" soft flag so moderators can adjudicate unusual cases (body paint, lingerie sets, cosplay armor, etc.).
+- [ ] **Disallowed Content Detection**
+  - [ ] Scan prompts, filenames, and tag metadata for minor/bestiality keywords (reuse the lists above).
+  - [?] Incorporate a CNN classifier (e.g., MobileNet-based) fine-tuned for `minor` and `bestiality` cues; run it locally via ONNX Runtime on the CPU.
+    - Question: Which internal or third-party dataset will we leverage to train and validate the minor/bestiality detector while meeting compliance constraints?
+  - [ ] Add context disambiguation rules for terms such as `teen`, `schoolgirl`, and `schoolboy`:
+    - [ ] Require co-occurring maturity markers (e.g., `adult`, `cosplay`, `college`) or explicit age metadata before treating the content as safe.
+    - [ ] When textual context is neutral but imagery is suggestive, down-rank the result into a manual review bucket rather than a hard block to avoid false positives on age-play or cosplay LoRAs.
+  - [ ] Any positive match marks the image with `moderationFlag=BLOCKED` and suppresses public visibility.
+- [ ] **Result Storage**
+  - [ ] Serialize results into image metadata (e.g., `nsfw.adultScore`, `nsfw.suggestiveScore`, `nsfw.moderationFlag`).
+  - [ ] Expose these fields to `determineAdultForImage` so the updated filter can combine them with textual signals.
 
 ### Runtime Considerations
-- CPU-only deployment using OpenCV with OpenMP for multi-core scaling; expect < 120 ms per 1024×1024 image on a modern 8-core CPU when processing single frames.
-- Introduce configurable worker pools with bounded batch sizes (`maxWorkers`, `maxBatchSize`) so bulk imports can saturate the pipeline without starving the API. Allow administrators to tune these values from the Safety tab and persist them in the configuration JSON.
-- Batch processing queue with retry/backoff to prevent high CPU usage from blocking uploads; store intermediate results for auditing and expose queue depth metrics to the operations dashboard.
-- Auto-detect pressure situations (queue length > soft limit) and temporarily downshift to heuristic-only scoring until the queue drains, then re-run deferred CNN passes asynchronously.
-- Optional GPU acceleration via OpenCL or CUDA when deploying alongside the existing GPU worker; treat it as a drop-in accelerator for the CNN passes while keeping CPU-only processing viable.
+- [ ] CPU-only deployment using OpenCV with OpenMP for multi-core scaling; expect < 120 ms per 1024×1024 image on a modern 8-core CPU when processing single frames.
+- [ ] Introduce configurable worker pools with bounded batch sizes (`maxWorkers`, `maxBatchSize`) so bulk imports can saturate the pipeline without starving the API. Allow administrators to tune these values from the Safety tab and persist them in the configuration JSON.
+- [ ] Batch processing queue with retry/backoff to prevent high CPU usage from blocking uploads; store intermediate results for auditing and expose queue depth metrics to the operations dashboard.
+- [?] Auto-detect pressure situations (queue length > soft limit) and temporarily downshift to heuristic-only scoring until the queue drains, then re-run deferred CNN passes asynchronously.
+  - Question: Which existing queueing infrastructure (e.g., BullMQ, custom worker) should expose the pressure metrics needed to trigger the heuristic-only fallback?
+- [ ] Optional GPU acceleration via OpenCL or CUDA when deploying alongside the existing GPU worker; treat it as a drop-in accelerator for the CNN passes while keeping CPU-only processing viable.
 
 ## 3. NSFW Filter & UI Integration
 
 ### Backend Filter Replacement
-- Replace the existing keyword-only `determineAdultForImage` and `determineAdultForModel` implementations with a composable scoring engine that fuses:
-  - Textual keyword hits (existing behavior).
-  - LoRA metadata scores (`adultScore`, `minorScore`, `beastScore`).
-  - OpenCV image analysis outputs (`adultScore`, `suggestiveScore`, `moderationFlag`).
-- Define a final decision matrix:
-  - `moderationFlag=BLOCKED` → auto-queue for moderation, hide from all non-admin roles.
-  - `adultScore ≥ adultThreshold` → mark asset as adult; honor user safe-mode toggles.
-  - `suggestiveScore ≥ suggestiveThreshold` → keep public but highlight in moderation queue for optional review.
-  - `needsReview=true` (e.g., swimwear CNN `ambiguous`, cosplay minor keywords) → place the asset in a **Pending Review** soft state that remains discoverable with a badge while awaiting moderator triage.
-- Implement audit logging so every decision writes the contributing signals for transparency.
+- [ ] Replace the existing keyword-only `determineAdultForImage` and `determineAdultForModel` implementations with a composable scoring engine that fuses:
+  - [ ] Textual keyword hits (existing behavior).
+  - [ ] LoRA metadata scores (`adultScore`, `minorScore`, `beastScore`).
+  - [ ] OpenCV image analysis outputs (`adultScore`, `suggestiveScore`, `moderationFlag`).
+- [ ] Define a final decision matrix:
+  - [ ] `moderationFlag=BLOCKED` → auto-queue for moderation, hide from all non-admin roles.
+  - [ ] `adultScore ≥ adultThreshold` → mark asset as adult; honor user safe-mode toggles.
+  - [ ] `suggestiveScore ≥ suggestiveThreshold` → keep public but highlight in moderation queue for optional review.
+  - [ ] `needsReview=true` (e.g., swimwear CNN `ambiguous`, cosplay minor keywords) → place the asset in a **Pending Review** soft state that remains discoverable with a badge while awaiting moderator triage.
+- [ ] Implement audit logging so every decision writes the contributing signals for transparency.
 
 ### Administration Panel Updates
-- **Safety Tab Enhancements**
-  - Add configuration cards for metadata thresholds, image analysis thresholds, and keyword packs.
-  - Provide CSV upload/download for filter lists to streamline bulk edits.
-  - Visualize recent classification stats (e.g., counts of adult vs. flagged items in the last 24 hours).
-- **Moderation Queue Redesign**
-  - Replace the current tile layout with a split-pane UI:
-    - Left rail: prioritized queue filtered by severity (Blocked, Adult, Suggestive, User Flags).
-    - Right pane: large preview, metadata scores, contributing tags, and quick actions (Approve, Mark Adult, Remove).
-  - Surface reason badges (`Keyword`, `Metadata`, `OpenCV`, `User Flag`) so moderators immediately know why an asset was queued.
-  - Display a "Pending Review" badge (yellow) for assets soft-flagged by heuristics/CNNs so creators understand their LoRA is awaiting human validation rather than hidden outright.
-  - Allow inline threshold adjustments for admins (debounced save to avoid noisy updates).
-  - Provide a preview blur toggle in moderation and public galleries: default to a blurred thumbnail for adult/suggestive assets, reveal the clear image on click (respecting user safe-mode preferences).
+- [ ] **Safety Tab Enhancements**
+  - [ ] Add configuration cards for metadata thresholds, image analysis thresholds, and keyword packs.
+  - [ ] Provide CSV upload/download for filter lists to streamline bulk edits.
+  - [ ] Visualize recent classification stats (e.g., counts of adult vs. flagged items in the last 24 hours).
+- [ ] **Moderation Queue Redesign**
+  - [ ] Replace the current tile layout with a split-pane UI:
+    - [ ] Left rail: prioritized queue filtered by severity (Blocked, Adult, Suggestive, User Flags).
+    - [ ] Right pane: large preview, metadata scores, contributing tags, and quick actions (Approve, Mark Adult, Remove).
+  - [ ] Surface reason badges (`Keyword`, `Metadata`, `OpenCV`, `User Flag`) so moderators immediately know why an asset was queued.
+  - [ ] Display a "Pending Review" badge (yellow) for assets soft-flagged by heuristics/CNNs so creators understand their LoRA is awaiting human validation rather than hidden outright.
+  - [ ] Allow inline threshold adjustments for admins (debounced save to avoid noisy updates).
+  - [ ] Provide a preview blur toggle in moderation and public galleries: default to a blurred thumbnail for adult/suggestive assets, reveal the clear image on click (respecting user safe-mode preferences).
 
 ### Deployment Steps
-1. Implement backend scoring services and migrations for new metadata fields.
-2. Ship OpenCV pipeline as a dedicated worker process (`services/nsfw-analyzer`) with message queue integration (Redis or BullMQ via existing Node stack).
-3. Update frontend admin routes to consume the new moderation API responses and render enhanced controls.
-4. Backfill historical assets by enqueueing a one-time job that:
-   - Rehydrates LoRA metadata scores from stored tables.
-   - Processes existing images through the OpenCV pipeline.
-   - Updates adult flags and moderation queue entries accordingly.
-5. Document operational runbooks for tuning thresholds, reviewing audit logs, and handling false positives.
+- [ ] Implement backend scoring services and migrations for new metadata fields.
+- [ ] Ship OpenCV pipeline as a dedicated worker process (`services/nsfw-analyzer`) with message queue integration (Redis or BullMQ via existing Node stack).
+- [ ] Update frontend admin routes to consume the new moderation API responses and render enhanced controls.
+- [ ] Backfill historical assets by enqueueing a one-time job that:
+  - [ ] Rehydrates LoRA metadata scores from stored tables.
+  - [ ] Processes existing images through the OpenCV pipeline.
+  - [ ] Updates adult flags and moderation queue entries accordingly.
+- [ ] Document operational runbooks for tuning thresholds, reviewing audit logs, and handling false positives.
 
 ## 4. Future Enhancements
 
-- Integrate specialized ONNX models (e.g., `open_nsfw2`, body-part detectors) as optional modules that can supersede heuristic scores when higher precision is required. Each module should register with the scoring engine via a plug-in contract so future detectors (face obscuration, gesture classification) can be added without refactoring the core pipeline.
-- Maintain a continuous learning loop: archive moderator decisions and false positive reports to a feedback dataset that can periodically refresh the swimwear and minor/bestiality classifiers.
-- Explore federated sharing of anonymized moderation fingerprints across trusted deployments to accelerate warm starts when rolling out new detectors.
+- [ ] Integrate specialized ONNX models (e.g., `open_nsfw2`, body-part detectors) as optional modules that can supersede heuristic scores when higher precision is required. Each module should register with the scoring engine via a plug-in contract so future detectors (face obscuration, gesture classification) can be added without refactoring the core pipeline.
+- [ ] Maintain a continuous learning loop: archive moderator decisions and false positive reports to a feedback dataset that can periodically refresh the swimwear and minor/bestiality classifiers.
+- [?] Explore federated sharing of anonymized moderation fingerprints across trusted deployments to accelerate warm starts when rolling out new detectors.
+  - Question: Do we have legal clearance and infrastructure guidance to exchange anonymized moderation signals across deployments while complying with privacy policies?
 
 ## Rollout & Monitoring
 
-- **Staging Validation**: Deploy to a staging environment with anonymized samples representing safe, suggestive, and explicit categories. Verify pipeline latency and moderation accuracy.
-- **Training**: Provide administrators with a short guide on interpreting the new scores and adjusting thresholds responsibly.
-- **Observability**: Emit metrics (`nsfw.adult.marked`, `nsfw.moderation.flagged`, processing latency) to the existing monitoring stack.
-- **Fallback Plan**: Maintain a feature flag that reverts to the legacy keyword-only system if severe regressions occur during rollout.
+- [ ] **Staging Validation**: Deploy to a staging environment with anonymized samples representing safe, suggestive, and explicit categories. Verify pipeline latency and moderation accuracy.
+- [ ] **Training**: Provide administrators with a short guide on interpreting the new scores and adjusting thresholds responsibly.
+- [ ] **Observability**: Emit metrics (`nsfw.adult.marked`, `nsfw.moderation.flagged`, processing latency) to the existing monitoring stack.
+- [ ] **Fallback Plan**: Maintain a feature flag that reverts to the legacy keyword-only system if severe regressions occur during rollout.
 
 Following this plan will deliver a robust, fully self-hosted NSFW moderation system that blends metadata heuristics, on-device computer vision, and operator-friendly controls without depending on external services.


### PR DESCRIPTION
## Summary
- convert the NSFW deployment roadmap into checklists that highlight pending steps
- flag open questions around CNN training data, queue pressure detection, and federated moderation sharing
- log the documentation update in the changelog as a normal change entry

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7be235a9883339c2605239af7bb77