### PR TITLE
Fix Prisma Studio host flag

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1317,3 +1317,8 @@
 - **Type**: Normal Change
 - **Reason**: A documentation review was requested to ensure the README accurately reflects the implemented VisionSuit features.
 - **Changes**: Documented a sanity-check report that confirms key README highlights against backend/frontend behaviour and calls out mismatches (missing trust/CTA panels and optional trigger edits) to guide future documentation or feature updates.
+
+## 222 – [Fix] Prisma Studio hostname flag correction
+- **Type**: Normal Change
+- **Reason**: Launching Prisma Studio with the outdated `--host` flag caused the CLI to abort before starting, leaving the developer database console unavailable during local server boot.
+- **Changes**: Updated `dev-start.sh` to pass the supported `--hostname` parameter so Prisma Studio binds to the requested interface without error when running the development stack helper.

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -14,7 +14,7 @@ export HOST="$HOST_ADDRESS"
 echo "Starting Prisma Studio on ${PRISMA_STUDIO_HOST}:${PRISMA_STUDIO_PORT} (proxied at /db)" >&2
 (
   cd "$ROOT_DIR/backend"
-  npx prisma studio --browser none --host "$PRISMA_STUDIO_HOST" --port "$PRISMA_STUDIO_PORT"
+  npx prisma studio --browser none --hostname "$PRISMA_STUDIO_HOST" --port "$PRISMA_STUDIO_PORT"
 ) &
 PRISMA_STUDIO_PID=$!
 


### PR DESCRIPTION
## Summary
- update the development helper script to use Prisma Studio's supported `--hostname` flag
- document the fix and its rationale in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8681ae2508333a0ad7515d9163e86