### PR TITLE
Add temporary NSFW moderation bypass controls

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1407,3 +1407,8 @@
 - **Type**: Normal Change
 - **Reason**: The refreshed homepage still left the Take action and Platform health areas feeling oversized and repetitive for operators reviewing the dashboard.
 - **Changes**: Condensed the Take action shortcuts into single-line pills with an inline affordance, trimmed Platform health metrics down to label-and-value pairs, tightened the surrounding spacing, and refreshed the styling tokens to reinforce the compact presentation.
+
+## 229 – [Fix] Restore uploads during NSFW queue outage
+- **Type**: Emergency Change
+- **Reason**: Gallery uploads failed once the NSFW analysis queue was unavailable, crashing with a `runNsfwImageAnalysis is not defined` error and blocking operators from publishing content.
+- **Changes**: Ensured the upload pipeline imports the NSFW analyzer correctly, added defensive bypass handling throughout the moderation workflow to short-circuit analysis when disabled, and exposed a temporary admin setting so operators can keep uploads flowing while the queue is offline.

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -978,6 +978,7 @@ export const appConfig = {
     },
   },
   nsfw: {
+    bypassFilter: toBoolean(process.env.BYPASS_NSFW_FILTER, false),
     metadataFilters: metadataFilterConfig,
     imageAnalysis: imageAnalysisConfig,
   },

--- a/backend/src/lib/nsfw/moderation.ts
+++ b/backend/src/lib/nsfw/moderation.ts
@@ -9,6 +9,8 @@ import type { ImageAnalysisResult } from './imageAnalysis';
 
 type TagReference = Array<{ tag: { label: string; isAdult: boolean } }>;
 
+const isBypassEnabled = () => appConfig.nsfw.bypassFilter;
+
 const normalizeString = (value: string | null | undefined) =>
   typeof value === 'string' ? value.trim().toLowerCase() : '';
 
