### PR TITLE
Fix Prisma Studio admin link routing

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 045 – [Standard Change] Prisma Studio admin launch alignment
+- **Type**: Standard Change
+- **Reason**: Opening Prisma Studio from the admin sidebar on split-origin deployments redirected back to the frontend homepage, preventing administrators from reaching the proxied database tool.
+- **Change**: Routed the Prisma Studio launcher through the configured API base URL and documented the behaviour so admins on separate frontend/backend hosts land on the `/db` proxy without manual URL tweaks.
+
 ## 044 – [Standard Change] Curator visibility moderation hardening
 - **Type**: Standard Change
 - **Reason**: Restore curator-facing visibility controls while ensuring flagged assets remain private until moderation approval.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Default ports:
 
 > Tip: Always point `HOST` to a reachable address (e.g., `HOST=192.168.1.50 ./dev-start.sh`) when accessing services from other devices or containers.
 
-When the stack is running, administrators can open Prisma Studio directly from the sidebar button (or by visiting `/db` with an access token). The backend mints a short-lived HttpOnly cookie scoped to `/db` so subsequent asset requests load without leaking tokens in the URL, and signing out clears that cookie via `POST /db/logout`.
+When the stack is running, administrators can open Prisma Studio directly from the sidebar button (or by visiting `/db` with an access token). The backend mints a short-lived HttpOnly cookie scoped to `/db` so subsequent asset requests load without leaking tokens in the URL, signing out clears that cookie via `POST /db/logout`, and the frontend now respects `VITE_API_URL` when launching Studio so deployments with split origins still land on the proxied backend endpoint.
 
 ## Bulk Import Utilities
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import { api } from './lib/api';
 import { useAuth } from './lib/auth';
 import { resolveCachedStorageUrl } from './lib/storage';
 import { isAuditHiddenFromViewer, isAuditPlaceholderForViewer } from './lib/moderation';
-import { defaultSiteTitle } from './config';
+import { buildApiUrl, defaultSiteTitle } from './config';
 import type {
   Gallery,
   GeneratorSettings,
@@ -742,7 +742,7 @@ export const App = () => {
       return;
     }
 
-    const studioUrl = `/db?accessToken=${encodeURIComponent(token)}`;
+    const studioUrl = buildApiUrl(`/db?accessToken=${encodeURIComponent(token)}`);
     const popup = window.open(studioUrl, '_blank', 'noopener');
     if (!popup) {
       setToast({


### PR DESCRIPTION
## Summary
- update the Prisma Studio launcher to build its URL with the configured API base so split-origin deployments reach the backend proxy
- document the corrected behaviour and log the change for administrators

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8e3d3a81c8333aa6abc5a59bb25f2