### PR TITLE
Add CLI sweep to approve flagged assets

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1507,3 +1507,8 @@
 - **Type**: Normal Change
 - **Reason**: Stacked panels forced extra scrolling as the adult and illegal keyword lists grew, slowing moderators reviewing safety filters.
 - **Changes**: Combined both keyword managers into a responsive two-column layout with shared styling tweaks so the lists stay visible side by side on wide screens while preserving form and table spacing.
+
+## 241 – [Addition] Bulk moderation approval CLI
+- **Type**: Normal Change
+- **Reason**: Moderators needed to clear verified false positives from the queue without approving each flagged model or image manually.
+- **Changes**: Added a Prisma-backed `moderation:approve-flagged` script that resets flagged metadata, writes moderation log entries, documented the command in the README, and exposed it through the backend npm scripts.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
 
 For production deployments, review storage credentials, JWT secrets, GPU agent endpoints, and generator bucket provisioning before exposing the stack.
 
+## Moderation CLI Helpers
+
+- **Approve all flagged assets** – Clear the moderation queue in one sweep after an incident review:
+  ```bash
+  npm --prefix backend run moderation:approve-flagged
+  ```
+  The command reconnects flagged models and images to the active catalog, removes their `flaggedAt` markers, and writes a moderation log entry for each asset so the audit trail records the bulk approval.
+
 ## Bulk Import Helpers
 
 - **Windows (`scripts/bulk_import_windows.ps1`)** – Pre-validates upload files, disables the implicit `Expect: 100-continue` header to keep self-hosted API proxies happy, unwraps transport exceptions so failures such as `Error while copying content to a stream` surface the underlying cause, and inspects paginated or flattened catalog responses so duplicate models are skipped even when `/api/assets/models` wraps items inside `items`, `data`, or `results`. Populate `./loras` and `./images` and run the script from PowerShell 7+.

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "prisma:studio": "prisma studio",
     "seed": "ts-node --transpile-only prisma/seed.ts",
     "create-admin": "ts-node --transpile-only scripts/createAdmin.ts",
+    "moderation:approve-flagged": "ts-node --transpile-only scripts/approveFlaggedAssets.ts",
     "generator:sync-base-models": "ts-node --transpile-only scripts/syncGeneratorBaseModels.ts",
     "storage:reindex": "ts-node --transpile-only scripts/reindexStorage.ts"
   },

--- a/backend/scripts/approveFlaggedAssets.ts
+++ b/backend/scripts/approveFlaggedAssets.ts
@@ -1,0 +1,157 @@
+import { ModerationActionType, ModerationEntityType, ModerationStatus, PrismaClient } from '@prisma/client';
+
+import '../src/config';
+
+const prisma = new PrismaClient();
+
+const BULK_APPROVAL_MESSAGE = 'Bulk approval via CLI sweep.';
+
+type AssetTarget = {
+  id: string;
+  ownerId: string;
+  title: string;
+};
+
+const fetchFlaggedModels = async (): Promise<AssetTarget[]> => {
+  return prisma.modelAsset.findMany({
+    where: {
+      moderationStatus: { not: ModerationStatus.REMOVED },
+      OR: [
+        { moderationStatus: ModerationStatus.FLAGGED },
+        { flaggedAt: { not: null } },
+      ],
+    },
+    select: {
+      id: true,
+      ownerId: true,
+      title: true,
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+};
+
+const fetchFlaggedImages = async (): Promise<AssetTarget[]> => {
+  return prisma.imageAsset.findMany({
+    where: {
+      moderationStatus: { not: ModerationStatus.REMOVED },
+      OR: [
+        { moderationStatus: ModerationStatus.FLAGGED },
+        { flaggedAt: { not: null } },
+      ],
+    },
+    select: {
+      id: true,
+      ownerId: true,
+      title: true,
+    },
+    orderBy: { createdAt: 'asc' },
+  });
+};
+
+const approveModel = async (model: AssetTarget) => {
+  await prisma.$transaction(async (tx) => {
+    await tx.modelAsset.update({
+      where: { id: model.id },
+      data: {
+        moderationStatus: ModerationStatus.ACTIVE,
+        flaggedAt: null,
+        flaggedBy: { disconnect: true },
+      },
+    });
+
+    await tx.moderationLog.create({
+      data: {
+        entityType: ModerationEntityType.MODEL,
+        entityId: model.id,
+        action: ModerationActionType.APPROVED,
+        targetUserId: model.ownerId,
+        message: BULK_APPROVAL_MESSAGE,
+      },
+    });
+  });
+};
+
+const approveImage = async (image: AssetTarget) => {
+  await prisma.$transaction(async (tx) => {
+    await tx.imageAsset.update({
+      where: { id: image.id },
+      data: {
+        moderationStatus: ModerationStatus.ACTIVE,
+        flaggedAt: null,
+        flaggedBy: { disconnect: true },
+      },
+    });
+
+    await tx.moderationLog.create({
+      data: {
+        entityType: ModerationEntityType.IMAGE,
+        entityId: image.id,
+        action: ModerationActionType.APPROVED,
+        targetUserId: image.ownerId,
+        message: BULK_APPROVAL_MESSAGE,
+      },
+    });
+  });
+};
+
+const run = async () => {
+  const [flaggedModels, flaggedImages] = await Promise.all([
+    fetchFlaggedModels(),
+    fetchFlaggedImages(),
+  ]);
+
+  if (flaggedModels.length === 0 && flaggedImages.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log('[moderation] No flagged models or images found.');
+    return;
+  }
+
+  let approvedModels = 0;
+  let approvedImages = 0;
+
+  for (const model of flaggedModels) {
+    try {
+      await approveModel(model);
+      approvedModels += 1;
+      // eslint-disable-next-line no-console
+      console.log(`[moderation] Approved model ${model.id} (${model.title}).`);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[moderation] Failed to approve model ${model.id}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  for (const image of flaggedImages) {
+    try {
+      await approveImage(image);
+      approvedImages += 1;
+      // eslint-disable-next-line no-console
+      console.log(`[moderation] Approved image ${image.id} (${image.title}).`);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[moderation] Failed to approve image ${image.id}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('[moderation] Bulk approval complete:', {
+    approvedModels,
+    approvedImages,
+  });
+};
+
+run()
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('[moderation] Bulk approval failed:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add a Prisma-powered moderation script that reactivates flagged models and images, clears their metadata, and logs approvals
- expose the helper through an npm script and document the workflow in the README
- record the operational addition in the changelog

## Testing
- npm --prefix backend run lint *(fails: missing local @types/node definition before dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f1ef69a48333afa12f96d84abbfe