### PR TITLE
Add notification migration and update onboarding instructions

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1522,3 +1522,8 @@
 - **Type**: Normal Change
 - **Reason**: Curators shared a CSV catalog of LoRA files and categories that needed to map onto VisionSuit model tags without manual editing.
 - **Changes**: Added a Prisma-powered `tags:import` CLI that reads `lora,lora_name,category` rows, matches existing models by slug, title, or storage filename, creates any missing tags, links every matched LoRA to each category, and updated the README with usage guidance and options for dry-run previews and tag grouping.
+
+## 243 – [Fix] Notification schema migration alignment
+- **Type**: Normal Change
+- **Reason**: Prisma's development migrations failed with `no such table: SafetyKeyword` because the notification migration executed before the renamed safety keyword table existed.
+- **Changes**: Added a post-keyword Prisma migration that creates the notifications table and rebuilds the safety keyword schema without legacy defaults so the migration history applies cleanly on new environments.

--- a/README.md
+++ b/README.md
@@ -42,13 +42,18 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
    export DATABASE_URL="file:./dev.db"
    ```
    The development helper scripts load `.env`, and exporting `DATABASE_URL` keeps standalone Prisma tasks such as `npx prisma migrate reset` from failing on a fresh installation.
-3. **Start the development stack**
+3. **Apply database migrations**
+   ```bash
+   npm --prefix backend run prisma:migrate
+   ```
+   This creates newly introduced tables—such as the notification inbox—and reconciles safety keyword schema tweaks before any services start.
+4. **Start the development stack**
    ```bash
    ./dev-start.sh
    ```
    The starter now refreshes the Prisma client before launching services so new schema fields—such as the GPU toggle—apply without manual regeneration, then the backend automatically downloads the SmilingWolf auto-tagging assets on first launch and prints `[startup] Downloading ...` messages so you can track progress in the console.
    VisionSuit now degrades gracefully if the native ONNX Runtime CPU backend cannot be loaded (for example, when `onnxruntime-node` does not provide binaries for the installed Node.js version). Startup logs `[startup] Auto tagger disabled` and continues serving requests, while affected uploads remain flagged with a descriptive `tagScanError`. Reinstall the dependency with `npm --prefix backend rebuild onnxruntime-node`, align the Node.js version with the published binaries, or set `ORT_BACKEND_PATH` to the directory that contains the native bindings to restore automatic tagging.
-4. **Seed and explore** – The backend ships with Prisma seed data. Visit the frontend URL shown in the terminal output and sign in with the seeded administrator account to configure services. Administrators can now launch Prisma Studio directly from the dashboard link—asset requests stay proxied through the backend so the interface loads end-to-end even when the frontend is served via the Vite development server. The proxy now rewrites Prisma Studio’s transport bootstrap so Prisma 6’s new `/api` default keeps flowing through the `/db` tunnel instead of colliding with the VisionSuit API namespace.
+5. **Seed and explore** – The backend ships with Prisma seed data. Visit the frontend URL shown in the terminal output and sign in with the seeded administrator account to configure services. Administrators can now launch Prisma Studio directly from the dashboard link—asset requests stay proxied through the backend so the interface loads end-to-end even when the frontend is served via the Vite development server. The proxy now rewrites Prisma Studio’s transport bootstrap so Prisma 6’s new `/api` default keeps flowing through the `/db` tunnel instead of colliding with the VisionSuit API namespace.
 
 For production deployments, review storage credentials, JWT secrets, GPU agent endpoints, and generator bucket provisioning before exposing the stack.
 

--- a/backend/prisma/migrations/20251023120000_notifications/migration.sql
+++ b/backend/prisma/migrations/20251023120000_notifications/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT,
+    "data" JSONB,
+    "readAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_SafetyKeyword" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "label" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_SafetyKeyword" ("category", "createdAt", "id", "label", "updatedAt") SELECT "category", "createdAt", "id", "label", "updatedAt" FROM "SafetyKeyword";
+DROP TABLE "SafetyKeyword";
+ALTER TABLE "new_SafetyKeyword" RENAME TO "SafetyKeyword";
+CREATE UNIQUE INDEX "SafetyKeyword_category_label_key" ON "SafetyKeyword"("category", "label");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "Notification_userId_type_idx" ON "Notification"("userId", "type");
+
+-- CreateIndex
+CREATE INDEX "Notification_userId_readAt_idx" ON "Notification"("userId", "readAt");


### PR DESCRIPTION
## Summary
- add a post-keyword Prisma migration that creates the Notification table and rebuilds the SafetyKeyword schema without legacy defaults
- document running the backend Prisma migrations in the README quick start so fresh environments pick up the new tables
- record the migration alignment in the project changelog

## Testing
- npm run prisma:migrate

------
https://chatgpt.com/codex/tasks/task_e_68da1b868c88833387630cea699e796b