### PR TITLE
Fix Hugging Face auto tagger download redirect handling

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 047 – [Standard Change] Hugging Face auto-tagger download hardening
+- **Type**: Standard Change
+- **Reason**: Backend startup failed after Hugging Face redirects left no temp file to rename and operators could not confirm the download status from the console output.
+- **Change**: Taught the downloader to follow redirects without double-renaming, cleared stale temp artifacts, surfaced `[startup]` download logs, and refreshed the README so the first-boot Hugging Face fetch is clearly communicated.
+
 ## 046 – [Standard Change] README refresh & technical doc relocation
 - **Type**: Standard Change
 - **Reason**: The README had become cluttered with extensive technical detail, making it difficult to quickly understand the platform while keeping documentation consistent.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
    ```bash
    ./dev-start.sh
    ```
+   The backend will automatically download the SmilingWolf auto-tagging assets on first launch and prints `[startup] Downloading ...` messages so you can track progress in the console.
 3. **Seed and explore** – The backend ships with Prisma seed data. Visit the frontend URL shown in the terminal output and sign in with the seeded administrator account to configure services.
 
 For production deployments, review storage credentials, JWT secrets, GPU agent endpoints, and generator bucket provisioning before exposing the stack.


### PR DESCRIPTION
## Summary
- harden the wd-swinv2 downloader so redirect responses no longer trigger a missing temp file rename
- surface `[startup]` logs around Hugging Face asset downloads and clean stale `.download` artifacts
- document the first-boot download messaging in the README and ChangeLog

## Testing
- npm run lint *(fails: missing local Node type definitions because dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d92fa47d788333b1823bbcd67f160e