### PR TITLE
Fix Hugging Face redirect handling for auto tagger

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1342,3 +1342,8 @@
 - **Type**: Normal Change
 - **Reason**: Prompt-free renders skipped NSFW screening because the moderation workflow relies on textual cues that were missing from those uploads.
 - **Changes**: Added a CPU-backed SmilingWolf/wd-swinv2 tagger that downloads on startup when absent, queued promptless gallery uploads behind a “Scan in Progress” placeholder until tagging and moderation complete, persisted scan status and auto-tag summaries in Prisma, exposed the state via the API and front end, and refreshed the README to document the workflow.
+
+## 224 – [Fix] Hugging Face redirect handling
+- **Type**: Emergency Change
+- **Reason**: The backend failed to start because Hugging Face returned relative redirect URLs for the auto tagger assets, causing the download helper to throw an invalid URL error and abort initialization.
+- **Changes**: Updated `backend/src/lib/tagging/wdSwinv2.ts` to resolve relative redirects against the original request URL before retrying the download and to report redirect resolution failures clearly.

--- a/backend/src/lib/tagging/wdSwinv2.ts
+++ b/backend/src/lib/tagging/wdSwinv2.ts
@@ -73,7 +73,20 @@ const downloadFile = async (url: string, targetPath: string): Promise<void> => {
       const redirectedLocation = response.headers.location;
       if (response.statusCode >= 300 && response.statusCode < 400 && redirectedLocation) {
         response.resume();
-        downloadFile(redirectedLocation, targetPath).then(resolve).catch(reject);
+        const redirectedUrl = (() => {
+          try {
+            return new URL(redirectedLocation, url).toString();
+          } catch (error) {
+            reject(new Error(`Failed to resolve redirect for ${url}: ${(error as Error).message}`));
+            return null;
+          }
+        })();
+
+        if (!redirectedUrl) {
+          return;
+        }
+
+        downloadFile(redirectedUrl, targetPath).then(resolve).catch(reject);
         return;
       }
 


### PR DESCRIPTION
## Summary
- resolve relative redirect URLs when downloading the SmilingWolf auto tagger assets so initialization no longer fails on relative redirects
- document the emergency fix in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d92eadeb808333851b428a2d8be93a