### PR TITLE
Guard Windows bulk importer against missing catalog titles

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 059 – [Normal Change] Windows bulk uploader catalog resilience
+- **Type**: Normal Change
+- **Reason**: Import runs against older VisionSuit builds crashed because the `/api/assets/models` response omitted `title`, causing the duplicate detection to dereference a missing property.
+- **Change**: Guarded remote catalog parsing with a helper that safely reads optional properties and documented the resilience boost in the README so PowerShell uploads continue even when optional fields are absent.
+
 ## 058 – [Normal Change] Prisma client regeneration for GPU toggle
 - **Type**: Normal Change
 - **Reason**: Toggling the GPU module failed because the Prisma client still referenced the older schema and rejected the new `isGpuEnabled` field.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For production deployments, review storage credentials, JWT secrets, GPU agent e
 
 ## Bulk Import Helpers
 
-- **Windows (`scripts/bulk_import_windows.ps1`)** – Pre-validates upload files, disables the implicit `Expect: 100-continue` header to keep self-hosted API proxies happy, and unwraps transport exceptions so failures such as `Error while copying content to a stream` surface the underlying cause. Populate `./loras` and `./images` and run the script from PowerShell 7+.
+- **Windows (`scripts/bulk_import_windows.ps1`)** – Pre-validates upload files, disables the implicit `Expect: 100-continue` header to keep self-hosted API proxies happy, unwraps transport exceptions so failures such as `Error while copying content to a stream` surface the underlying cause, and tolerates remote catalog responses that omit optional `title`/`slug` fields while still detecting duplicates. Populate `./loras` and `./images` and run the script from PowerShell 7+.
 - **Linux/macOS (`scripts/bulk_import_linux.sh`)** – Uses `curl` for the same two-phase workflow; consult the script header for usage flags and environment overrides.
 
 ## Repository Layout

--- a/scripts/bulk_import_windows.ps1
+++ b/scripts/bulk_import_windows.ps1
@@ -129,6 +129,24 @@ function Resolve-ExistingDirectory {
   return $resolved.ProviderPath
 }
 
+function Get-PropertyValue {
+  param(
+    $Object,
+    [string]$PropertyName
+  )
+
+  if ($null -eq $Object -or [string]::IsNullOrWhiteSpace($PropertyName)) {
+    return $null
+  }
+
+  $property = $Object.PSObject.Properties[$PropertyName]
+  if ($property) {
+    return $property.Value
+  }
+
+  return $null
+}
+
 function Get-MimeType {
   param([string]$Path)
   switch ([System.IO.Path]::GetExtension($Path).ToLowerInvariant()) {
@@ -277,23 +295,26 @@ function Get-ExistingModelIndex {
     foreach ($model in $collection) {
       if (-not $model) { continue }
 
+      $titleValue = Get-PropertyValue -Object $model -PropertyName 'title'
+      $slugValue = Get-PropertyValue -Object $model -PropertyName 'slug'
+
       $entry = [pscustomobject]@{
-        Title = $model.title
-        Slug = $model.slug
+        Title = $titleValue
+        Slug = $slugValue
         Source = 'remote'
       }
 
       $titleKey = $null
-      if ($model.PSObject.Properties.Match('title')) {
-        $titleKey = Build-ModelNameKey -Value $model.title
+      if ($titleValue) {
+        $titleKey = Build-ModelNameKey -Value $titleValue
       }
       if ($titleKey) {
         $index[$titleKey] = $entry
       }
 
       $slugKey = $null
-      if ($model.PSObject.Properties.Match('slug')) {
-        $slugKey = Build-ModelNameKey -Value $model.slug
+      if ($slugValue) {
+        $slugKey = Build-ModelNameKey -Value $slugValue
       }
       if ($slugKey) {
         $index[$slugKey] = $entry


### PR DESCRIPTION
## Summary
- add a helper for safely reading optional properties from existing model catalog responses
- prevent the Windows bulk importer duplicate detection from dereferencing missing title/slug values and document the resilience boost in the README
- record the change in the changelog

## Testing
- not run (pwsh is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d9818aa9108333ac59bfe4fd38f402