### PR TITLE
Refine homepage focus on new content

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 054 – [Standard Change] Homepage focus realignment
+- **Type**: Standard Change
+- **Reason**: The landing page dedicated too much space to admin-oriented actions and dense trust summaries, leaving little room to spotlight fresh catalog activity.
+- **Change**: Introduced a "What's new" highlight rail, replaced the bulky action cards with compact next-step pills, condensed the platform health metrics, removed the redundant live services callout, and refreshed the README to describe the updated home experience.
+
 ## 053 – [Standard Change] Dedicated service status page rollout
 - **Type**: Standard Change
 - **Reason**: The dashboard and sidebar were crowded by the embedded service status widgets, making it harder to surface uptime details in a focused way.
@@ -1397,3 +1402,8 @@
 - **Type**: Normal Change
 - **Reason**: The support footer needed to stay accessible without occupying space while browsing, prompting a request for a scroll-aware menu bar with icon-based support links.
 - **Changes**: Converted the footer into a floating bar that hides on downward scroll and appears when scrolling up, swapped Discord and GitHub links for icon buttons, condensed the VisionSuit Support and credits text, and added a placeholder Service Status link within the new layout.
+
+## 228 – [Update] Homepage action & health compaction
+- **Type**: Normal Change
+- **Reason**: The refreshed homepage still left the Take action and Platform health areas feeling oversized and repetitive for operators reviewing the dashboard.
+- **Changes**: Condensed the Take action shortcuts into single-line pills with an inline affordance, trimmed Platform health metrics down to label-and-value pairs, tightened the surrounding spacing, and refreshed the styling tokens to reinforce the compact presentation.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
 - MinIO-backed storage pipeline with secure download proxying, size guardrails, and curated collection linking.
 
 ### Community Experience
-- Persistent operations dashboard with curator spotlights, live queue status, and quick actions for uploads, moderation, and generator runs.
+- Home view centered on a "What's new" highlight rail with compact next-step shortcuts so curators and members can jump directly into fresh releases.
 - Member registration with reactions, comments, and private upload visibility for curators while administrators retain full inventory insight.
 - Spotlight profiles, gallery explorers with infinite scroll, intelligent caching, and account settings that keep avatars and bios in sync.
 - Model and image explorers fetch paginated windows with seamless “load more” controls so initial visits stay lightweight while deeper dives remain responsive.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -498,23 +498,25 @@ body {
 .home-section--callouts {
   background: linear-gradient(160deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.65));
   border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 26px;
-  padding: 2rem;
-  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.35);
+  border-radius: 22px;
+  padding: 1.5rem 1.6rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.32);
+  gap: 1rem;
 }
 
 .home-section--trust {
   background: linear-gradient(165deg, rgba(15, 23, 42, 0.82), rgba(2, 6, 23, 0.78));
   border: 1px solid rgba(56, 189, 248, 0.16);
-  border-radius: 26px;
-  padding: 2rem;
-  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.4);
+  border-radius: 22px;
+  padding: 1.5rem 1.6rem;
+  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.35);
+  gap: 1rem;
 }
 
 .home-section__header {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
 }
 
 .home-section__header h2 {
@@ -542,143 +544,177 @@ body {
   }
 }
 
-.home-cta-grid {
+.home-whats-new-grid {
   display: grid;
-  gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.home-cta-card {
+.home-whats-new-card {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
-  border-radius: 20px;
-  padding: 1.5rem 1.6rem;
+  gap: 0.4rem;
+  padding: 1.15rem 1.3rem;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.82);
+  color: #f8fafc;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.home-whats-new-card:focus-visible {
+  outline: 2px solid rgba(148, 163, 184, 0.65);
+  outline-offset: 3px;
+}
+
+.home-whats-new-card:hover,
+.home-whats-new-card:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 28px rgba(2, 6, 23, 0.45);
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.home-whats-new-card__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.home-whats-new-card__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.home-whats-new-card__description {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.4;
+}
+
+.home-whats-new-empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.8);
+  padding: 1rem 0;
+}
+
+.home-cta-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.home-cta-pill {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
   border: 1px solid transparent;
-  background: rgba(15, 23, 42, 0.75);
+  background: rgba(15, 23, 42, 0.7);
   color: #f8fafc;
   text-align: left;
   cursor: pointer;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
 }
 
-.home-cta-card:focus-visible {
+.home-cta-pill:focus-visible {
   outline: 2px solid rgba(148, 163, 184, 0.6);
   outline-offset: 3px;
 }
 
-.home-cta-card:hover,
-.home-cta-card:focus-visible {
-  transform: translateY(-4px);
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
+.home-cta-pill:hover,
+.home-cta-pill:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.4);
 }
 
