### PR TITLE
Fix curator dialog hook order for closed state

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 070 – [Emergency Change] Curator dialog hook order fix
+- **Type**: Emergency Change
+- **Reason**: Opening the curator application dialog as a member crashed the UI because React detected a changing hook order between closed and open renders, breaking the modal experience for normal users.
+- **Change**: Ensured the dialog's memoized status summary runs every render by moving it ahead of the early return so hook ordering stays stable even when the modal is closed.
+
 ## 069 – [Normal Change] Maintenance control center and service split
 - **Type**: Normal Change
 - **Reason**: Operating both stacks through a single launcher obscured which component failed, made service restarts clumsy, and lacked a central script for lifecycle tasks such as updates or rollbacks.

--- a/frontend/src/components/CuratorApplicationDialog.tsx
+++ b/frontend/src/components/CuratorApplicationDialog.tsx
@@ -33,10 +33,6 @@ export const CuratorApplicationDialog = ({
     setLocalError(null);
   }, [isOpen, application?.status]);
 
-  if (!isOpen) {
-    return null;
-  }
-
   const status = application?.status ?? null;
   const submittedAt = application?.createdAt ? formatter.format(new Date(application.createdAt)) : null;
   const decidedAt = application?.decidedAt ? formatter.format(new Date(application.decidedAt)) : null;
@@ -57,6 +53,10 @@ export const CuratorApplicationDialog = ({
     }
     return 'Share your motivation for joining the curator team. Include focus areas, moderation experience, or showcase links.';
   }, [status]);
+
+  if (!isOpen) {
+    return null;
+  }
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- keep the curator application dialog hook order stable by evaluating memoized state before the closed early return
- document the emergency crash fix in the changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab2d9e2a48333b77b05702950fd89