### PR TITLE
Add admin-routed Prisma Studio access

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 038 – [Standard Change] Prisma Studio service proxy
+- **Type**: Standard Change
+- **Reason**: Provide administrators with persistent database tooling without exposing the default Prisma Studio port or bypassing existing authentication flows.
+- **Change**: Launched Prisma Studio alongside the dev stack, proxied it through `/db` with admin-only JWT validation and HttpOnly session cookies, surfaced an admin sidebar shortcut, routed `/db` through the dev proxy, documented the workflow, and ensured logout clears the Studio session.
+
 ## 037 – [Standard Change] NSFW moderation workspace integration
 - **Type**: Standard Change
 - **Reason**: Align the admin moderation experience with the structured NSFW verdicts now produced by the backend so moderators can act on the new signals without conflicting UI patterns.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ VisionSuit is a self-hosted platform for curated AI image galleries and LoRA saf
 ## Good to Know
 
 - Sticky shell layout with live service badges, trust metrics, and call-to-action panels for a polished product look including toast notifications for upload events.
+- Embedded Prisma Studio lives behind the `/db` route—`./dev-start.sh` boots it on port 5555, the frontend proxies access through the sidebar button, and only authenticated administrators can open a session (backed by a short-lived HttpOnly cookie).
 - Ship the MobileNet-based `models/nude_vs_swimwear.onnx` (or update its path in `config/nsfw-image-analysis.json`) before running the NSFW analyzer; when the file is missing the backend logs a warning and falls back to heuristics only.
 - Guests can browse public assets, while downloads, comments, and reactions require a signed-in account (USER role or higher). Adult-tagged models and renders stay hidden from guests and from members who leave the NSFW toggle off (default) in their account settings.
 - Administrators can disable self-service signups at any time; the **Create account** control stays visible but disabled so visitors immediately understand that registrations are closed while credentialed users continue signing in.
@@ -204,8 +205,11 @@ Default ports:
 
 - Backend: `4000` (override with `BACKEND_PORT`)
 - Front end: `5173` (override with `FRONTEND_PORT`)
+- Prisma Studio: `5555` (override with `PRISMA_STUDIO_PORT`; routed through `/db` for signed-in administrators)
 
 > Tip: Always point `HOST` to a reachable address (e.g., `HOST=192.168.1.50 ./dev-start.sh`) when accessing services from other devices or containers.