-.home-cta-card__title {
-  font-size: 1.1rem;
+.home-cta-pill:hover::after,
+.home-cta-pill:focus-visible::after {
+  transform: translateX(3px);
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.home-cta-pill__title {
+  font-size: 0.95rem;
   font-weight: 600;
 }
 
-.home-cta-card__description {
-  font-size: 0.95rem;
-  color: rgba(226, 232, 240, 0.8);
+.home-cta-pill::after {
+  content: '›';
+  font-size: 1.1rem;
+  color: rgba(226, 232, 240, 0.75);
+  transition: transform 0.18s ease;
 }
 
-.home-cta-card--violet {
-  border-color: rgba(129, 140, 248, 0.45);
-  background: linear-gradient(160deg, rgba(76, 29, 149, 0.45), rgba(30, 41, 59, 0.85));
+.home-cta-pill--violet {
+  border-color: rgba(129, 140, 248, 0.4);
+  background: linear-gradient(155deg, rgba(67, 56, 202, 0.32), rgba(15, 23, 42, 0.85));
 }
 
-.home-cta-card--cyan {
-  border-color: rgba(56, 189, 248, 0.45);
-  background: linear-gradient(160deg, rgba(8, 145, 178, 0.45), rgba(15, 23, 42, 0.85));
+.home-cta-pill--cyan {
+  border-color: rgba(56, 189, 248, 0.4);
+  background: linear-gradient(155deg, rgba(14, 116, 144, 0.32), rgba(15, 23, 42, 0.82));
 }
 
-.home-cta-card--amber {
-  border-color: rgba(251, 191, 36, 0.45);
-  background: linear-gradient(160deg, rgba(217, 119, 6, 0.38), rgba(30, 41, 59, 0.85));
+.home-cta-pill--amber {
+  border-color: rgba(251, 191, 36, 0.4);
+  background: linear-gradient(155deg, rgba(180, 83, 9, 0.28), rgba(30, 41, 59, 0.82));
 }
 
-.home-cta-card--rose {
-  border-color: rgba(244, 114, 182, 0.45);
-  background: linear-gradient(160deg, rgba(190, 24, 93, 0.4), rgba(30, 41, 59, 0.85));
+.home-cta-pill--rose {
+  border-color: rgba(244, 114, 182, 0.4);
+  background: linear-gradient(155deg, rgba(190, 24, 93, 0.28), rgba(30, 41, 59, 0.82));
 }
 
-.home-trust-panel {
+.home-cta-pill--slate {
+  border-color: rgba(148, 163, 184, 0.4);
+  background: linear-gradient(155deg, rgba(30, 41, 59, 0.42), rgba(15, 23, 42, 0.82));
+}
+
+.home-trust-list {
   display: grid;
-  gap: 1.75rem;
-}
-
-@media (min-width: 1024px) {
-  .home-trust-panel {
-    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
-  }
-}
-
-.home-trust-metrics {
-  display: grid;
-  gap: 1.25rem;
-}
-
-@media (min-width: 640px) {
-  .home-trust-metrics {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  }
-}
-
-.home-trust-metric {
-  padding: 1.4rem 1.5rem;
-  border-radius: 18px;
-  background: rgba(15, 23, 42, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  color: #e2e8f0;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.home-trust-metric dt {
-  font-size: 0.85rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.8);
-}
-
-.home-trust-metric dd {
+  gap: 0.6rem;
   margin: 0;
-  font-size: 1.6rem;
+  padding: 0;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.home-trust-list__item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  gap: 0.2rem 0.5rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  color: #e2e8f0;
+}
+
+.home-trust-list__item dt {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.home-trust-list__item dd {
+  margin: 0;
+  font-size: 1.2rem;
   font-weight: 600;
   color: #f8fafc;
-}
-
-.home-trust-metric p {
-  margin: 0;
-  font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.75);
-}
-
-.home-trust-summary {
-  display: flex;
-  flex-direction: column;
-  gap: 0.8rem;
-  padding: 1.6rem 1.75rem;
-  border-radius: 18px;
-  background: rgba(15, 23, 42, 0.88);
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-
-.home-trust-summary h3 {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: #e0f2fe;
-}
-
-.home-trust-summary p {
-  margin: 0;
-  font-size: 0.95rem;
-  color: rgba(191, 219, 254, 0.85);
 }
 
 .status-page {


### PR DESCRIPTION
## Summary
- add a "What's new" highlight rail and compact next-step shortcuts to the homepage
- streamline the platform health metrics, remove redundant copy, and tighten the Take action panel layout
- document the refreshed landing experience in the README and changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9593d176c8333a078b8724d79cd55