### PR TITLE
Update moderation keyword management layout

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1492,3 +1492,8 @@
 - **Type**: Normal Change
 - **Reason**: Adult prompt filters needed to stay view-only while illegal keywords must block uploads pending moderation, requiring separate management and review flows.
 - **Changes**: Replaced the single adult keyword table with a categorized safety keyword schema and migration, refreshed backend moderation pipelines to use both adult and illegal keyword sets across uploads, rescans, and generator workflows, expanded the admin safety panel with dedicated management for both queues, and updated documentation to describe the split keyword enforcement.
+
+## 240 – [Update] Moderation keyword management layout
+- **Type**: Normal Change
+- **Reason**: Stacked panels forced extra scrolling as the adult and illegal keyword lists grew, slowing moderators reviewing safety filters.
+- **Changes**: Combined both keyword managers into a responsive two-column layout with shared styling tweaks so the lists stay visible side by side on wide screens while preserving form and table spacing.

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -3201,149 +3201,154 @@ export const AdminPanel = ({
             )}
           </section>
           <section className="admin__section">
-            <div className="admin__section-intro">
-              <h3>Adult prompt keywords</h3>
-              <p>Configure prompt keywords that automatically mark uploads as adult-only when detected in prompts or metadata.</p>
+            <div className="admin__keyword-columns">
+              <article className="admin__keyword-column">
+                <div className="admin__section-intro">
+                  <h3>Adult prompt keywords</h3>
+                  <p>
+                    Configure prompt keywords that automatically mark uploads as adult-only when detected in prompts or metadata.
+                  </p>
+                </div>
+                {adultKeywordError ? (
+                  <p className="admin__status admin__status--error" role="alert">{adultKeywordError}</p>
+                ) : null}
+                <form
+                  className="adult-keyword-form"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void handleAddAdultKeyword();
+                  }}
+                >
+                  <label className="adult-keyword-form__field">
+                    <span>New keyword</span>
+                    <input
+                      type="text"
+                      value={newAdultKeyword}
+                      onChange={(event) => setNewAdultKeyword(event.currentTarget.value)}
+                      placeholder="e.g. explicit content phrase"
+                      disabled={isCreatingAdultKeyword || isAdultKeywordsLoading}
+                    />
+                  </label>
+                  <button
+                    type="submit"
+                    className="button button--primary"
+                    disabled={isCreatingAdultKeyword || newAdultKeyword.trim().length === 0}
+                  >
+                    {isCreatingAdultKeyword ? 'Adding…' : 'Add keyword'}
+                  </button>
+                </form>
+                {isAdultKeywordsLoading ? (
+                  <p className="admin__loading" role="status">Loading keyword configuration…</p>
+                ) : adultKeywords.length === 0 ? (
+                  <p className="admin__empty">No adult keywords configured yet. Add one to start scanning prompts.</p>
+                ) : (
+                  <table className="adult-keyword-table">
+                    <thead>
+                      <tr>
+                        <th scope="col">Keyword</th>
+                        <th scope="col">Created</th>
+                        <th scope="col">Updated</th>
+                        <th scope="col">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {adultKeywords.map((keyword) => (
+                        <tr key={keyword.id}>
+                          <th scope="row">{keyword.label}</th>
+                          <td>{new Date(keyword.createdAt).toLocaleDateString('en-US')}</td>
+                          <td>{new Date(keyword.updatedAt).toLocaleDateString('en-US')}</td>
+                          <td>
+                            <button
+                              type="button"
+                              className="button button--ghost"
+                              onClick={() => handleDeleteAdultKeyword(keyword)}
+                              disabled={activeAdultKeywordRemoval === keyword.id}
+                            >
+                              {activeAdultKeywordRemoval === keyword.id ? 'Removing…' : 'Remove'}
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+                <p className="admin__footnote">
+                  Matches hide the asset from guests and users with the NSFW filter enabled without blocking the upload.
+                </p>
+              </article>
+              <article className="admin__keyword-column">
+                <div className="admin__section-intro">
+                  <h3>Illegal prompt keywords</h3>
+                  <p>Keywords in this list immediately block uploads and queue them for moderator review when detected.</p>
+                </div>
+                {illegalKeywordError ? (
+                  <p className="admin__status admin__status--error" role="alert">{illegalKeywordError}</p>
+                ) : null}
+                <form
+                  className="adult-keyword-form"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void handleAddIllegalKeyword();
+                  }}
+                >
+                  <label className="adult-keyword-form__field">
+                    <span>New keyword</span>
+                    <input
+                      type="text"
+                      value={newIllegalKeyword}
+                      onChange={(event) => setNewIllegalKeyword(event.currentTarget.value)}
+                      placeholder="e.g. disallowed content phrase"
+                      disabled={isCreatingIllegalKeyword || isIllegalKeywordsLoading}
+                    />
+                  </label>
+                  <button
+                    type="submit"
+                    className="button button--primary"
+                    disabled={isCreatingIllegalKeyword || newIllegalKeyword.trim().length === 0}
+                  >
+                    {isCreatingIllegalKeyword ? 'Adding…' : 'Add keyword'}
+                  </button>
+                </form>
+                {isIllegalKeywordsLoading ? (
+                  <p className="admin__loading" role="status">Loading keyword configuration…</p>
+                ) : illegalKeywords.length === 0 ? (
+                  <p className="admin__empty">No illegal keywords configured yet. Add one to block problematic prompts.</p>
+                ) : (
+                  <table className="adult-keyword-table">
+                    <thead>
+                      <tr>
+                        <th scope="col">Keyword</th>
+                        <th scope="col">Created</th>
+                        <th scope="col">Updated</th>
+                        <th scope="col">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {illegalKeywords.map((keyword) => (
+                        <tr key={keyword.id}>
+                          <th scope="row">{keyword.label}</th>
+                          <td>{new Date(keyword.createdAt).toLocaleDateString('en-US')}</td>
+                          <td>{new Date(keyword.updatedAt).toLocaleDateString('en-US')}</td>
+                          <td>
+                            <button
+                              type="button"
+                              className="button button--ghost"
+                              onClick={() => handleDeleteIllegalKeyword(keyword)}
+                              disabled={activeIllegalKeywordRemoval === keyword.id}
+                            >
+                              {activeIllegalKeywordRemoval === keyword.id ? 'Removing…' : 'Remove'}
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+                <p className="admin__footnote">
+                  Assets matched by these keywords are hidden from all users until a moderator reviews and approves them.
+                </p>
+              </article>
             </div>
-            {adultKeywordError ? (
-              <p className="admin__status admin__status--error" role="alert">{adultKeywordError}</p>
-            ) : null}
-            <form
-              className="adult-keyword-form"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void handleAddAdultKeyword();
-              }}
-            >
-              <label className="adult-keyword-form__field">
-                <span>New keyword</span>
-                <input
-                  type="text"
-                  value={newAdultKeyword}
-                  onChange={(event) => setNewAdultKeyword(event.currentTarget.value)}
-                  placeholder="e.g. explicit content phrase"
-                  disabled={isCreatingAdultKeyword || isAdultKeywordsLoading}
-                />
-              </label>
-              <button
-                type="submit"
-                className="button button--primary"
-                disabled={isCreatingAdultKeyword || newAdultKeyword.trim().length === 0}
-              >
-                {isCreatingAdultKeyword ? 'Adding…' : 'Add keyword'}
-              </button>
-            </form>
-            {isAdultKeywordsLoading ? (
-              <p className="admin__loading" role="status">Loading keyword configuration…</p>
-            ) : adultKeywords.length === 0 ? (
-              <p className="admin__empty">No adult keywords configured yet. Add one to start scanning prompts.</p>
-            ) : (
-              <table className="adult-keyword-table">
-                <thead>
-                  <tr>
-                    <th scope="col">Keyword</th>
-                    <th scope="col">Created</th>
-                    <th scope="col">Updated</th>
-                    <th scope="col">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {adultKeywords.map((keyword) => (
-                    <tr key={keyword.id}>
-                      <th scope="row">{keyword.label}</th>
-                      <td>{new Date(keyword.createdAt).toLocaleDateString('en-US')}</td>
-                      <td>{new Date(keyword.updatedAt).toLocaleDateString('en-US')}</td>
-                      <td>
-                        <button
-                          type="button"
-                          className="button button--ghost"
-                          onClick={() => handleDeleteAdultKeyword(keyword)}
-                          disabled={activeAdultKeywordRemoval === keyword.id}
-                        >
-                          {activeAdultKeywordRemoval === keyword.id ? 'Removing…' : 'Remove'}
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-            <p className="admin__footnote">
-              Matches hide the asset from guests and users with the NSFW filter enabled without blocking the upload.
-            </p>
-          </section>
-
-          <section className="admin__section">
-            <div className="admin__section-intro">
-              <h3>Illegal prompt keywords</h3>
-              <p>Keywords in this list immediately block uploads and queue them for moderator review when detected.</p>
-            </div>
-            {illegalKeywordError ? (
-              <p className="admin__status admin__status--error" role="alert">{illegalKeywordError}</p>
-            ) : null}
-            <form
-              className="adult-keyword-form"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void handleAddIllegalKeyword();
-              }}
-            >
-              <label className="adult-keyword-form__field">
-                <span>New keyword</span>
-                <input
-                  type="text"
-                  value={newIllegalKeyword}
-                  onChange={(event) => setNewIllegalKeyword(event.currentTarget.value)}
-                  placeholder="e.g. disallowed content phrase"
-                  disabled={isCreatingIllegalKeyword || isIllegalKeywordsLoading}
-                />
-              </label>
-              <button
-                type="submit"
-                className="button button--primary"
-                disabled={isCreatingIllegalKeyword || newIllegalKeyword.trim().length === 0}
-              >
-                {isCreatingIllegalKeyword ? 'Adding…' : 'Add keyword'}
-              </button>
-            </form>
-            {isIllegalKeywordsLoading ? (
-              <p className="admin__loading" role="status">Loading keyword configuration…</p>
-            ) : illegalKeywords.length === 0 ? (
-              <p className="admin__empty">No illegal keywords configured yet. Add one to block problematic prompts.</p>
-            ) : (
-              <table className="adult-keyword-table">
-                <thead>
-                  <tr>
-                    <th scope="col">Keyword</th>
-                    <th scope="col">Created</th>
-                    <th scope="col">Updated</th>
-                    <th scope="col">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {illegalKeywords.map((keyword) => (
-                    <tr key={keyword.id}>
-                      <th scope="row">{keyword.label}</th>
-                      <td>{new Date(keyword.createdAt).toLocaleDateString('en-US')}</td>
-                      <td>{new Date(keyword.updatedAt).toLocaleDateString('en-US')}</td>
-                      <td>
-                        <button
-                          type="button"
-                          className="button button--ghost"
-                          onClick={() => handleDeleteIllegalKeyword(keyword)}
-                          disabled={activeIllegalKeywordRemoval === keyword.id}
-                        >
-                          {activeIllegalKeywordRemoval === keyword.id ? 'Removing…' : 'Remove'}
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-            <p className="admin__footnote">
-              Assets matched by these keywords are hidden from all users until a moderator reviews and approves them.
-            </p>
           </section>
         </div>
       ) : null}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1835,6 +1835,27 @@ body {
   flex-wrap: wrap;
 }
 
+.admin__keyword-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.75rem;
+  align-items: flex-start;
+}
+
+.admin__keyword-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.admin__keyword-column .adult-keyword-form {
+  margin-top: 0;
+}
+
+.admin__keyword-column .adult-keyword-table {
+  margin-top: 1rem;
+}
+
 .adult-keyword-form__field {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- render adult and illegal prompt keyword managers side by side in the admin moderation queue
- add responsive grid styling so both keyword lists stay visible together on wide viewports
- record the layout refresh in the changelog

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d9ad82f3308333b516acaa912c0c7a