### PR TITLE
Default frontend API base to same origin

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 072 – [Emergency Change] Frontend same-origin API fallback
+- **Type**: Emergency Change
+- **Reason**: After the deployment the frontend defaulted to `http://localhost:4000`, so browsers accessing a remote instance attempted to call the API on the viewer's machine, triggering connection refusals and breaking service status checks.
+- **Change**: Defaulted `VITE_API_URL` to the same-origin token so `/api/*` requests flow through the configured proxy or reverse proxy, and documented how to point the frontend at an alternate API host when required.
+
 ## 071 – [Normal Change] Systemd rollout for maintenance workflow
 - **Type**: Normal Change
 - **Reason**: The PID-based shell launchers required manual babysitting during updates and could leave orphaned processes when deployments switched to the systemd-backed environment.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ VisionSuit is a self-hosted platform for curating AI image galleries, distributi
    export DATABASE_URL="file:./dev.db"
    ```
    The development helper scripts load `.env`, and exporting `DATABASE_URL` keeps standalone Prisma tasks such as `npx prisma migrate reset` from failing on a fresh installation.
+   The frontend now defaults to calling the API on the same origin, so `/api/*` requests automatically reach the backend through the Vite proxy and production reverse proxies. When the frontend and backend are served from different hosts, set `VITE_API_URL` (and optionally `DEV_API_PROXY_TARGET` during development) to point at the external API base URL.
 3. **Apply database migrations**
    ```bash
    npm --prefix backend run prisma:migrate

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,5 +1,5 @@
 const resolveApiBase = () => {
-  const rawValue = import.meta.env.VITE_API_URL ?? 'http://localhost:4000';
+  const rawValue = import.meta.env.VITE_API_URL ?? '@origin';
   const trimmed = rawValue.trim();
 
   const sameOriginTokens = new Set(['', '/', '@origin', 'origin', 'same-origin', 'relative']);


### PR DESCRIPTION
## Summary
- default the frontend API base URL to the same-origin token so remote users hit the backend instead of localhost
- document the deployment note in the README and log the emergency change in the changelog

## Testing
- npm --prefix VisionSuit/frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68dab7bfe6088333bc3307c4fc63cdab