### PR TITLE
Fix NSFW PNG decoding dependency

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -158,6 +158,11 @@
 - **Technical Changes**: Added modal navigation with backdrop/escape handling, parent callbacks, responsive CSS, and README updates.
 - **Data Changes**: None.
 
+## 032 – [Fix] NSFW decoder dependency swap
+- **Type**: Emergency Change
+- **Reason**: Backend startup failed because the NSFW image analysis required the `pngjs` module, which was absent in new installs and broke the launch sequence.
+- **Change**: Replaced the PNG decoder with `upng-js`, updated dependency manifests, and refreshed the synthetic test fixture so the analyzer no longer depends on `pngjs`.
+
 ## 032 – [Addition] NSFW image ingestion signals
 - **Type**: Normal Change
 - **Reason**: The moderation roadmap called for automatic adult tagging beyond keyword scans so that explicit previews and gallery uploads are caught even when creators avoid sensitive terms.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,7 @@
         "minio": "^8.0.6",
         "morgan": "^1.10.1",
         "multer": "^2.0.2",
-        "pngjs": "^7.0.0",
+        "upng-js": "^2.1.0",
         "zod": "^4.1.9"
       },
       "devDependencies": {
@@ -33,7 +33,6 @@
         "@types/morgan": "^1.9.10",
         "@types/multer": "^2.0.0",
         "@types/node": "^24.5.2",
-        "@types/pngjs": "^6.0.5",
         "prisma": "^6.16.2",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
@@ -340,16 +339,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.12.0"
-      }
-    },
-    "node_modules/@types/pngjs": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
-      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -2203,15 +2192,6 @@
         "pathe": "^2.0.3"
       }
     },
-    "node_modules/pngjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
-      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.19.0"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -2985,6 +2965,21 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/upng-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz",
+      "integrity": "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
+      }
+    },
+    "node_modules/upng-js/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,7 +31,7 @@
     "minio": "^8.0.6",
     "morgan": "^1.10.1",
     "multer": "^2.0.2",
-    "pngjs": "^7.0.0",
+    "upng-js": "^2.1.0",
     "zod": "^4.1.9"
   },
   "devDependencies": {
@@ -43,7 +43,6 @@
     "@types/morgan": "^1.9.10",
     "@types/multer": "^2.0.0",
     "@types/node": "^24.5.2",
-    "@types/pngjs": "^6.0.5",
     "prisma": "^6.16.2",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/backend/src/lib/nsfw/imageAnalysis.ts
+++ b/backend/src/lib/nsfw/imageAnalysis.ts
@@ -1,5 +1,5 @@
-import { PNG } from 'pngjs';
 import jpeg from 'jpeg-js';
+import UPNG from 'upng-js';
 
 import { appConfig } from '../../config';
 
@@ -79,10 +79,12 @@ const decodeImage = async (payload: Buffer): Promise<OpenCvMat> => {
   let rgba: Uint8Array | null = null;
 
   try {
-    const png = PNG.sync.read(payload);
-    width = png.width;
-    height = png.height;
-    rgba = png.data;
+    const decoded = UPNG.decode(payload);
+    width = decoded.width;
+    height = decoded.height;
+    const frames = UPNG.toRGBA8(decoded);
+    const frame = frames && frames.length > 0 ? frames[0] : null;
+    rgba = frame ? new Uint8Array(frame) : null;
   } catch (pngError) {
     try {
       const decoded = jpeg.decode(payload, { useTArray: true });

--- a/backend/src/types/upng-js.d.ts
+++ b/backend/src/types/upng-js.d.ts
@@ -1,0 +1,25 @@
+declare module 'upng-js' {
+  interface UPNGImage {
+    width: number;
+    height: number;
+    data: Uint8Array;
+    frames?: unknown[];
+    tabs?: Record<string, unknown>;
+  }
+
+  interface UPNGStatic {
+    decode(data: ArrayBuffer | ArrayBufferView | Buffer): UPNGImage;
+    encode(
+      frames: ArrayBuffer[] | Uint8Array[] | ArrayLike<ArrayBuffer>,
+      width: number,
+      height: number,
+      compression?: number,
+      delays?: number[],
+      frags?: unknown[],
+    ): ArrayBuffer;
+    toRGBA8(image: UPNGImage): ArrayBuffer[];
+  }
+
+  const UPNG: UPNGStatic;
+  export default UPNG;
+}

--- a/backend/test/upng-js.d.ts
+++ b/backend/test/upng-js.d.ts
@@ -1,0 +1,25 @@
+declare module 'upng-js' {
+  interface UPNGImage {
+    width: number;
+    height: number;
+    data: Uint8Array;
+    frames?: unknown[];
+    tabs?: Record<string, unknown>;
+  }
+
+  interface UPNGStatic {
+    decode(data: ArrayBuffer | ArrayBufferView | Buffer): UPNGImage;
+    encode(
+      frames: ArrayBuffer[] | Uint8Array[] | ArrayLike<ArrayBuffer>,
+      width: number,
+      height: number,
+      compression?: number,
+      delays?: number[],
+      frags?: unknown[],
+    ): ArrayBuffer;
+    toRGBA8(image: UPNGImage): ArrayBuffer[];
+  }
+
+  const UPNG: UPNGStatic;
+  export default UPNG;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "es2020",
     "lib": ["es2020"],
     "types": ["node"],
+    "typeRoots": ["./src/types", "./test", "./node_modules/@types"],
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary
- replace the NSFW image analyzer's PNG decoder with upng-js and update the unit test fixture to use the new encoder
- add local type declarations for upng-js and extend the TypeScript configuration so both source and tests compile cleanly
- record the emergency fix in the changelog alongside the dependency manifest updates

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e02533088333a9d41ec7d012d96f