### PR TITLE
Improve service status monitoring accuracy

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 057 – [Normal Change] Dedicated service health probes
+- **Type**: Normal Change
+- **Reason**: The service status dashboard incorrectly reported MinIO as offline whenever the backend API was unavailable because all probes flowed through the API, hiding the real storage state.
+- **Change**: Introduced dedicated backend endpoints for API, MinIO, and GPU health checks, updated the frontend to fall back to the individual probes so storage and GPU indicators move to an unknown state instead of offline when the API is unreachable, and refreshed the README to highlight the per-service monitoring.
+
 ## 056 – [Emergency Change] Maintenance lock hardening
 - **Type**: Emergency Change
 - **Reason**: The maintenance toggle still exposed dashboards to guests and members because the frontend never enforced the admin-only lockout, defeating the purpose of scheduled downtime windows.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
 ## Core Features
 
 ### Operations & Governance
-- Unified administrator workspace with environment alignment, `.env` synchronization for frontend and backend settings, and a dedicated service status page accessible from the footer.
+- Unified administrator workspace with environment alignment, `.env` synchronization for frontend and backend settings, and a dedicated service status page accessible from the footer with per-service health probes.
 - Role-aware access control backed by JWT authentication, admin onboarding flows, and guarded upload paths for curators.
 - Configurable registration policies and a maintenance mode that collapses the UI to an admin-only login gate, plus guided restart prompts for safe rollouts.
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,7 @@ import type {
   AdminSettings,
   AdminSettingsResponse,
   PlatformConfigResponse,
+  ServiceStatusProbeResponse,
   ServiceStatusResponse,
   UserProfile,
   UserProfileRank,
@@ -540,6 +541,9 @@ export const api = {
     return request<PaginatedResponse<ImageAsset>>(path, {}, token);
   },
   getServiceStatus: () => request<ServiceStatusResponse>('/api/meta/status'),
+  getBackendServiceStatus: () => request<ServiceStatusProbeResponse>('/api/meta/status/backend'),
+  getMinioServiceStatus: () => request<ServiceStatusProbeResponse>('/api/meta/status/minio'),
+  getGpuServiceStatus: () => request<ServiceStatusProbeResponse>('/api/meta/status/gpu'),
   createUploadDraft: postUploadDraft,
   createModelVersion: postModelVersion,
   updateModelVersion: putModelVersion,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -539,6 +539,11 @@ export interface ServiceStatusResponse {
   };
 }
 
+export interface ServiceStatusProbeResponse {
+  timestamp: string;
+  service: ServiceStatusDetails;
+}
+
 export interface PlatformConfig {
   siteTitle: string;
   allowRegistration: boolean;


### PR DESCRIPTION
## Summary
- add dedicated backend, MinIO, and GPU health-check endpoints and reuse them for the aggregated status payload
- update the frontend status poller to fall back to the individual probes and mark storage/GPU as unknown instead of offline when the API is unreachable
- document the dedicated probes in the README and changelog

## Testing
- npm --prefix backend run lint *(fails: missing @types/node because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d970857654833383be9805ca31cc16