@@ -157,6 +159,17 @@ export interface ModelModerationDecision {
 export const evaluateModelModeration = (
   context: ModelModerationContext,
 ): ModelModerationDecision => {
+  if (isBypassEnabled()) {
+    return {
+      isAdult: false,
+      requiresModeration: false,
+      metadataScreening: null,
+      metadataAdult: false,
+      metadataMinor: false,
+      metadataBeast: false,
+    };
+  }
+
   const screening = resolveMetadataScreening(context.metadata ?? null);
   const thresholds = metadataThresholds();
 
@@ -226,6 +239,15 @@ export interface ImageModerationDecision {
 export const evaluateImageModeration = (
   context: ImageModerationContext,
 ): ImageModerationDecision => {
+  if (isBypassEnabled()) {
+    return {
+      isAdult: false,
+      requiresModeration: false,
+      illegalMinor: false,
+      illegalBeast: false,
+    };
+  }
+
   const metadataList = context.metadataList ?? [];
   const analysisInput = context.analysis
     ? { imageAnalysis: { decisions: context.analysis.decisions, scores: context.analysis.scores } }

--- a/backend/src/lib/nsfw/service.ts
+++ b/backend/src/lib/nsfw/service.ts
@@ -3,6 +3,7 @@ import type { Prisma } from '@prisma/client';
 import type { AnalyzerTaskOptions } from './runtime';
 import { nsfwAnalysisScheduler } from './runtime';
 import type { ImageAnalysisResult } from './imageAnalysis';
+import { appConfig } from '../../config';
 
 const toNumber = (value: number) => (Number.isFinite(value) ? value : 0);
 
@@ -23,6 +24,10 @@ export const runNsfwImageAnalysis = async (
   payload: Buffer,
   options: AnalyzerTaskOptions = {},
 ): Promise<ImageAnalysisResult | null> => {
+  if (appConfig.nsfw.bypassFilter) {
+    return null;
+  }
+
   try {
     return await nsfwAnalysisScheduler.enqueue(payload, options);
   } catch (error) {

--- a/backend/src/lib/nsfw/workflow.ts
+++ b/backend/src/lib/nsfw/workflow.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '@prisma/client';
 
 import { analyzeImageModeration, serializeModerationSummary, type ImageModerationSummary } from '../nsfw-open-cv';
+import { appConfig } from '../../config';
 
 import type { ImageModerationDecision } from './moderation';
 import { evaluateImageModeration } from './moderation';
@@ -39,6 +40,20 @@ export interface ImageModerationWorkflowResult {
 export const runImageModerationWorkflow = async (
   input: ImageModerationWorkflowInput,
 ): Promise<ImageModerationWorkflowResult> => {
+  if (appConfig.nsfw.bypassFilter) {
+    return {
+      analysis: null,
+      summary: null,
+      serializedSummary: null,
+      decision: {
+        isAdult: false,
+        requiresModeration: false,
+        illegalMinor: false,
+        illegalBeast: false,
+      },
+    };
+  }
+
   const { buffer, adultKeywords, context, analysisOptions, existingSummary } = input;
 
   const [analysis, summary] = await Promise.all([

--- a/backend/src/lib/settings.ts
+++ b/backend/src/lib/settings.ts
@@ -9,6 +9,7 @@ export interface AdminSettingsGeneral {
   siteTitle: string;
   allowRegistration: boolean;
   maintenanceMode: boolean;
+  bypassNsfwFilter: boolean;
 }
 
 export interface AdminSettingsConnections {
@@ -289,6 +290,7 @@ const resolveAdminSettings = async (): Promise<AdminSettings> => {
       siteTitle,
       allowRegistration: parseBoolean(backendEnv.ALLOW_REGISTRATION, appConfig.platform.allowRegistration),
       maintenanceMode: parseBoolean(backendEnv.MAINTENANCE_MODE, appConfig.platform.maintenanceMode),
+      bypassNsfwFilter: parseBoolean(backendEnv.BYPASS_NSFW_FILTER, appConfig.nsfw.bypassFilter),
     },
     connections: {
       backendHost,
@@ -329,6 +331,7 @@ export const applyAdminSettings = async (settings: AdminSettings): Promise<Apply
     SITE_TITLE: settings.general.siteTitle,
     ALLOW_REGISTRATION: toBooleanString(settings.general.allowRegistration),
     MAINTENANCE_MODE: toBooleanString(settings.general.maintenanceMode),
+    BYPASS_NSFW_FILTER: toBooleanString(settings.general.bypassNsfwFilter),
     HOST: settings.connections.backendHost,
     MINIO_ENDPOINT: settings.connections.minioEndpoint,
     GENERATOR_NODE_URL: settings.connections.generatorNode,
@@ -347,6 +350,7 @@ export const applyAdminSettings = async (settings: AdminSettings): Promise<Apply
   appConfig.platform.siteTitle = settings.general.siteTitle;
   appConfig.platform.allowRegistration = settings.general.allowRegistration;
   appConfig.platform.maintenanceMode = settings.general.maintenanceMode;
+  appConfig.nsfw.bypassFilter = settings.general.bypassNsfwFilter;
 
   const incomingThresholds = {
     adult: sanitizeThresholdValue(settings.safety.metadataThresholds.adult),

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -30,6 +30,7 @@ const settingsSchema = z.object({
     siteTitle: trimmedString.min(1, 'Site title is required.').max(120, 'Site title is too long.'),
     allowRegistration: z.boolean(),
     maintenanceMode: z.boolean(),
+    bypassNsfwFilter: z.boolean(),
   }),
   connections: z.object({
     backendHost: trimmedString.min(1, 'Backend host is required.').max(255, 'Backend host is too long.'),

--- a/backend/src/routes/uploads.ts
+++ b/backend/src/routes/uploads.ts
@@ -25,7 +25,7 @@ import {
   type ImageModerationSummary,
 } from '../lib/nsfw-open-cv';
 import { runImageModerationWorkflow } from '../lib/nsfw/workflow';
-import { toJsonImageAnalysis } from '../lib/nsfw/service';
+import { runNsfwImageAnalysis, toJsonImageAnalysis } from '../lib/nsfw/service';
 import { evaluateModelModeration } from '../lib/nsfw/moderation';
 import type { AutoTaggingJobInput } from '../lib/tagging/service';
 import { enqueueAutoTaggingJob } from '../lib/tagging/service';

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -2453,6 +2453,17 @@ export const AdminPanel = ({
                         />
                         <span>Enable maintenance mode (admins only)</span>
                       </label>
+                      <label className="admin__checkbox">
+                        <input
+                          type="checkbox"
+                          checked={settingsDraft.general.bypassNsfwFilter}
+                          onChange={(event) =>
+                            updateGeneralSetting('bypassNsfwFilter', event.currentTarget.checked)
+                          }
+                          disabled={isSavingSettings}
+                        />
+                        <span>Bypass NSFW upload filtering</span>
+                      </label>
                     </div>
                   </>
                 ) : (

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -553,6 +553,7 @@ export interface AdminSettingsGeneral {
   siteTitle: string;
   allowRegistration: boolean;
   maintenanceMode: boolean;
+  bypassNsfwFilter: boolean;
 }
 
 export interface AdminSettingsConnections {


### PR DESCRIPTION
## Summary
- add a backend-administered bypass flag for NSFW screening that persists to env config
- short-circuit NSFW moderation workflows and restore the missing analyzer import when the bypass is active
- surface the bypass toggle in the admin settings UI and capture the release in the changelog

## Testing
- npm run lint *(fails: missing @types/node because dependencies are not installed in the container)*
- npm install *(fails: npm cannot reach the registry from this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d95ec120d88333b2ffc594fcf5a20e