### PR TITLE
Create dedicated service status view and footer indicators

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 053 – [Standard Change] Dedicated service status page rollout
+- **Type**: Standard Change
+- **Reason**: The dashboard and sidebar were crowded by the embedded service status widgets, making it harder to surface uptime details in a focused way.
+- **Change**: Introduced a standalone service status view accessible from the footer, added compact LED indicators to the footer link, removed the sidebar and home dashboard widgets, refreshed styles, and updated the README to reflect the new navigation.
+
 ## 052 – [Normal Change] Auto tagger graceful degradation
 - **Type**: Normal Change
 - **Reason**: Hosts running Node.js versions without matching `onnxruntime-node` binaries caused the CPU execution provider check to fail, blocking the entire backend from starting.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
 ## Core Features
 
 ### Operations & Governance
-- Unified administrator workspace with service health, environment alignment, and `.env` synchronization for frontend and backend settings.
+- Unified administrator workspace with environment alignment, `.env` synchronization for frontend and backend settings, and a dedicated service status page accessible from the footer.
 - Role-aware access control backed by JWT authentication, admin onboarding flows, and guarded upload paths for curators.
 - Configurable registration policies, maintenance modes, and guided restart prompts for safe rollouts.
 

--- a/frontend/src/components/ServiceStatusPage.tsx
+++ b/frontend/src/components/ServiceStatusPage.tsx
@@ -1,0 +1,88 @@
+import type { FC } from 'react';
+
+import type { ServiceIndicator, ServiceState, ServiceStatusKey } from '../types/serviceStatus';
+
+interface ServiceStatusPageProps {
+  services: Array<{
+    key: ServiceStatusKey;
+    badge: string;
+    indicator: ServiceIndicator;
+  }>;
+  statusLabels: Record<ServiceState, string>;
+  onBack: () => void;
+}
+
+export const ServiceStatusPage: FC<ServiceStatusPageProps> = ({ services, statusLabels, onBack }) => {
+  const healthyServices = services.filter(({ indicator }) => indicator.status === 'online').length;
+  const affectedServices = services.filter(({ indicator }) =>
+    indicator.status === 'degraded' || indicator.status === 'unknown'
+  ).length;
+  const offlineServices = services.filter(({ indicator }) => indicator.status === 'offline').length;
+
+  return (
+    <div className="status-page">
+      <header className="status-page__header">
+        <button type="button" className="status-page__back" onClick={onBack}>
+          ← Back to dashboard
+        </button>
+        <div>
+          <h2>Live service status</h2>
+          <p>
+            Real-time health for the VisionSuit interface, API, asset storage, and GPU worker. Status checks refresh in the
+            background while you browse.
+          </p>
+        </div>
+      </header>
+
+      <section className="status-page__overview" aria-label="Status summary">
+        <div className="status-page__metric">
+          <span className="status-page__metric-label">Online</span>
+          <span className="status-page__metric-value">{healthyServices}</span>
+          <span className="status-page__metric-description">Services responding normally.</span>
+        </div>
+        <div className="status-page__metric">
+          <span className="status-page__metric-label">Attention</span>
+          <span className="status-page__metric-value">{affectedServices}</span>
+          <span className="status-page__metric-description">Degraded or recovering components.</span>
+        </div>
+        <div className="status-page__metric">
+          <span className="status-page__metric-label">Offline</span>
+          <span className="status-page__metric-value">{offlineServices}</span>
+          <span className="status-page__metric-description">Services requiring immediate action.</span>
+        </div>
+      </section>
+
+      <section className="status-page__services" aria-label="Service details">
+        <h3>Current status</h3>
+        <ul className="status-page__list">
+          {services.map(({ key, badge, indicator }) => (
+            <li key={key} className={`status-card status-card--${indicator.status}`}>
+              <div className="status-card__header">
+                <span className="status-card__badge">{badge}</span>
+                <div className="status-card__title-group">
+                  <span className="status-card__name">{indicator.label}</span>
+                  <span className={`status-led status-led--${indicator.status}`} aria-hidden="true" />
+                  <span className="sr-only">{statusLabels[indicator.status]}</span>
+                </div>
+              </div>
+              <p className="status-card__message">{indicator.message}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="status-page__help" aria-label="Support guidance">
+        <h3>Need support?</h3>
+        <p>
+          Visit the VisionSuit{' '}
+          <a href="https://discord.gg/UEb68YQwKR" target="_blank" rel="noreferrer noopener">
+            Discord support hub
+          </a>{' '}
+          or review the GPU worker logs to triage outages. Service updates appear here the moment health checks change state.
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default ServiceStatusPage;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,169 +140,6 @@ body {
   box-shadow: 0 18px 38px rgba(37, 99, 235, 0.3);
 }
 
-.sidebar__status {
-  display: flex;
-  flex-direction: column;
-  gap: 1.2rem;
-}
-
-.sidebar__status h2 {
-  margin: 0;
-  font-size: 0.95rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.9);
-}
-
-.sidebar__status-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
-}
-
-.sidebar__status-item {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem 1.1rem;
-  border-radius: 16px;
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.88), rgba(30, 41, 59, 0.78));
-  border: 1px solid rgba(59, 130, 246, 0.18);
-  box-shadow: 0 24px 42px rgba(15, 23, 42, 0.45);
-  backdrop-filter: blur(24px);
-  overflow: hidden;
-  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
-}
-
-.sidebar__status-item::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 90% 10%, rgba(59, 130, 246, 0.2), transparent 55%);
-  opacity: 0;
-  transition: opacity 0.25s ease;
-  pointer-events: none;
-}
-
-.sidebar__status-item:hover,
-.sidebar__status-item:focus-within {
-  transform: translateY(-2px);
-  box-shadow: 0 28px 48px rgba(15, 23, 42, 0.55);
-}
-
-.sidebar__status-item:hover::after,
-.sidebar__status-item:focus-within::after {
-  opacity: 1;
-}
-
-.sidebar__status-item--online {
-  border-color: rgba(34, 197, 94, 0.32);
-  box-shadow: 0 24px 44px rgba(34, 197, 94, 0.16);
-}
-
-.sidebar__status-item--offline {
-  border-color: rgba(248, 113, 113, 0.32);
-  box-shadow: 0 24px 42px rgba(248, 113, 113, 0.18);
-}
-
-.sidebar__status-item--degraded {
-  border-color: rgba(234, 179, 8, 0.32);
-  box-shadow: 0 24px 42px rgba(234, 179, 8, 0.18);
-}
-
-.sidebar__status-item--unknown {
-  border-color: rgba(148, 163, 184, 0.28);
-}
-
-.sidebar__status-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(248, 250, 252, 0.95);
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.24), rgba(30, 64, 175, 0.18));
-  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.45);
-  flex-shrink: 0;
-}
-
-.sidebar__status-icon--frontend {
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.38), rgba(14, 165, 233, 0.26));
-  border-color: rgba(96, 165, 250, 0.45);
-  color: rgba(224, 242, 254, 0.96);
-  box-shadow: 0 18px 38px rgba(37, 99, 235, 0.28);
-}
-
-.sidebar__status-icon--backend {
-  background: linear-gradient(135deg, rgba(129, 140, 248, 0.38), rgba(236, 72, 153, 0.24));
-  border-color: rgba(167, 139, 250, 0.42);
-  color: rgba(250, 245, 255, 0.95);
-  box-shadow: 0 18px 38px rgba(124, 58, 237, 0.28);
-}
-
-.sidebar__status-icon--minio {
-  background: linear-gradient(135deg, rgba(45, 212, 191, 0.36), rgba(96, 165, 250, 0.24));
-  border-color: rgba(94, 234, 212, 0.4);
-  color: rgba(236, 253, 245, 0.96);
-  box-shadow: 0 18px 38px rgba(15, 118, 110, 0.28);
-}
-
-.sidebar__status-icon--gpu {
-  background: linear-gradient(135deg, rgba(250, 204, 21, 0.32), rgba(59, 130, 246, 0.26));
-  border-color: rgba(250, 204, 21, 0.42);
-  color: rgba(254, 249, 195, 0.95);
-  box-shadow: 0 18px 38px rgba(234, 179, 8, 0.25);
-}
-
-.sidebar__status-content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
-.sidebar__status-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.sidebar__status-title {
-  color: #f8fafc;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-
-.sidebar__status-message {
-  margin: 0;
-  font-size: 0.82rem;
-  color: rgba(226, 232, 240, 0.72);
-  line-height: 1.4;
-}
-
-.status-led-wrapper {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.65));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 10px 18px rgba(15, 23, 42, 0.45);
-}
-
 .status-led {
   width: 12px;
   height: 12px;
@@ -820,10 +657,10 @@ body {
   color: rgba(226, 232, 240, 0.75);
 }
 
-.home-trust-services {
+.home-trust-summary {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.8rem;
   padding: 1.6rem 1.75rem;
   border-radius: 18px;
   background: rgba(15, 23, 42, 0.88);
@@ -831,60 +668,232 @@ body {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
-.home-trust-services h3 {
+.home-trust-summary h3 {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 600;
   color: #e0f2fe;
 }
 
-.home-trust-services p {
+.home-trust-summary p {
   margin: 0;
   font-size: 0.95rem;
   color: rgba(191, 219, 254, 0.85);
 }
 
-.home-trust-statuses {
+.status-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.status-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.6rem;
+  border-radius: 22px;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(59, 130, 246, 0.32));
+  border: 1px solid rgba(59, 130, 246, 0.32);
+  box-shadow: 0 32px 64px rgba(2, 6, 23, 0.55);
+}
+
+.status-page__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.status-page__header p {
+  margin: 0;
+  max-width: 46rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.8);
+  line-height: 1.6;
+}
+
+.status-page__back {
+  align-self: flex-start;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.4);
+  color: rgba(226, 232, 240, 0.85);
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.status-page__back:hover,
+.status-page__back:focus-visible {
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(226, 232, 240, 0.55);
+  color: #f8fafc;
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.status-page__overview {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .status-page__overview {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+.status-page__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1.2rem 1.4rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.status-page__metric-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.status-page__metric-value {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.status-page__metric-description {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.status-page__services {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.status-page__services h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #e0f2fe;
+}
+
+.status-page__list {
   margin: 0;
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.6rem;
+  gap: 1rem;
 }
 
-.home-trust-status {
+@media (min-width: 768px) {
+  .status-page__list {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+}
+
+.status-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.25rem 1.4rem;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  box-shadow: 0 28px 52px rgba(2, 6, 23, 0.5);
+}
+
+.status-card__header {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
-  padding: 0.65rem 0.85rem;
-  border-radius: 12px;
-  background: rgba(15, 23, 42, 0.72);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
-.home-trust-status__badge {
+.status-card__badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 2rem;
   height: 2rem;
   border-radius: 999px;
-  font-size: 0.85rem;
+  background: rgba(30, 41, 59, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: rgba(226, 232, 240, 0.9);
   font-weight: 600;
-  background: rgba(30, 41, 59, 0.85);
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  letter-spacing: 0.08em;
+}
+
+.status-card__title-group {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.status-card__name {
+  font-size: 1rem;
+  font-weight: 600;
   color: #f8fafc;
 }
 
-.home-trust-status__label {
-  flex: 1;
-  font-size: 0.95rem;
-  color: rgba(226, 232, 240, 0.85);
+.status-card__message {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.72);
+  line-height: 1.5;
 }
 
-.home-trust-status .status-led {
-  width: 0.75rem;
-  height: 0.75rem;
+.status-card--online {
+  border-color: rgba(34, 197, 94, 0.28);
+}
+
+.status-card--offline {
+  border-color: rgba(248, 113, 113, 0.32);
+}
+
+.status-card--degraded {
+  border-color: rgba(250, 204, 21, 0.32);
+}
+
+.status-card--unknown {
+  border-color: rgba(148, 163, 184, 0.32);
+}
+
+.status-page__help {
+  padding: 1.4rem 1.6rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.6;
+}
+
+.status-page__help h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.status-page__help a {
+  color: rgba(125, 211, 252, 0.9);
+  text-decoration: underline;
+}
+
+.status-page__help a:hover,
+.status-page__help a:focus-visible {
+  color: #f0f9ff;
 }
 
 .home-card {
@@ -4025,6 +4034,51 @@ main {
   font-size: 0.95rem;
 }
 
+.footer__status-summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.footer__status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.62);
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.footer__status-initial {
+  font-weight: 600;
+}
+
+.footer__status-pill--online {
+  border-color: rgba(34, 197, 94, 0.35);
+  color: rgba(187, 247, 208, 0.9);
+}
+
+.footer__status-pill--offline {
+  border-color: rgba(248, 113, 113, 0.38);
+  color: rgba(254, 215, 215, 0.9);
+}
+
+.footer__status-pill--degraded {
+  border-color: rgba(250, 204, 21, 0.38);
+  color: rgba(254, 243, 199, 0.88);
+}
+
+.footer__status-pill--unknown {
+  border-color: rgba(148, 163, 184, 0.4);
+  color: rgba(226, 232, 240, 0.7);
+}
+
 .footer__meta-group a {
   color: inherit;
   text-decoration: underline;
@@ -4058,16 +4112,6 @@ main {
   border-color: rgba(56, 189, 248, 0.5);
   background: rgba(14, 165, 233, 0.25);
   transform: translateY(-1px);
-}
-
-.footer__status-link[aria-disabled='true'] {
-  cursor: not-allowed;
-  opacity: 0.9;
-}
-
-.footer__status-link[aria-disabled='true']:hover,
-.footer__status-link[aria-disabled='true']:focus-visible {
-  transform: none;
 }
 
 .panel--accent {

--- a/frontend/src/types/serviceStatus.ts
+++ b/frontend/src/types/serviceStatus.ts
@@ -1,0 +1,9 @@
+export type ServiceStatusKey = 'frontend' | 'backend' | 'minio' | 'gpu';
+
+export type ServiceState = 'online' | 'offline' | 'degraded' | 'unknown';
+
+export interface ServiceIndicator {
+  label: string;
+  status: ServiceState;
+  message: string;
+}


### PR DESCRIPTION
## Summary
- add a ServiceStatusPage view that consumes the existing health checks and remove the legacy sidebar/home widgets
- expose the view through the scroll-aware footer with LED indicators and refreshed styling
- document the navigation change in the README and changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9561f596083338fe375b01b3396e3