### PR TITLE
Align moderation queue preview layout and add zoom affordance

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1477,3 +1477,8 @@
 - **Type**: Normal Change
 - **Reason**: The floating VisionSuit Support bubble obscured content and felt disconnected from the layout, prompting a request for a persistent bar anchored to the viewport edge.
 - **Changes**: Reworked the footer into a full-width support bar with inline sections separated by spacers, refreshed styling for the support links and service badges, and updated the README to describe the anchored bar experience.
+
+## 237 – [Update] Moderation queue preview alignment
+- **Type**: Normal Change
+- **Reason**: Moderators had to scroll unpredictably because preview images expanded inconsistently and the approve/remove controls drifted vertically.
+- **Changes**: Locked moderation detail previews to a 256 px column with object-fit scaling, added a zoomable preview button that opens the existing admin media modal, anchored the action bar to the bottom of the detail panel, refreshed responsive styling, and documented the workflow in the README.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
 
 ### Moderation & Safety
 - Layered moderation queues with severity filters, audit trails, and rejection requirements for administrators.
+- Moderation workspace previews stay at a consistent 256 px width with one-click zooming so approve/remove actions remain aligned.
 - Centralized NSFW pipeline that blends OpenCV heuristics, ONNX swimwear detection, and configurable scheduler pools stored in `config/nsfw-image-analysis.json`.
 - Textual safety screening that never bypasses metadata or prompt keywords, so guests stay shielded from NSFW-tagged models and covers even when the ONNX analyzer is offline.
 - Prompt governance with keyword enforcement, adult tagging, automated rescans, and SmilingWolf/wd-swinv2 auto-tagging for prompt-free uploads.

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -679,6 +679,16 @@ export const AdminPanel = ({
           { updatedAt: selectedModerationAsset.asset.updatedAt, cacheKey: selectedModerationAsset.asset.id },
         ) ?? selectedModerationAsset.asset.storagePath
     : null;
+  const handleOpenModerationPreview = useCallback(() => {
+    if (!selectedModerationAsset || !moderationDialogPreviewUrl) {
+      return;
+    }
+
+    setPreviewAsset({
+      url: moderationDialogPreviewUrl,
+      title: selectedModerationAsset.asset.title,
+    });
+  }, [moderationDialogPreviewUrl, selectedModerationAsset]);
   const moderationActionMatches = useCallback(
     (entity: 'model' | 'image', action: 'approve' | 'remove', id: string) =>
       moderationAction?.entity === entity &&
@@ -4226,14 +4236,17 @@ export const AdminPanel = ({
                       </header>
                       <div className="moderation-detail__body">
                         <div className="moderation-detail__media">
-                          {selectedModerationAsset.entity === 'model' ? (
-                            moderationDialogPreviewUrl ? (
+                          {moderationDialogPreviewUrl ? (
+                            <button
+                              type="button"
+                              className="moderation-detail__media-button"
+                              onClick={handleOpenModerationPreview}
+                              aria-label={`Enlarge preview of ${selectedModerationAsset.asset.title}`}
+                              aria-haspopup="dialog"
+                              title="Click to enlarge preview"
+                            >
                               <img src={moderationDialogPreviewUrl} alt={selectedModerationAsset.asset.title} />
-                            ) : (
-                              <div className="moderation-detail__media-placeholder" aria-hidden="true" />
-                            )
-                          ) : moderationDialogPreviewUrl ? (
-                            <img src={moderationDialogPreviewUrl} alt={selectedModerationAsset.asset.title} />
+                            </button>
                           ) : (
                             <div className="moderation-detail__media-placeholder" aria-hidden="true" />
                           )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12236,8 +12236,9 @@ button {
 
 .moderation-detail__body {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+  grid-template-columns: minmax(0, 256px) minmax(0, 1fr);
   gap: 1.5rem;
+  align-items: start;
 }
 
 .moderation-detail__media {
@@ -12249,12 +12250,30 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
+}
+
+.moderation-detail__media-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.moderation-detail__media-button:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 
 .moderation-detail__media img {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
+  object-fit: contain;
+  display: block;
 }
 
 .moderation-detail__media-placeholder {
@@ -12351,6 +12370,7 @@ button {
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
+  margin-top: auto;
 }
 
 .moderation-detail__action-buttons {
@@ -12377,4 +12397,15 @@ button {
 .moderation-detail__section {
   border-top: 1px solid var(--surface-border-subtle);
   padding-top: 1rem;
+}
+
+@media (max-width: 960px) {
+  .moderation-detail__body {
+    grid-template-columns: 1fr;
+  }
+
+  .moderation-detail__media {
+    max-width: 256px;
+    margin: 0 auto;
+  }
 }


### PR DESCRIPTION
## Summary
- lock the moderation detail preview to a consistent 256 px column and anchor the action bar so approve/remove stay aligned
- add a zoomable preview button that opens the existing admin preview modal for higher-resolution inspection
- document the moderation queue refinements in the README and changelog

## Testing
- npm run build *(fails: pre-existing TypeScript errors in App.tsx, GalleryExplorer.tsx, ImageAssetEditDialog.tsx, ModelAssetEditDialog.tsx, and OnSiteGenerator.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a04301e88333926361195efacf65