### PR TITLE
Ensure dev starter regenerates Prisma client for GPU toggle

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 058 – [Normal Change] Prisma client regeneration for GPU toggle
+- **Type**: Normal Change
+- **Reason**: Toggling the GPU module failed because the Prisma client still referenced the older schema and rejected the new `isGpuEnabled` field.
+- **Change**: Ensured the dev starter runs `prisma generate` before launching services and refreshed the README to document the automatic regeneration so GPU settings updates succeed immediately.
+
 ## 057 – [Normal Change] Dedicated service health probes
 - **Type**: Normal Change
 - **Reason**: The service status dashboard incorrectly reported MinIO as offline whenever the backend API was unavailable because all probes flowed through the API, hiding the real storage state.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
    ```bash
    ./dev-start.sh
    ```
-   The backend will automatically download the SmilingWolf auto-tagging assets on first launch and prints `[startup] Downloading ...` messages so you can track progress in the console.
+   The starter now refreshes the Prisma client before launching services so new schema fields—such as the GPU toggle—apply without manual regeneration, then the backend automatically downloads the SmilingWolf auto-tagging assets on first launch and prints `[startup] Downloading ...` messages so you can track progress in the console.
    VisionSuit now degrades gracefully if the native ONNX Runtime CPU backend cannot be loaded (for example, when `onnxruntime-node` does not provide binaries for the installed Node.js version). Startup logs `[startup] Auto tagger disabled` and continues serving requests, while affected uploads remain flagged with a descriptive `tagScanError`. Reinstall the dependency with `npm --prefix backend rebuild onnxruntime-node`, align the Node.js version with the published binaries, or set `ORT_BACKEND_PATH` to the directory that contains the native bindings to restore automatic tagging.
 4. **Seed and explore** – The backend ships with Prisma seed data. Visit the frontend URL shown in the terminal output and sign in with the seeded administrator account to configure services.
 

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -18,6 +18,12 @@ echo "Starting Prisma Studio on ${PRISMA_STUDIO_HOST}:${PRISMA_STUDIO_PORT} (pro
 ) &
 PRISMA_STUDIO_PID=$!
 
+echo "Ensuring Prisma client artifacts are up to date" >&2
+(
+  cd "$ROOT_DIR/backend"
+  npx --yes prisma generate >/dev/null 2>&1 || npx --yes prisma generate
+)
+
 echo "Starting VisionSuit backend on ${HOST_ADDRESS}:${BACKEND_PORT}" >&2
 (
   cd "$ROOT_DIR/backend"


### PR DESCRIPTION
## Summary
- refresh the Prisma client before launching dev services so new schema fields like the GPU toggle are accepted
- document the automatic regeneration in the quick start guide
- record the operational fix in the changelog

## Testing
- not run (explanation: prisma client generation relies on installed dependencies and was not executed as part of this change)

------
https://chatgpt.com/codex/tasks/task_e_68d97d3de5d083339ca481783131d609