### PR TITLE
Fix Prisma migration for moderation summary on SQLite

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1367,3 +1367,8 @@
 - **Type**: Normal Change
 - **Reason**: Falling back to the WebAssembly runtime hid missing native dependencies and left the wd-swinv2 tagger without the expected CPU execution provider.
 - **Changes**: Locate the installed `onnxruntime-node` native backend automatically, fail fast when the CPU provider is still missing, remove the WebAssembly dependency, and refresh the README with instructions for reinstalling or pointing `ORT_BACKEND_PATH` at the native binaries.
+
+## 226 – [Fix] Prisma migration shadow database rebuild
+- **Type**: Normal Change
+- **Reason**: Fresh installations failed because the `add_moderation_summary` migration attempted to add existing columns to the SQLite shadow database, producing duplicate-column errors during `prisma migrate`.
+- **Changes**: Rebuilt the Prisma migration to recreate the `ModelAsset`, `ModelVersion`, and `ImageAsset` tables with moderation summary and tagging metadata columns so SQLite resets and deploys succeed without conflicts.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,20 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
    ```bash
    ./install.sh
    ```
-2. **Start the development stack**
+2. **Configure environment variables**
+   Copy the sample backend `.env` file and ensure Prisma has a SQLite connection string before running CLI commands:
+   ```bash
+   cp backend/.env.example backend/.env
+   export DATABASE_URL="file:./dev.db"
+   ```
+   The development helper scripts load `.env`, and exporting `DATABASE_URL` keeps standalone Prisma tasks such as `npx prisma migrate reset` from failing on a fresh installation.
+3. **Start the development stack**
    ```bash
    ./dev-start.sh
    ```
    The backend will automatically download the SmilingWolf auto-tagging assets on first launch and prints `[startup] Downloading ...` messages so you can track progress in the console.
    Ensure the host can load the native ONNX Runtime CPU backend. If startup reports the backend is missing, reinstall the dependency with `npm --prefix backend rebuild onnxruntime-node` or set `ORT_BACKEND_PATH` to the directory that contains the native bindings.
-3. **Seed and explore** – The backend ships with Prisma seed data. Visit the frontend URL shown in the terminal output and sign in with the seeded administrator account to configure services.
+4. **Seed and explore** – The backend ships with Prisma seed data. Visit the frontend URL shown in the terminal output and sign in with the seeded administrator account to configure services.
 
 For production deployments, review storage credentials, JWT secrets, GPU agent endpoints, and generator bucket provisioning before exposing the stack.
 

