### PR TITLE
Refine support footer presentation

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1432,3 +1432,8 @@
 - **Type**: Emergency Change
 - **Reason**: The temporary NSFW bypass disabled prompt and metadata screening, exposing guests to adult-tagged assets while the ONNX analyzer was offline.
 - **Changes**: Kept the bypass scoped to ONNX image analysis so textual filters always run, prevented moderation summaries from contributing when bypassed, reworked the image moderation workflow to reuse the fallback logic, expanded tests to cover bypass scenarios, and updated the README to highlight the always-on guest protection.
+
+## 232 – [Update] Support footer polish
+- **Type**: Normal Change
+- **Reason**: The Support and credits footer looked improvised and needed a more intentional presentation for operators and community members.
+- **Changes**: Reoriented the floating footer into a three-column layout with a descriptive support panel, refreshed icon button styling, grouped credits alongside service health badges, and tuned responsive behavior for compact screens.

--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ For production deployments, review storage credentials, JWT secrets, GPU agent e
 
 ## Community & Support
 
-VisionSuit is actively evolving. Contributions, issues, and deployment learnings are welcome—open a discussion or pull request to share feedback and improvements.
+VisionSuit is actively evolving. Contributions, issues, and deployment learnings are welcome—open a discussion or pull request to share feedback and improvements. The floating support footer keeps Discord, GitHub, and live service status links within reach for rapid triage.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1731,54 +1731,65 @@ export const App = () => {
               className={`footer${isFooterVisible ? ' footer--visible' : ' footer--hidden'}`}
               aria-label="Support and credits"
             >
-              <span className="footer__label">VisionSuit Support</span>
-              <nav className="footer__icons" aria-label="Support channels">
-                <a
-                  href="https://discord.gg/UEb68YQwKR"
-                  className="footer__icon-link"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <span className="sr-only">Join the Discord Support Hub</span>
-                  <svg className="footer__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path d="M20.317 4.369a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.078.037c-.211.375-.444.864-.608 1.249-1.844-.276-3.68-.276-5.486 0-.164-.398-.41-.874-.622-1.249a.077.077 0 0 0-.078-.037 19.736 19.736 0 0 0-4.885 1.515.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.061a.082.082 0 0 0 .031.056c2.052 1.5 4.041 2.416 5.993 3.029a.078.078 0 0 0 .084-.027c.461-.63.873-1.295 1.226-1.996a.076.076 0 0 0-.041-.105c-.652-.247-1.27-.545-1.872-.892a.077.077 0 0 1-.007-.129c.125-.094.25-.192.37-.291a.074.074 0 0 1 .077-.01c3.927 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.009c.12.099.244.198.37.292a.077.077 0 0 1-.006.128 12.298 12.298 0 0 1-1.873.892.076.076 0 0 0-.04.106c.36.7.772 1.366 1.225 1.996a.076.076 0 0 0 .084.028c1.961-.613 3.95-1.53 6.002-3.03a.077.077 0 0 0 .031-.055c.5-5.177-.838-9.673-3.548-13.665a.061.061 0 0 0-.031-.028ZM8.02 15.331c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.334-.955 2.419-2.157 2.419Zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.334-.947 2.419-2.157 2.419Z" />
-                  </svg>
-                </a>
-                <a
-                  href="https://github.com/MythosMachina"
-                  className="footer__icon-link"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  <span className="sr-only">Visit MythosMachina Studio on GitHub</span>
-                  <svg className="footer__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path d="M12 .5c-6.63 0-12 5.37-12 12 0 5.3 3.438 9.747 8.205 11.325.6.111.82-.261.82-.58 0-.286-.011-1.04-.017-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.73.083-.73 1.205.084 1.84 1.236 1.84 1.236 1.07 1.834 2.809 1.304 3.495.997.108-.775.418-1.305.762-1.605-2.665-.303-5.466-1.332-5.466-5.931 0-1.31.469-2.381 1.236-3.221-.124-.303-.536-1.523.117-3.176 0 0 1.008-.322 3.3 1.23a11.52 11.52 0 0 1 3.003-.404c1.02.005 2.047.138 3.003.404 2.291-1.552 3.297-1.23 3.297-1.23.655 1.653.243 2.873.119 3.176.77.84 1.235 1.911 1.235 3.221 0 4.61-2.807 5.625-5.48 5.921.43.372.823 1.103.823 2.222 0 1.604-.015 2.896-.015 3.289 0 .321.216.697.825.579C20.565 22.243 24 17.78 24 12.5 24 5.87 18.627.5 12 .5Z" />
-                  </svg>
-                </a>
-              </nav>
-              <div className="footer__meta-group">
-                <div className="footer__status-summary" aria-label="Live service indicator">
-                  {(['frontend', 'backend', 'minio', 'gpu'] as ServiceStatusKey[]).map((key) => {
-                    const entry = serviceStatus[key];
-                    return (
-                      <span key={key} className={`footer__status-pill footer__status-pill--${entry.status}`}>
-                        <span className="footer__status-initial">{serviceBadgeLabels[key]}</span>
-                        <span className={`status-led status-led--${entry.status}`} aria-hidden="true" />
-                        <span className="sr-only">{`${entry.label}: ${statusLabels[entry.status]}`}</span>
-                      </span>
-                    );
-                  })}
+              <div className="footer__support-block">
+                <div className="footer__support-copy">
+                  <span className="footer__label">VisionSuit Support</span>
+                  <p className="footer__description">Connect with the team or follow live platform updates.</p>
                 </div>
-                <span>
-                  © {currentYear} MythosMachina · All rights reserved · Developed by{' '}
-                  <a href="https://github.com/AsaTyr2018/" target="_blank" rel="noreferrer noopener">
-                    AsaTyr
+                <nav className="footer__icons" aria-label="Support channels">
+                  <a
+                    href="https://discord.gg/UEb68YQwKR"
+                    className="footer__icon-link"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <span className="sr-only">Join the Discord Support Hub</span>
+                    <svg className="footer__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path d="M20.317 4.369a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.078.037c-.211.375-.444.864-.608 1.249-1.844-.276-3.68-.276-5.486 0-.164-.398-.41-.874-.622-1.249a.077.077 0 0 0-.078-.037 19.736 19.736 0 0 0-4.885 1.515.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.061a.082.082 0 0 0 .031.056c2.052 1.5 4.041 2.416 5.993 3.029a.078.078 0 0 0 .084-.027c.461-.63.873-1.295 1.226-1.996a.076.076 0 0 0-.041-.105c-.652-.247-1.27-.545-1.872-.892a.077.077 0 0 1-.007-.129c.125-.094.25-.192.37-.291a.074.074 0 0 1 .077-.01c3.927 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.009c.12.099.244.198.37.292a.077.077 0 0 1-.006.128 12.298 12.298 0 0 1-1.873.892.076.076 0 0 0-.04.106c.36.7.772 1.366 1.225 1.996a.076.076 0 0 0 .084.028c1.961-.613 3.95-1.53 6.002-3.03a.077.077 0 0 0 .031-.055c.5-5.177-.838-9.673-3.548-13.665a.061.061 0 0 0-.031-.028ZM8.02 15.331c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.334-.955 2.419-2.157 2.419Zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.419 0 1.334-.947 2.419-2.157 2.419Z" />
+                    </svg>
                   </a>
-                  .
-                </span>
+                  <a
+                    href="https://github.com/MythosMachina"
+                    className="footer__icon-link"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <span className="sr-only">Visit MythosMachina Studio on GitHub</span>
+                    <svg className="footer__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path d="M12 .5c-6.63 0-12 5.37-12 12 0 5.3 3.438 9.747 8.205 11.325.6.111.82-.261.82-.58 0-.286-.011-1.04-.017-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.73.083-.73 1.205.084 1.84 1.236 1.84 1.236 1.07 1.834 2.809 1.304 3.495.997.108-.775.418-1.305.762-1.605-2.665-.303-5.466-1.332-5.466-5.931 0-1.31.469-2.381 1.236-3.221-.124-.303-.536-1.523.117-3.176 0 0 1.008-.322 3.3 1.23a11.52 11.52 0 0 1 3.003-.404c1.02.005 2.047.138 3.003.404 2.291-1.552 3.297-1.23 3.297-1.23.655 1.653.243 2.873.119 3.176.77.84 1.235 1.911 1.235 3.221 0 4.61-2.807 5.625-5.48 5.921.43.372.823 1.103.823 2.222 0 1.604-.015 2.896-.015 3.289 0 .321.216.697.825.579C20.565 22.243 24 17.78 24 12.5 24 5.87 18.627.5 12 .5Z" />
+                    </svg>
+                  </a>
+                </nav>
                 <a href="#service-status" className="footer__status-link" onClick={handleServiceStatusClick}>
                   Service Status
                 </a>
+              </div>
+              <div className="footer__divider" aria-hidden="true" />
+              <div className="footer__meta-group">
+                <div className="footer__credits" aria-label="Project credits">
+                  <span className="footer__credit-heading">MythosMachina Studio</span>
+                  <p className="footer__credit-copy">
+                    © {currentYear} MythosMachina · All rights reserved · Developed by{' '}
+                    <a href="https://github.com/AsaTyr2018/" target="_blank" rel="noreferrer noopener">
+                      AsaTyr
+                    </a>
+                    .
+                  </p>
+                </div>
+                <div className="footer__status-deck" aria-label="Live service indicator">
+                  <div className="footer__status-summary">
+                    {(['frontend', 'backend', 'minio', 'gpu'] as ServiceStatusKey[]).map((key) => {
+                      const entry = serviceStatus[key];
+                      return (
+                        <span key={key} className={`footer__status-pill footer__status-pill--${entry.status}`}>
+                          <span className="footer__status-initial">{serviceBadgeLabels[key]}</span>
+                          <span className={`status-led status-led--${entry.status}`} aria-hidden="true" />
+                          <span className="sr-only">{`${entry.label}: ${statusLabels[entry.status]}`}</span>
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
               </div>
             </footer>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4018,17 +4018,17 @@ main {
   left: 50%;
   bottom: 2rem;
   transform: translate(-50%, 0);
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1.25rem;
-  padding: 0.85rem 1.75rem;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.92);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: stretch;
+  gap: 1.5rem;
+  padding: 1rem 2rem;
+  border-radius: 36px;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.25), rgba(15, 23, 42, 0.92) 60%);
   border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.5);
-  max-width: min(960px, calc(100% - 2rem));
-  width: fit-content;
+  max-width: min(1040px, calc(100% - 2rem));
+  width: 100%;
   opacity: 1;
   transition: transform 0.35s ease, opacity 0.35s ease;
   z-index: 30;
@@ -4044,10 +4044,30 @@ main {
   opacity: 1;
 }
 
+.footer__support-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.footer__support-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .footer__label {
-  font-weight: 600;
+  font-weight: 700;
   font-size: 1rem;
-  color: #f8fafc;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #c7d2fe;
+}
+
+.footer__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.9);
 }
 
 .footer__icons {
@@ -4060,12 +4080,12 @@ main {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: rgba(30, 41, 59, 0.65);
-  color: rgba(226, 232, 240, 0.85);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(30, 41, 59, 0.6);
+  color: rgba(226, 232, 240, 0.88);
   text-decoration: none;
   transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
@@ -4073,25 +4093,69 @@ main {
 .footer__icon-link:hover,
 .footer__icon-link:focus-visible {
   color: #f8fafc;
-  background: rgba(59, 130, 246, 0.35);
-  border-color: rgba(96, 165, 250, 0.4);
-  transform: translateY(-1px);
+  background: rgba(59, 130, 246, 0.28);
+  border-color: rgba(148, 163, 184, 0.45);
+  transform: translateY(-2px);
 }
 
 .footer__icon {
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 1.2rem;
+  height: 1.2rem;
   fill: currentColor;
 }
 
-.footer__meta-group {
-  margin-left: auto;
-  display: flex;
+.footer__status-link {
+  align-self: flex-start;
+  display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  color: rgba(226, 232, 240, 0.85);
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.45rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  background: rgba(30, 41, 59, 0.55);
+  color: rgba(125, 211, 252, 0.92);
+  text-decoration: none;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.footer__status-link:hover,
+.footer__status-link:focus-visible {
+  color: #f0f9ff;
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(14, 165, 233, 0.25);
+  transform: translateY(-2px);
+}
+
+.footer__divider {
+  width: 1px;
+  background: linear-gradient(to bottom, rgba(148, 163, 184, 0), rgba(148, 163, 184, 0.45), rgba(148, 163, 184, 0));
+}
+
+.footer__meta-group {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.85rem;
+  color: rgba(226, 232, 240, 0.9);
   font-size: 0.95rem;
+}
+
+.footer__credits {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.footer__credit-heading {
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  color: #f8fafc;
+}
+
+.footer__credit-copy {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
 }
 
 .footer__status-summary {
@@ -4099,6 +4163,12 @@ main {
   align-items: center;
   flex-wrap: wrap;
   gap: 0.6rem;
+}
+
+.footer__status-deck {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .footer__status-pill {
@@ -4152,27 +4222,6 @@ main {
   text-decoration-color: #f8fafc;
 }
 
-.footer__status-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid rgba(96, 165, 250, 0.25);
-  background: rgba(30, 41, 59, 0.55);
-  color: rgba(125, 211, 252, 0.9);
-  text-decoration: none;
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.footer__status-link:hover,
-.footer__status-link:focus-visible {
-  color: #f0f9ff;
-  border-color: rgba(56, 189, 248, 0.5);
-  background: rgba(14, 165, 233, 0.25);
-  transform: translateY(-1px);
-}
 
 .panel--accent {
   background: rgba(15, 23, 42, 0.65);
@@ -7581,25 +7630,26 @@ button {
 
   .footer {
     bottom: 1rem;
-    padding: 0.75rem 1.25rem;
-    gap: 0.9rem;
+    padding: 0.85rem 1.25rem;
+    gap: 1rem;
+    grid-template-columns: 1fr;
     max-width: calc(100% - 1.5rem);
   }
 
-  .footer__label {
-    flex-basis: 100%;
-  }
-
-  .footer__meta-group {
-    margin-left: 0;
-    width: 100%;
-    justify-content: space-between;
-    gap: 0.6rem;
-    font-size: 0.9rem;
+  .footer__support-block {
+    gap: 0.75rem;
   }
 
   .footer__status-link {
-    padding: 0.35rem 0.75rem;
+    width: fit-content;
+  }
+
+  .footer__divider {
+    display: none;
+  }
+
+  .footer__meta-group {
+    font-size: 0.9rem;
   }
 
   .process__timeline {


### PR DESCRIPTION
## Summary
- Reworked the floating support footer into a structured support panel with refreshed icon buttons and credits layout.
- Updated footer styling to add gradient treatments, columnar layout, and responsive tweaks for small screens.
- Documented the support footer polish in the changelog and noted the quick-access footer links in the README.

## Testing
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d96e4df35c8333ab6870b7b7834bc7