### PR TITLE
Add automatic moderation reason details

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1467,3 +1467,8 @@
 - **Type**: Normal Change
 - **Reason**: The Windows bulk uploader only checked the first page of existing models, so duplicate LoRA names beyond the initial batch were silently re-uploaded.
 - **Changes**: Added a paginated catalog fetcher that requests 100 models per page, walks the server-provided cursor until exhaustion, and reuses the normalized title and slug keys so duplicate detection now covers the entire remote library.
+
+## 235 – [Fix] Moderation queue automatic flag reasons
+- **Type**: Normal Change
+- **Reason**: Administrators could not see why assets were auto-flagged, forcing guesswork before approving or removing items from the moderation queue.
+- **Changes**: Generated NSFW snapshots in the moderation queue API response with metadata and OpenCV summaries, exposed those details to the admin UI, and surfaced automatic flag explanations directly in the queue and detail panes.

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -4147,6 +4147,7 @@ export const AdminPanel = ({
                           isModerationLoading;
                         const nsfw = entry.nsfw;
                         const reasonBadges = nsfw?.reasons ?? [];
+                        const primaryReasonDetail = nsfw?.reasonDetails?.[0] ?? null;
 
                         return (
                           <li key={`${entry.entity}-${asset.id}`} className="moderation-list__item">
@@ -4190,6 +4191,11 @@ export const AdminPanel = ({
                                   </span>
                                 ) : null}
                               </div>
+                              {primaryReasonDetail ? (
+                                <p className="moderation-list-item__reason" title={primaryReasonDetail}>
+                                  {primaryReasonDetail}
+                                </p>
+                              ) : null}
                               <div className="moderation-list-item__footer">
                                 <span>{summary.total} reports</span>
                                 <span aria-hidden="true">•</span>
@@ -4265,6 +4271,17 @@ export const AdminPanel = ({
                               <span className="moderation-reason moderation-reason--user">User flag</span>
                             ) : null}
                           </div>
+                          {selectedModerationAsset.nsfw?.reasonDetails &&
+                          selectedModerationAsset.nsfw.reasonDetails.length > 0 ? (
+                            <div className="moderation-detail__section moderation-detail__reason">
+                              <h4>Automatic flag reasons</h4>
+                              <ul className="moderation-detail__reason-list">
+                                {selectedModerationAsset.nsfw.reasonDetails.map((detail) => (
+                                  <li key={detail}>{detail}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          ) : null}
                           {selectedModerationAsset.nsfw ? (
                             <div className="moderation-detail__nsfw">
                               <h4>NSFW signals</h4>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12071,6 +12071,14 @@ button {
   gap: 0.4rem;
 }
 
+.moderation-list-item__reason {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  color: var(--text-subtle);
+  text-align: left;
+}
+
 .moderation-list-item__footer {
   display: flex;
   align-items: center;
@@ -12238,6 +12246,22 @@ button {
   flex-wrap: wrap;
   gap: 0.4rem;
   margin-bottom: 1rem;
+}
+
+.moderation-detail__reason h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.moderation-detail__reason-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text-subtle);
+  font-size: 0.95rem;
+  line-height: 1.45;
 }
 
 .moderation-detail__nsfw {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -47,6 +47,28 @@ export interface ModerationReport {
   };
 }
 
+export type NsfwReason = 'KEYWORD' | 'METADATA' | 'OPENCV';
+
+export interface NsfwSnapshotSignals {
+  moderationAdultScore: number | null;
+  moderationSuggestiveScore: number | null;
+}
+
+export interface NsfwSnapshotMetadata {
+  adultScore: number | null;
+  minorScore: number | null;
+  beastScore: number | null;
+}
+
+export interface NsfwSnapshot {
+  visibility: 'BLOCKED' | 'ADULT' | 'SUGGESTIVE';
+  pendingReview: boolean;
+  reasons: NsfwReason[];
+  reasonDetails: string[];
+  signals: NsfwSnapshotSignals;
+  metadata: NsfwSnapshotMetadata | null;
+}
+
 export interface AssetComment {
   id: string;
   content: string;
@@ -369,6 +391,7 @@ export interface ModelAsset {
   flaggedAt?: string | null;
   flaggedBy?: ModerationActorSummary | null;
   moderationReports?: ModerationReport[];
+  nsfw?: NsfwSnapshot | null;
 }
 
 export interface ImageAssetMetadata {
@@ -432,6 +455,7 @@ export interface ImageAsset {
   flaggedAt?: string | null;
   flaggedBy?: ModerationActorSummary | null;
   moderationReports?: ModerationReport[];
+  nsfw?: NsfwSnapshot | null;
 }
 
 export interface GalleryEntry {


### PR DESCRIPTION
## Summary
- add NSFW snapshot helpers in the moderation queue API so auto-flagged models and images include reason details, scores, and severity metadata
- surface the automatic flag explanations in the admin moderation queue list and detail view with new styling and updated TypeScript types
- record the change in the changelog

## Testing
- `npm run lint` *(fails: existing backend TypeScript errors unrelated to this change)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68d996b2bd08833387bdf3afaf57884e