+
+When the stack is running, administrators can open Prisma Studio directly from the sidebar button (or by visiting `/db` with an access token). The backend mints a short-lived HttpOnly cookie scoped to `/db` so subsequent asset requests load without leaking tokens in the URL, and signing out clears that cookie via `POST /db/logout`.
 
 ## Bulk Import Utilities
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -900,6 +900,12 @@ export const appConfig = {
   host: process.env.HOST ?? '0.0.0.0',
   port: toNumber(process.env.PORT, 4000),
   databaseUrl: process.env.DATABASE_URL ?? 'file:./dev.db',
+  prismaStudio: {
+    host: process.env.PRISMA_STUDIO_HOST?.trim() && process.env.PRISMA_STUDIO_HOST.trim().length > 0
+      ? process.env.PRISMA_STUDIO_HOST.trim()
+      : '127.0.0.1',
+    port: toNumber(process.env.PRISMA_STUDIO_PORT, 5555),
+  },
   platform: {
     siteTitle: deriveSiteTitle(),
     allowRegistration: toBoolean(process.env.ALLOW_REGISTRATION, true),

--- a/backend/src/devtools/constants.ts
+++ b/backend/src/devtools/constants.ts
@@ -1,0 +1,1 @@
+export const PRISMA_STUDIO_COOKIE_NAME = 'visionsuit_db_token';

--- a/backend/src/devtools/prismaStudioProxy.ts
+++ b/backend/src/devtools/prismaStudioProxy.ts
@@ -1,0 +1,288 @@
+import http from 'node:http';
+import type { IncomingHttpHeaders, IncomingMessage, RequestOptions } from 'node:http';
+import type { Socket } from 'node:net';
+import { pipeline } from 'node:stream/promises';
+import { URL } from 'node:url';
+
+import type { RequestHandler } from 'express';
+
+import { appConfig } from '../config';
+import { prisma } from '../lib/prisma';
+import { verifyAccessToken } from '../lib/auth';
+import { PRISMA_STUDIO_COOKIE_NAME } from './constants';
+
+type UpgradeHandler = (req: IncomingMessage, socket: Socket, head: Buffer) => Promise<boolean>;
+
+const isPrismaRequest = (url: string | undefined) => Boolean(url && url.startsWith('/db'));
+
+const sanitizeProxyPath = (originalUrl: string | undefined): string => {
+  if (!originalUrl) {
+    return '/';
+  }
+
+  if (!originalUrl.startsWith('/db')) {
+    return originalUrl;
+  }
+
+  const trimmed = originalUrl.slice(3);
+  if (trimmed.length === 0) {
+    return '/';
+  }
+
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+};
+
+const cloneHeaders = (headers: IncomingHttpHeaders) => {
+  const cloned: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'undefined') {
+      continue;
+    }
+
+    if (key.toLowerCase() === 'connection') {
+      cloned[key] = 'keep-alive';
+      continue;
+    }
+
+    if (key.toLowerCase() === 'host') {
+      cloned[key] = `${appConfig.prismaStudio.host}:${appConfig.prismaStudio.port}`;
+      continue;
+    }
+
+    cloned[key] = value;
+  }
+
+  return cloned;
+};
+
+const applyProxyResponse = async (res: Parameters<RequestHandler>[1], proxyRes: IncomingMessage) => {
+  res.status(proxyRes.statusCode ?? 500);
+  for (const [key, value] of Object.entries(proxyRes.headers)) {
+    if (typeof value === 'undefined') {
+      continue;
+    }
+
+    res.setHeader(key, value);
+  }
+
+  await pipeline(proxyRes, res);
+};
+
+const extractCookieValue = (cookieHeader: string | undefined, name: string): string | null => {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const segments = cookieHeader.split(';');
+  for (const segment of segments) {
+    const [rawName, ...rawValue] = segment.split('=');
+    if (!rawName) {
+      continue;
+    }
+
+    if (rawName.trim() !== name) {
+      continue;
+    }
+
+    const value = rawValue.join('=').trim();
+    if (!value) {
+      return null;
+    }
+
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+
+  return null;
+};
+
+const extractTokenFromHeaders = (headers: IncomingHttpHeaders): string | null => {
+  const authorization = headers['authorization'];
+  if (typeof authorization === 'string') {
+    const trimmed = authorization.trim();
+    if (trimmed.toLowerCase().startsWith('bearer ')) {
+      const token = trimmed.slice(7).trim();
+      if (token) {
+        return token;
+      }
+    }
+
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+};
+
+const extractTokenForUpgrade = (req: IncomingMessage): string | null => {
+  const headerToken = extractTokenFromHeaders(req.headers);
+  if (headerToken) {
+    return headerToken;
+  }
+
+  if (req.url) {
+    try {
+      const parsed = new URL(req.url, 'http://localhost');
+      const queryToken = parsed.searchParams.get('accessToken') ?? parsed.searchParams.get('token');
+      if (queryToken && queryToken.trim().length > 0) {
+        return queryToken.trim();
+      }
+    } catch {
+      // Ignore malformed URLs
+    }
+  }
+
+  const cookieToken = extractCookieValue(req.headers.cookie, PRISMA_STUDIO_COOKIE_NAME);
+  if (cookieToken) {
+    return cookieToken;
+  }
+
+  return null;
+};
+
+const respondWithSocketError = (socket: Socket, status: number, message: string) => {
+  const statusText = (() => {
+    switch (status) {
+      case 401:
+        return 'Unauthorized';
+      case 403:
+        return 'Forbidden';
+      case 502:
+        return 'Bad Gateway';
+      default:
+        return 'Error';
+    }
+  })();
+
+  const body = Buffer.from(message, 'utf8');
+  socket.write(
+    `HTTP/1.1 ${status} ${statusText}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n`,
+  );
+  socket.write(body);
+  socket.destroy();
+};
+
+const ensureAdminForToken = async (token: string) => {
+  const payload = verifyAccessToken(token);
+  const user = await prisma.user.findUnique({
+    where: { id: payload.sub },
+    select: { role: true, isActive: true },
+  });
+
+  if (!user || !user.isActive) {
+    throw new Error('User inactive or missing');
+  }
+
+  if (user.role !== 'ADMIN') {
+    throw new Error('Administrator privileges required');
+  }
+};
+
+export const createPrismaStudioProxy = (): RequestHandler => {
+  return async (req, res) => {
+    const targetPath = sanitizeProxyPath(req.originalUrl);
+    const requestOptions: RequestOptions = {
+      hostname: appConfig.prismaStudio.host,
+      port: appConfig.prismaStudio.port,
+      method: req.method,
+      path: targetPath,
+      headers: cloneHeaders(req.headers),
+    };
+
+    const proxyReq = http.request(requestOptions, (proxyRes) => {
+      void applyProxyResponse(res, proxyRes).catch(() => {
+        if (!res.headersSent) {
+          res.status(502).json({ message: 'Prisma Studio response failed.' });
+        }
+      });
+    });
+
+    proxyReq.on('error', (error) => {
+      if (!res.headersSent) {
+        res.status(502).json({ message: 'Prisma Studio service unavailable.', detail: String(error) });
+      } else {
+        res.end();
+      }
+    });
+
+    req.on('aborted', () => {
+      proxyReq.destroy();
+    });
+
+    if (req.readable) {
+      req.pipe(proxyReq);
+    } else {
+      proxyReq.end();
+    }
+  };
+};
+
+export const createPrismaStudioUpgradeHandler = (): UpgradeHandler => {
+  return async (req, socket, head) => {
+    if (!isPrismaRequest(req.url)) {
+      return false;
+    }
+
+    try {
+      const token = extractTokenForUpgrade(req);
+      if (!token) {
+        respondWithSocketError(socket, 401, 'Authentication token missing.');
+        return true;
+      }
+
+      await ensureAdminForToken(token);
+    } catch (error) {
+      respondWithSocketError(socket, 403, error instanceof Error ? error.message : 'Access denied.');
+      return true;
+    }
+
+    const targetPath = sanitizeProxyPath(req.url);
+    const requestOptions: RequestOptions = {
+      hostname: appConfig.prismaStudio.host,
+      port: appConfig.prismaStudio.port,
+      method: req.method ?? 'GET',
+      path: targetPath,
+      headers: cloneHeaders(req.headers),
+    };
+
+    const proxyReq = http.request(requestOptions);
+
+    proxyReq.on('upgrade', (proxyRes, proxySocket, proxyHead) => {
+      const statusLine = `HTTP/1.1 ${proxyRes.statusCode ?? 101} Switching Protocols\r\n`;
+      const headerLines = Object.entries(proxyRes.headers)
+        .flatMap(([key, value]) => {
+          if (typeof value === 'undefined') {
+            return [] as string[];
+          }
+          if (Array.isArray(value)) {
+            return value.map((entry) => `${key}: ${entry}`);
+          }
+          return [`${key}: ${value}`];
+        })
+        .join('\r\n');
+
+      socket.write(`${statusLine}${headerLines}\r\n\r\n`);
+
+      if (head && head.length > 0) {
+        proxySocket.write(head);
+      }
+      if (proxyHead && proxyHead.length > 0) {
+        socket.write(proxyHead);
+      }
+
+      proxySocket.pipe(socket);
+      socket.pipe(proxySocket);
+    });
+
+    proxyReq.on('error', () => {
+      respondWithSocketError(socket, 502, 'Failed to reach Prisma Studio service.');
+    });
+
+    proxyReq.end(head);
+    return true;
+  };
+};

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -6,13 +6,22 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOST_ADDRESS="${HOST:-0.0.0.0}"
 BACKEND_PORT="${BACKEND_PORT:-4000}"
 FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+PRISMA_STUDIO_HOST="${PRISMA_STUDIO_HOST:-127.0.0.1}"
+PRISMA_STUDIO_PORT="${PRISMA_STUDIO_PORT:-5555}"
 
 export HOST="$HOST_ADDRESS"
+
+echo "Starting Prisma Studio on ${PRISMA_STUDIO_HOST}:${PRISMA_STUDIO_PORT} (proxied at /db)" >&2
+(
+  cd "$ROOT_DIR/backend"
+  npx prisma studio --browser none --host "$PRISMA_STUDIO_HOST" --port "$PRISMA_STUDIO_PORT"
+) &
+PRISMA_STUDIO_PID=$!
 
 echo "Starting VisionSuit backend on ${HOST_ADDRESS}:${BACKEND_PORT}" >&2
 (
   cd "$ROOT_DIR/backend"
-  HOST="$HOST_ADDRESS" PORT="$BACKEND_PORT" npm run dev
+  HOST="$HOST_ADDRESS" PORT="$BACKEND_PORT" PRISMA_STUDIO_HOST="$PRISMA_STUDIO_HOST" PRISMA_STUDIO_PORT="$PRISMA_STUDIO_PORT" npm run dev
 ) &
 BACKEND_PID=$!
 
@@ -25,16 +34,18 @@ FRONTEND_PID=$!
 
 cleanup() {
   trap - INT TERM EXIT
-  for pid in "$BACKEND_PID" "$FRONTEND_PID"; do
+  for pid in "$PRISMA_STUDIO_PID" "$BACKEND_PID" "$FRONTEND_PID"; do
     if kill -0 "$pid" 2>/dev/null; then
       kill "$pid" 2>/dev/null || true
     fi
   done
+  wait "$PRISMA_STUDIO_PID" 2>/dev/null || true
   wait "$BACKEND_PID" 2>/dev/null || true
   wait "$FRONTEND_PID" 2>/dev/null || true
 }
 
 trap cleanup INT TERM EXIT
 
+wait "$PRISMA_STUDIO_PID"
 wait "$BACKEND_PID"
 wait "$FRONTEND_PID"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -164,12 +164,22 @@ const resolveApiProxy = (env: Record<string, string>) => {
     return `/${normalizedApiUrl.replace(/\/$/, '')}`
   })()
 
-  return {
+  const mappings: Record<string, ProxyOptions> = {
     [proxyKey]: {
       target: proxyTarget,
       changeOrigin: true,
-    } satisfies ProxyOptions,
+    },
   }
+
+  if (!mappings['/db']) {
+    mappings['/db'] = {
+      target: proxyTarget,
+      changeOrigin: true,
+      ws: true,
+    }
+  }
+
+  return mappings
 }
 
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
## Summary
- proxy Prisma Studio through the backend with admin-only authentication, request cookies, and websocket forwarding so it is reachable at `/db`
- launch Prisma Studio from the dev starter and proxy `/db` via the Vite dev server while preserving auth tokens in HttpOnly cookies
- surface an admin-only Prisma Studio button in the sidebar, clear its session on logout, and document the workflow in the README and changelog

## Testing
- `npm run lint` (backend) *(fails: existing TypeScript errors about missing Sharp types and moderation summary properties)*
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d80eb7fd5083339d5059825aa76fa0