### PR TITLE
Fix image edit dialog crash without owner options

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 055 – [Normal Change] Image edit dialog owner fallback hardening
+- **Type**: Normal Change
+- **Reason**: Opening the image edit dialog from gallery contexts crashed because curator owner options were not supplied, leaving the ownership selector without data.
+- **Change**: Made curator owner data optional in `ImageAssetEditDialog` so it gracefully falls back to the current owner when no list is provided, preventing the crash during gallery edits.
+
 ## 054 – [Standard Change] Homepage focus realignment
 - **Type**: Standard Change
 - **Reason**: The landing page dedicated too much space to admin-oriented actions and dense trust summaries, leaving little room to spotlight fresh catalog activity.

--- a/frontend/src/components/ImageAssetEditDialog.tsx
+++ b/frontend/src/components/ImageAssetEditDialog.tsx
@@ -10,7 +10,7 @@ interface ImageAssetEditDialogProps {
   image: ImageAsset;
   token: string | null | undefined;
   onSuccess?: (updated: ImageAsset) => void;
-  owners: { id: string; label: string }[];
+  owners?: { id: string; label: string }[];
 }
 
 const parseTags = (value: string) =>
@@ -79,7 +79,7 @@ export const ImageAssetEditDialog = ({
   image,
   token,
   onSuccess,
-  owners,
+  owners = [],
 }: ImageAssetEditDialogProps) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');


### PR DESCRIPTION
## Summary
- allow `ImageAssetEditDialog` to operate when no curator owner list is supplied by defaulting to an empty array
- document the fix in the changelog for release tracking

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d965235824833387d812b489a4e6f9