### PR TITLE
Gracefully handle missing ONNX runtime backend

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 052 – [Normal Change] Auto tagger graceful degradation
+- **Type**: Normal Change
+- **Reason**: Hosts running Node.js versions without matching `onnxruntime-node` binaries caused the CPU execution provider check to fail, blocking the entire backend from starting.
+- **Change**: Allowed startup to continue when the ONNX backend is unavailable, record failed auto-tagging jobs with clear `tagScanError` messages, surfaced console warnings for skipped queues, and refreshed the README with recovery guidance.
+
 ## 051 – [Standard Change] ONNX CPU provider detection hardening
 - **Type**: Standard Change
 - **Reason**: Hosts with `onnxruntime-node` v1.23 reported the CPU execution provider as `CPUExecutionProvider`, causing startup to abort even though the native backend binaries were present.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
    ./dev-start.sh
    ```
    The backend will automatically download the SmilingWolf auto-tagging assets on first launch and prints `[startup] Downloading ...` messages so you can track progress in the console.
-   Ensure the host can load the native ONNX Runtime CPU backend. Startup now recognises both `CPUExecutionProvider` and `cpuExecutionProvider` so mismatched casing between releases no longer blocks the tagger. If detection still fails, reinstall the dependency with `npm --prefix backend rebuild onnxruntime-node` or set `ORT_BACKEND_PATH` to the directory that contains the native bindings.
+   VisionSuit now degrades gracefully if the native ONNX Runtime CPU backend cannot be loaded (for example, when `onnxruntime-node` does not provide binaries for the installed Node.js version). Startup logs `[startup] Auto tagger disabled` and continues serving requests, while affected uploads remain flagged with a descriptive `tagScanError`. Reinstall the dependency with `npm --prefix backend rebuild onnxruntime-node`, align the Node.js version with the published binaries, or set `ORT_BACKEND_PATH` to the directory that contains the native bindings to restore automatic tagging.
 4. **Seed and explore** – The backend ships with Prisma seed data. Visit the frontend URL shown in the terminal output and sign in with the seeded administrator account to configure services.
 
 For production deployments, review storage credentials, JWT secrets, GPU agent endpoints, and generator bucket provisioning before exposing the stack.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,12 +7,10 @@ import { initializeAutoTagger } from './lib/tagging/service';
 import './types/express';
 
 const start = async () => {
-  try {
-    await initializeAutoTagger();
-  } catch (error) {
+  const autoTaggerInitialized = await initializeAutoTagger();
+  if (!autoTaggerInitialized) {
     // eslint-disable-next-line no-console
-    console.error('[startup] Failed to initialize auto tagger:', error);
-    process.exit(1);
+    console.warn('[startup] Continuing without automatic tagging support.');
   }
 
   try {


### PR DESCRIPTION
## Summary
- allow the backend to continue starting when the ONNX Runtime CPU provider cannot initialize
- record skipped auto-tagging jobs with clear failures and warn in the logs so operators see why uploads stay flagged
- refresh the README and changelog with the new graceful-degradation flow and recovery guidance

## Testing
- not run (dependencies unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d94cf1280c8333a7c7a4ad078281f9