### PR TITLE
Guard gallery explorer against missing tag scans

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1412,3 +1412,8 @@
 - **Type**: Emergency Change
 - **Reason**: Gallery uploads failed once the NSFW analysis queue was unavailable, crashing with a `runNsfwImageAnalysis is not defined` error and blocking operators from publishing content.
 - **Changes**: Ensured the upload pipeline imports the NSFW analyzer correctly, added defensive bypass handling throughout the moderation workflow to short-circuit analysis when disabled, and exposed a temporary admin setting so operators can keep uploads flowing while the queue is offline.
+
+## 230 – [Fix] Gallery tag scan fallback guard
+- **Type**: Normal Change
+- **Reason**: The gallery explorer crashed when legacy images without tag-scan metadata were selected because the UI unconditionally accessed the pending flag.
+- **Changes**: Introduced a shared `isTagScanPending` helper that safely handles missing metadata, updated every gallery explorer branch to rely on the guard, and refreshed the README to note the resilient legacy-image handling.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
 ### Community Experience
 - Home view centered on a "What's new" highlight rail with compact next-step shortcuts so curators and members can jump directly into fresh releases.
 - Member registration with reactions, comments, and private upload visibility for curators while administrators retain full inventory insight.
-- Spotlight profiles, gallery explorers with infinite scroll, intelligent caching, and account settings that keep avatars and bios in sync.
+- Spotlight profiles, gallery explorers with infinite scroll, intelligent caching, resilient legacy-image handling when auto-tag metadata is missing, and account settings that keep avatars and bios in sync.
 - Model and image explorers fetch paginated windows with seamless “load more” controls so initial visits stay lightweight while deeper dives remain responsive.
 
 ## Quick Start

--- a/frontend/src/components/GalleryExplorer.tsx
+++ b/frontend/src/components/GalleryExplorer.tsx
@@ -208,10 +208,12 @@ const buildSeededIndex = (seed: string, length: number) => {
   return Math.abs(hash) % length;
 };
 
+const isTagScanPending = (image?: ImageAsset | null) => image?.tagScan?.pending ?? false;
+
 const selectPreviewImage = (gallery: Gallery, viewer?: User | null) => {
   const imageEntries = getImageEntries(gallery).filter(
     (entry) =>
-      !entry.image.tagScan.pending &&
+      !isTagScanPending(entry.image) &&
       !isAuditHiddenFromViewer(entry.image.moderationStatus, entry.image.owner.id, viewer),
   );
   if (imageEntries.length === 0) {
@@ -383,7 +385,7 @@ export const GalleryExplorer = ({
     [activeImageIdValue],
   );
 
-  const activeImagePreviewUrl = activeImage && !activeImage.image.tagScan.pending
+  const activeImagePreviewUrl = activeImage && !isTagScanPending(activeImage.image)
     ?
         resolveCachedStorageUrl(
           activeImage.image.storagePath,
@@ -519,7 +521,7 @@ export const GalleryExplorer = ({
 
   const activeImageOverlayClasses = [
     'gallery-image-modal__media',
-    activeImage?.image.tagScan.pending ? 'gallery-image-modal__media--scan' : '',
+    isTagScanPending(activeImage?.image) ? 'gallery-image-modal__media--scan' : '',
     activeImage?.image.moderationStatus === 'FLAGGED' ? 'moderation-overlay' : '',
     activeImage?.image.moderationStatus === 'FLAGGED' && currentUser?.role !== 'ADMIN'
       ? 'moderation-overlay--blurred'
@@ -1257,7 +1259,7 @@ export const GalleryExplorer = ({
               <div className="gallery-detail__grid" role="list">
                 {activeGalleryImages.length > 0 ? (
                   activeGalleryImages.map((entry) => {
-                    if (entry.image.tagScan.pending) {
+                    if (isTagScanPending(entry.image)) {
                       return (
                         <div
                           key={entry.entryId}
@@ -1392,7 +1394,7 @@ export const GalleryExplorer = ({
                   disabled={
                     !canLikeImages ||
                     likeMutationId === activeImage.image.id ||
-                    activeImage.image.tagScan.pending
+                    isTagScanPending(activeImage.image)
                   }
                   aria-pressed={activeImage.image.viewerHasLiked}
                   aria-label={
@@ -1438,14 +1440,14 @@ export const GalleryExplorer = ({
                     </button>
                   </>
                 ) : null}
-                {authToken && activeImage.image.moderationStatus !== 'FLAGGED' && !activeImage.image.tagScan.pending ? (
+                {authToken && activeImage.image.moderationStatus !== 'FLAGGED' && !isTagScanPending(activeImage.image) ? (
                   <button
                     type="button"
                     className="gallery-image-modal__flag"
                     onClick={() => {
                       void handleFlagImage(activeImage.image);
                     }}
-                    disabled={isFlaggingImage || activeImage.image.tagScan.pending}
+                    disabled={isFlaggingImage || isTagScanPending(activeImage.image)}
                   >
                     {isFlaggingImage ? 'Sending…' : 'Flag image'}
                   </button>
@@ -1508,7 +1510,7 @@ export const GalleryExplorer = ({
                   }
                 } : undefined}
               >
-                {activeImage.image.tagScan.pending ? (
+                {isTagScanPending(activeImage.image) ? (
                   <div className="gallery-image-modal__scan-placeholder" role="status">
                     <span>Scan in progress</span>
                   </div>
@@ -1524,7 +1526,7 @@ export const GalleryExplorer = ({
                 <div className="gallery-image-modal__meta">
                   <div className="gallery-image-modal__meta-scroll">
                     {activeImage.note ? <p className="gallery-image-modal__note">Note: {activeImage.note}</p> : null}
-                    {activeImage.image.tagScan.pending ? (
+                    {isTagScanPending(activeImage.image) ? (
                       <p className="gallery-image-modal__scan-note" role="status">
                         Scan in progress. Tags will be available once the automated review completes.
                       </p>


### PR DESCRIPTION
## Summary
- guard all gallery explorer code paths against missing tag scan metadata so legacy images no longer crash the view
- add a shared helper for pending checks and document the resilience in the README
- record the fix in the project changelog

## Testing
- npm run build *(fails: pre-existing TypeScript type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9642d07ac83339a82f604202f71ee