### PR TITLE
Fix Prisma image asset include for moderation summary scalar

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1266,4 +1266,9 @@
 - **Reason**: Model uploads attempted to persist OpenCV moderation summaries, but the Prisma schema lacked the `moderationSummary` field on `ModelAsset`, leaving generated clients unaware of the column and blocking writes at runtime.
 - **Changes**: Declared the `moderationSummary` JSON column on the `ModelAsset` model inside `backend/prisma/schema.prisma` and reformatted the schema with `npx prisma format` so Prisma Client exposes the field to the upload pipeline.
 
+## 219 – [Fix] Image moderation summary include correction
+- **Type**: Emergency Change
+- **Reason**: The backend crashed on startup because `prisma.imageAsset.findMany` attempted to include the scalar `moderationSummary` field as a relation, triggering a PrismaClientValidationError.
+- **Changes**: Updated `backend/src/routes/assets.ts` to stop including `moderationSummary` via `buildImageInclude`, allowing Prisma to hydrate the scalar field without throwing during image queries.
+
 

--- a/backend/src/routes/assets.ts
+++ b/backend/src/routes/assets.ts
@@ -73,7 +73,6 @@ const buildImageInclude = (viewerId?: string | null) => ({
   owner: { select: { id: true, displayName: true, email: true } },
   flaggedBy: { select: { id: true, displayName: true, email: true } },
   _count: { select: { likes: true } },
-  moderationSummary: true,
   ...(viewerId
     ? {
         likes: {


### PR DESCRIPTION
## Summary
- remove the invalid `moderationSummary` include from the shared image include helper so Prisma can hydrate the scalar field without error
- log the emergency bug fix in the changelog

## Testing
- npm run lint *(fails: existing TypeScript errors about missing moderation helpers and types, plus missing `sharp` typings)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fa9770488333a7b08ece18855d64