--- a/backend/prisma/migrations/20251001120000_add_moderation_summary/migration.sql
+++ b/backend/prisma/migrations/20251001120000_add_moderation_summary/migration.sql
@@ -1,2 +1,211 @@
-ALTER TABLE "ModelAsset" ADD COLUMN "moderationSummary" JSONB;
-ALTER TABLE "ImageAsset" ADD COLUMN "moderationSummary" JSONB;
+-- RedefineTables to add moderation summary metadata to assets and versions
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_ModelAsset" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "trigger" TEXT,
+    "version" TEXT NOT NULL,
+    "fileSize" INTEGER,
+    "checksum" TEXT,
+    "storagePath" TEXT NOT NULL,
+    "previewImage" TEXT,
+    "metadata" JSONB,
+    "moderationSummary" JSONB,
+    "isPublic" BOOLEAN NOT NULL DEFAULT true,
+    "isAdult" BOOLEAN NOT NULL DEFAULT false,
+    "ownerId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "moderationStatus" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "flaggedAt" DATETIME,
+    "flaggedById" TEXT,
+    CONSTRAINT "ModelAsset_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ModelAsset_flaggedById_fkey" FOREIGN KEY ("flaggedById") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+INSERT INTO "new_ModelAsset" (
+    "checksum",
+    "createdAt",
+    "description",
+    "fileSize",
+    "flaggedAt",
+    "flaggedById",
+    "id",
+    "isAdult",
+    "isPublic",
+    "metadata",
+    "moderationStatus",
+    "ownerId",
+    "previewImage",
+    "slug",
+    "storagePath",
+    "title",
+    "trigger",
+    "updatedAt",
+    "version"
+)
+SELECT
+    "checksum",
+    "createdAt",
+    "description",
+    "fileSize",
+    "flaggedAt",
+    "flaggedById",
+    "id",
+    "isAdult",
+    "isPublic",
+    "metadata",
+    "moderationStatus",
+    "ownerId",
+    "previewImage",
+    "slug",
+    "storagePath",
+    "title",
+    "trigger",
+    "updatedAt",
+    "version"
+FROM "ModelAsset";
+
+DROP TABLE "ModelAsset";
+ALTER TABLE "new_ModelAsset" RENAME TO "ModelAsset";
+CREATE UNIQUE INDEX "ModelAsset_slug_key" ON "ModelAsset"("slug");
+CREATE UNIQUE INDEX "ModelAsset_storagePath_key" ON "ModelAsset"("storagePath");
+
+CREATE TABLE "new_ModelVersion" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "modelId" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "storagePath" TEXT NOT NULL,
+    "previewImage" TEXT,
+    "metadata" JSONB,
+    "moderationSummary" JSONB,
+    "fileSize" INTEGER,
+    "checksum" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ModelVersion_modelId_fkey" FOREIGN KEY ("modelId") REFERENCES "ModelAsset" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+INSERT INTO "new_ModelVersion" (
+    "checksum",
+    "createdAt",
+    "fileSize",
+    "id",
+    "metadata",
+    "modelId",
+    "previewImage",
+    "storagePath",
+    "updatedAt",
+    "version"
+)
+SELECT
+    "checksum",
+    "createdAt",
+    "fileSize",
+    "id",
+    "metadata",
+    "modelId",
+    "previewImage",
+    "storagePath",
+    "updatedAt",
+    "version"
+FROM "ModelVersion";
+
+DROP TABLE "ModelVersion";
+ALTER TABLE "new_ModelVersion" RENAME TO "ModelVersion";
+CREATE UNIQUE INDEX "ModelVersion_storagePath_key" ON "ModelVersion"("storagePath");
+CREATE UNIQUE INDEX "ModelVersion_modelId_version_key" ON "ModelVersion"("modelId", "version");
+
+CREATE TABLE "new_ImageAsset" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "width" INTEGER,
+    "height" INTEGER,
+    "fileSize" INTEGER,
+    "storagePath" TEXT NOT NULL,
+    "prompt" TEXT,
+    "negativePrompt" TEXT,
+    "seed" TEXT,
+    "model" TEXT,
+    "sampler" TEXT,
+    "cfgScale" REAL,
+    "steps" INTEGER,
+    "moderationSummary" JSONB,
+    "autoTagSummary" JSONB,
+    "isPublic" BOOLEAN NOT NULL DEFAULT true,
+    "isAdult" BOOLEAN NOT NULL DEFAULT false,
+    "tagScanPending" BOOLEAN NOT NULL DEFAULT false,
+    "tagScanStatus" TEXT NOT NULL DEFAULT 'idle',
+    "tagScanQueuedAt" DATETIME,
+    "tagScanCompletedAt" DATETIME,
+    "tagScanError" TEXT,
+    "ownerId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "moderationStatus" TEXT NOT NULL DEFAULT 'ACTIVE',
+    "flaggedAt" DATETIME,
+    "flaggedById" TEXT,
+    CONSTRAINT "ImageAsset_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "ImageAsset_flaggedById_fkey" FOREIGN KEY ("flaggedById") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+INSERT INTO "new_ImageAsset" (
+    "cfgScale",
+    "createdAt",
+    "description",
+    "fileSize",
+    "flaggedAt",
+    "flaggedById",
+    "height",
+    "id",
+    "isAdult",
+    "isPublic",
+    "model",
+    "moderationStatus",
+    "negativePrompt",
+    "ownerId",
+    "prompt",
+    "sampler",
+    "seed",
+    "steps",
+    "storagePath",
+    "title",
+    "updatedAt",
+    "width"
+)
+SELECT
+    "cfgScale",
+    "createdAt",
+    "description",
+    "fileSize",
+    "flaggedAt",
+    "flaggedById",
+    "height",
+    "id",
+    "isAdult",
+    "isPublic",
+    "model",
+    "moderationStatus",
+    "negativePrompt",
+    "ownerId",
+    "prompt",
+    "sampler",
+    "seed",
+    "steps",
+    "storagePath",
+    "title",
+    "updatedAt",
+    "width"
+FROM "ImageAsset";
+
+DROP TABLE "ImageAsset";
+ALTER TABLE "new_ImageAsset" RENAME TO "ImageAsset";
+CREATE UNIQUE INDEX "ImageAsset_storagePath_key" ON "ImageAsset"("storagePath");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;


### PR DESCRIPTION
## Summary
- rebuild the moderation summary migration so SQLite installs recreate ModelAsset, ModelVersion, and ImageAsset with the new metadata columns without collisions
- document the required DATABASE_URL setup in the README to keep Prisma commands working on new environments
- record the migration fix in the changelog

## Testing
- DATABASE_URL="file:./dev.db" npx prisma migrate reset --force

------
https://chatgpt.com/codex/tasks/task_e_68d9375fa2ec8333a856d7d887bc598f