### PR TITLE
Raise gallery upload batch limit to 100 files

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1482,3 +1482,8 @@
 - **Type**: Normal Change
 - **Reason**: Moderators had to scroll unpredictably because preview images expanded inconsistently and the approve/remove controls drifted vertically.
 - **Changes**: Locked moderation detail previews to a 256 px column with object-fit scaling, added a zoomable preview button that opens the existing admin media modal, anchored the action bar to the bottom of the detail panel, refreshed responsive styling, and documented the workflow in the README.
+
+## 238 – [Update] Expanded gallery upload batch limit
+- **Type**: Normal Change
+- **Reason**: Curators needed to upload more than 12 gallery images at a time, making the previous limit too restrictive for larger releases.
+- **Changes**: Raised the shared upload cap to 100 files while preserving the 2 GB ceiling, refreshed the upload wizard to surface the new capacity, aligned the backend and bulk importer scripts with the higher limit, and updated the README to highlight the expanded batch support.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
 - Prompt governance with keyword enforcement, adult tagging, automated rescans, and SmilingWolf/wd-swinv2 auto-tagging for prompt-free uploads.
 
 ### Creation & Distribution
-- Guided three-step upload wizard for LoRA models and gallery renders with drag-and-drop validation and revisioned model cards.
+- Guided three-step upload wizard for LoRA models and gallery renders with drag-and-drop validation, revisioned model cards, and gallery batches up to 100 files (still capped at 2 GB per request).
 - On-site generator hub that dispatches SDXL workflows to GPU agents, supports multi-LoRA blends, and streams artifacts through authenticated proxies.
 - MinIO-backed storage pipeline with secure download proxying, size guardrails, and curated collection linking.
 

--- a/backend/src/lib/uploadLimits.ts
+++ b/backend/src/lib/uploadLimits.ts
@@ -1,3 +1,3 @@
-export const MAX_UPLOAD_FILES = 12;
+export const MAX_UPLOAD_FILES = 100;
 export const MAX_TOTAL_SIZE_BYTES = 2_147_483_648; // 2 GB
 export const MAX_AVATAR_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB

--- a/frontend/src/lib/uploadLimits.ts
+++ b/frontend/src/lib/uploadLimits.ts
@@ -1,2 +1,2 @@
-export const MAX_UPLOAD_FILES = 12;
+export const MAX_UPLOAD_FILES = 100;
 export const MAX_TOTAL_SIZE_BYTES = 2_147_483_648; // 2 GB

--- a/scripts/bulk_import_linux.sh
+++ b/scripts/bulk_import_linux.sh
@@ -565,7 +565,7 @@ PY
 
   total_images=${#other_images[@]}
   if [ "$total_images" -gt 0 ]; then
-    max_batch=12
+    max_batch=100
     uploaded_batches=0
     uploaded_images=0
     start_index=0

--- a/scripts/bulk_import_windows.ps1
+++ b/scripts/bulk_import_windows.ps1
@@ -60,7 +60,7 @@ param(
   [string]$DefaultTrigger,
 
   [Parameter()]
-  [int]$ImageBatchSize = 12
+  [int]$ImageBatchSize = 100
 )
 
 Set-StrictMode -Version Latest

--- a/scripts/migrate_mylora_to_visionsuit.py
+++ b/scripts/migrate_mylora_to_visionsuit.py
@@ -21,7 +21,7 @@ except ImportError as exc:  # pragma: no cover - dependency guard
     raise
 
 DEFAULT_TIMEOUT = 30
-MAX_PREVIEW_FILES = 11  # VisionSuit accepts at most 12 files per request (1 model + 11 previews).
+MAX_PREVIEW_FILES = 99  # VisionSuit accepts at most 100 files per request (1 model + 99 previews).
 
 
 class PreviewExtractor(HTMLParser):


### PR DESCRIPTION
## Summary
- raise the shared upload file cap to 100 while keeping the 2 GB total size ceiling
- update bulk import helpers and migration script to honour the expanded limit
- refresh the README and changelog to document the new gallery batch capacity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a3acfeb88333bf608e59e0e95e94