### PR TITLE
Implement paginated asset loading

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 050 – [Standard Change] Paginated asset explorers
+- **Type**: Standard Change
+- **Reason**: Loading every model and image on initial dashboard visits slowed the UI and risked timeouts once the catalog grew.
+- **Change**: Added cursor-aware pagination and metadata to the asset APIs, taught the frontend to request incremental windows with load-more controls, refreshed the README to highlight the streaming behaviour, and covered moderation/adult filters with regression tests.
+
 ## 049 – [Standard Change] Windows bulk uploader stream guard
 - **Type**: Standard Change
 - **Reason**: The Windows bulk importer intermittently crashed with `Error while copying content to a stream`, leaving operators without insight into the failing file or HTTP transport issue.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
 - Persistent operations dashboard with curator spotlights, live queue status, and quick actions for uploads, moderation, and generator runs.
 - Member registration with reactions, comments, and private upload visibility for curators while administrators retain full inventory insight.
 - Spotlight profiles, gallery explorers with infinite scroll, intelligent caching, and account settings that keep avatars and bios in sync.
+- Model and image explorers fetch paginated windows with seamless “load more” controls so initial visits stay lightweight while deeper dives remain responsive.
 
 ## Quick Start
 

--- a/backend/test/assetsPagination.test.ts
+++ b/backend/test/assetsPagination.test.ts
@@ -1,0 +1,171 @@
+import { strict as assert } from 'node:assert';
+import type { Request, Response, NextFunction } from 'express';
+import test from 'node:test';
+import { ModerationStatus, type Prisma } from '@prisma/client';
+
+import { assetsRouter } from '../src/routes/assets';
+import { prisma } from '../src/lib/prisma';
+
+const originalModelFindMany = prisma.modelAsset.findMany;
+const originalImageFindMany = prisma.imageAsset.findMany;
+
+const getRouteHandler = (path: string) => {
+  const layer = (assetsRouter as unknown as { stack: unknown[] }).stack.find((entry: unknown) => {
+    const candidate = entry as { route?: { path?: string; methods?: Record<string, boolean>; stack: { handle: unknown }[] } };
+    return candidate.route?.path === path && Boolean(candidate.route?.methods?.get);
+  }) as { route?: { stack: { handle: unknown }[] } } | undefined;
+
+  if (!layer?.route?.stack?.[0]?.handle) {
+    throw new Error(`Route handler for ${path} not found`);
+  }
+
+  return layer.route.stack[0].handle as (req: Request, res: Response, next: NextFunction) => unknown;
+};
+
+const createResponse = () => {
+  let payload: unknown;
+  const res = {
+    json: (value: unknown) => {
+      payload = value;
+      return res;
+    },
+  } as unknown as Response;
+
+  return {
+    res,
+    getPayload: () => payload,
+  };
+};
+
+test.after(() => {
+  prisma.modelAsset.findMany = originalModelFindMany;
+  prisma.imageAsset.findMany = originalImageFindMany;
+});
+
+test('models listing keeps adult filters and paginates results', async () => {
+  let capturedArgs: Prisma.ModelAssetFindManyArgs | null = null;
+
+  prisma.modelAsset.findMany = (async (args) => {
+    capturedArgs = args;
+    return [];
+  }) as typeof prisma.modelAsset.findMany;
+
+  const handler = getRouteHandler('/models');
+  const request = { query: {}, user: undefined } as unknown as Request;
+  const { res, getPayload } = createResponse();
+
+  await handler(request, res, (error?: unknown) => {
+    if (error) {
+      throw error;
+    }
+  });
+
+  assert.ok(capturedArgs);
+  assert.equal(capturedArgs?.take, 25);
+  assert.deepEqual(capturedArgs?.orderBy, [
+    { createdAt: 'desc' },
+    { id: 'desc' },
+  ]);
+  const where = capturedArgs?.where as Prisma.ModelAssetWhereInput;
+  assert.ok(where);
+  assert.ok(Array.isArray(where.AND));
+  assert.deepEqual(where.AND?.[0], {
+    isPublic: true,
+    moderationStatus: ModerationStatus.ACTIVE,
+  });
+  assert.deepEqual(where.AND?.[1], { isAdult: false });
+
+  assert.deepEqual(getPayload(), { items: [], nextCursor: null, hasMore: false });
+});
+
+test('image listing applies viewer adult visibility and surfaces next cursor', async () => {
+  let capturedArgs: Prisma.ImageAssetFindManyArgs | null = null;
+
+  prisma.imageAsset.findMany = (async (args) => {
+    capturedArgs = args;
+    const count = args.take ?? 0;
+    return Array.from({ length: count }, (_value, index) => ({
+      id: `image-${index + 1}`,
+      title: `Image ${index + 1}`,
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ownerId: 'viewer-1',
+      owner: { id: 'viewer-1', displayName: 'Viewer', email: 'viewer@example.com' },
+      flaggedAt: null,
+      flaggedById: null,
+      flaggedBy: null,
+      fileSize: 0,
+      height: null,
+      width: null,
+      seed: null,
+      model: null,
+      sampler: null,
+      cfgScale: null,
+      steps: null,
+      prompt: null,
+      negativePrompt: null,
+      storagePath: 'local/test',
+      storageBucket: null,
+      storageObject: null,
+      storageProvider: null,
+      isAdult: false,
+      isPublic: true,
+      moderationStatus: ModerationStatus.ACTIVE,
+      tagScanPending: false,
+      tagScanStatus: null,
+      metadata: null,
+      moderationSummary: null,
+      moderationReports: [],
+      tags: [],
+      likes: [],
+      _count: { likes: 0 },
+    }));
+  }) as typeof prisma.imageAsset.findMany;
+
+  const handler = getRouteHandler('/images');
+  const request = {
+    query: { cursor: 'image-0', take: '2' },
+    user: {
+      id: 'viewer-1',
+      email: 'viewer@example.com',
+      displayName: 'Viewer',
+      role: 'USER',
+      showAdultContent: false,
+    },
+  } as unknown as Request;
+  const { res, getPayload } = createResponse();
+
+  await handler(request, res, (error?: unknown) => {
+    if (error) {
+      throw error;
+    }
+  });
+
+  assert.ok(capturedArgs);
+  assert.equal(capturedArgs?.take, 3);
+  assert.deepEqual(capturedArgs?.cursor, { id: 'image-0' });
+  assert.equal(capturedArgs?.skip, 1);
+  const where = capturedArgs?.where as Prisma.ImageAssetWhereInput;
+  assert.ok(where);
+  assert.ok(Array.isArray(where.AND));
+  assert.deepEqual(where.AND?.[0], {
+    OR: [
+      { ownerId: 'viewer-1' },
+      {
+        AND: [
+          { isPublic: true },
+          { moderationStatus: ModerationStatus.ACTIVE },
+        ],
+      },
+    ],
+  });
+  assert.deepEqual(where.AND?.[1], {
+    OR: [{ isAdult: false }, { ownerId: 'viewer-1' }],
+  });
+
+  const payload = getPayload() as { items: { id: string }[]; nextCursor: string | null; hasMore: boolean };
+  assert.equal(payload.items.length, 2);
+  assert.equal(payload.hasMore, true);
+  assert.equal(payload.nextCursor, 'image-2');
+});


### PR DESCRIPTION
## Summary
- add cursor-based pagination to the asset routes and return window metadata to clients
- update the frontend API client, app state, and model explorer to request incremental slices with load-more fallbacks
- cover moderation/adult filtering with pagination-focused tests and document the change in the README and changelog

## Testing
- npm --prefix backend test *(fails: missing ts-node/register because dependencies cannot be installed in the sandboxed environment)*
- npm --prefix frontend run build *(fails: existing TypeScript issues in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d93c7ae5b0833381d0a59055a4722b