### PR TITLE
Add floating support footer menu

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1387,3 +1387,8 @@
 - **Type**: Normal Change
 - **Reason**: Fresh installations failed because the `add_moderation_summary` migration attempted to add existing columns to the SQLite shadow database, producing duplicate-column errors during `prisma migrate`.
 - **Changes**: Rebuilt the Prisma migration to recreate the `ModelAsset`, `ModelVersion`, and `ImageAsset` tables with moderation summary and tagging metadata columns so SQLite resets and deploys succeed without conflicts.
+
+## 227 – [Update] Floating support footer menu
+- **Type**: Normal Change
+- **Reason**: The support footer needed to stay accessible without occupying space while browsing, prompting a request for a scroll-aware menu bar with icon-based support links.
+- **Changes**: Converted the footer into a floating bar that hides on downward scroll and appears when scrolling up, swapped Discord and GitHub links for icon buttons, condensed the VisionSuit Support and credits text, and added a placeholder Service Status link within the new layout.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,6 +9,40 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+@media (max-width: 540px) {
+  .footer {
+    gap: 0.75rem;
+  }
+
+  .footer__icons {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .footer__meta-group {
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .footer__status-link {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .footer {
+    transition: none;
+  }
+
+  .footer__icon-link,
+  .footer__status-link {
+    transition: none;
+  }
+}
+
 body {
   margin: 0;
   min-height: 100vh;
@@ -507,7 +541,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  padding: 3rem 4rem;
+  padding: 3rem 4rem 7rem;
 }
 
 .content__header {
@@ -3512,7 +3546,7 @@ body {
 
 @media (max-width: 720px) {
   .content__inner {
-    padding: 2.5rem 1.75rem 3rem;
+    padding: 2.5rem 1.75rem 6rem;
   }
 
   .image-gallery__grid {
@@ -3911,44 +3945,129 @@ main {
 }
 
 .footer {
-  margin-top: 2rem;
-  padding: 2.5rem 2rem;
-  border-radius: 24px;
-  background: rgba(15, 23, 42, 0.72);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
+  position: fixed;
+  left: 50%;
+  bottom: 2rem;
+  transform: translate(-50%, 0);
+  display: flex;
   align-items: center;
-}
-
-.footer__title {
-  font-weight: 600;
-  font-size: 1.2rem;
-  color: #f8fafc;
-}
-
-.footer__links {
-  display: flex;
-  gap: 1.2rem;
   flex-wrap: wrap;
+  gap: 1.25rem;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.5);
+  max-width: min(960px, calc(100% - 2rem));
+  width: fit-content;
+  opacity: 1;
+  transition: transform 0.35s ease, opacity 0.35s ease;
+  z-index: 30;
 }
 
-.footer__links a {
-  color: rgba(226, 232, 240, 0.78);
-  text-decoration: none;
+.footer--hidden {
+  opacity: 0;
+  transform: translate(-50%, calc(100% + 2.5rem));
+  pointer-events: none;
 }
 
-.footer__links a:hover,
-.footer__links a:focus-visible {
+.footer--visible {
+  opacity: 1;
+}
+
+.footer__label {
+  font-weight: 600;
+  font-size: 1rem;
   color: #f8fafc;
 }
 
-.footer__status {
+.footer__icons {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.footer__icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(30, 41, 59, 0.65);
   color: rgba(226, 232, 240, 0.85);
+  text-decoration: none;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.footer__icon-link:hover,
+.footer__icon-link:focus-visible {
+  color: #f8fafc;
+  background: rgba(59, 130, 246, 0.35);
+  border-color: rgba(96, 165, 250, 0.4);
+  transform: translateY(-1px);
+}
+
+.footer__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: currentColor;
+}
+
+.footer__meta-group {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.95rem;
+}
+
+.footer__meta-group a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-decoration-color: rgba(148, 163, 184, 0.65);
+}
+
+.footer__meta-group a:hover,
+.footer__meta-group a:focus-visible {
+  color: #f8fafc;
+  text-decoration-color: #f8fafc;
+}
+
+.footer__status-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  background: rgba(30, 41, 59, 0.55);
+  color: rgba(125, 211, 252, 0.9);
+  text-decoration: none;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.footer__status-link:hover,
+.footer__status-link:focus-visible {
+  color: #f0f9ff;
+  border-color: rgba(56, 189, 248, 0.5);
+  background: rgba(14, 165, 233, 0.25);
+  transform: translateY(-1px);
+}
+
+.footer__status-link[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.9;
+}
+
+.footer__status-link[aria-disabled='true']:hover,
+.footer__status-link[aria-disabled='true']:focus-visible {
+  transform: none;
 }
 
 .panel--accent {
@@ -7357,8 +7476,26 @@ button {
   }
 
   .footer {
-    grid-template-columns: 1fr;
-    text-align: left;
+    bottom: 1rem;
+    padding: 0.75rem 1.25rem;
+    gap: 0.9rem;
+    max-width: calc(100% - 1.5rem);
+  }
+
+  .footer__label {
+    flex-basis: 100%;
+  }
+
+  .footer__meta-group {
+    margin-left: 0;
+    width: 100%;
+    justify-content: space-between;
+    gap: 0.6rem;
+    font-size: 0.9rem;
+  }
+
+  .footer__status-link {
+    padding: 0.35rem 0.75rem;
   }
 
   .process__timeline {


### PR DESCRIPTION
## Summary
- replace the static support footer with a floating bar that appears when scrolling up, complete with Discord and GitHub icon links plus a Service Status placeholder
- refresh global footer styling to support the new behavior, update padding to keep content clear of the floating menu, and extend responsive tweaks
- document the change in the changelog as a Normal Change entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d94fe640348333bc9c9db1cd14aab9