### PR TITLE
Add PostgreSQL migration planning workspace

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 073 – [Normal Change] PostgreSQL migration planning workspace
+- **Type**: Normal Change
+- **Reason**: Preparing for the upcoming move to PostgreSQL requires dedicated planning material and automation stubs so operators can evaluate the cutover approach before implementation begins.
+- **Change**: Added a PostgreSQL migration project plan and placeholder scripts covering target preparation, fresh installs, and production upgrades, and documented the workspace in the README.
+
 ## 072 – [Emergency Change] Frontend same-origin API fallback
 - **Type**: Emergency Change
 - **Reason**: After the deployment the frontend defaulted to `http://localhost:4000`, so browsers accessing a remote instance attempted to call the API on the viewer's machine, triggering connection refusals and breaking service status checks.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ For production deployments, review storage credentials, JWT secrets, GPU agent e
   ```
   The script writes a timestamped copy of the database next to the original file, removes the legacy migration entries from `_prisma_migrations`, and uses `prisma migrate resolve` to register `00000000000000_baseline` so subsequent deploys and `prisma migrate deploy` executions align with the trimmed migration directory.
 
+### PostgreSQL Migration Planning
+
+- **PostgreSQL migration workspace** – Early planning artifacts and placeholder automation for moving from SQLite to a remote PostgreSQL instance now live in `scripts/postgres-migration/`. The directory includes:
+  - `PROJECT_PLAN.md` outlining goals, deliverables, and the development timeline for the migration effort.
+  - `prepare_postgres_target.sh`, `fresh_install_postgres_setup.sh`, and `upgrade_sqlite_to_postgres.sh` placeholder scripts that will orchestrate target validation, fresh installs, and production upgrades once implementation begins.
+- The upgrade script sequence is designed to toggle maintenance mode, back up the SQLite database, import data into PostgreSQL, validate the cutover, and disable maintenance mode after health checks succeed. Future revisions will automate connectivity checks against remote database hosts before the migration starts.
+
 ## Moderation CLI Helpers
 
 - **Approve all flagged assets** – Clear the moderation queue in one sweep after an incident review:

--- a/scripts/postgres-migration/PROJECT_PLAN.md
+++ b/scripts/postgres-migration/PROJECT_PLAN.md
@@ -1,0 +1,45 @@
+# VisionSuit Database Migration Project Plan
+
+## Objective
+Transition VisionSuit deployments from the bundled SQLite database to a dedicated PostgreSQL instance without disrupting production traffic or losing historical data.
+
+## Scope
+- Support **fresh installations** that should immediately provision and migrate to PostgreSQL.
+- Provide an **upgrade path for existing SQLite installations**, including automated backups and validation gates.
+- Ship automation scripts that prepare remote PostgreSQL targets, orchestrate maintenance windows, and allow for fallback to SQLite if needed.
+
+## Constraints & Assumptions
+- Automation must operate in English and target Linux hosts that run the existing maintenance scripts.
+- Operators can provide SSH credentials or DSN details for the remote PostgreSQL server.
+- SQLite remains available as a fallback until cutover verification succeeds.
+- Prisma schema adjustments to support PostgreSQL compatibility will be tracked separately from these orchestration scripts.
+
+## Deliverables
+1. **Target preparation script** that validates connectivity to the remote PostgreSQL service, ensures the database and user exist, and checks TLS requirements.
+2. **Fresh install migration script** that provisions PostgreSQL, applies Prisma migrations against it, and replaces SQLite references in environment files.
+3. **Production upgrade script** that:
+   - Enables maintenance mode and blocks writes.
+   - Exports the existing SQLite database.
+   - Imports data into PostgreSQL using Prisma or a bulk loader.
+   - Runs verification queries and Prisma health checks.
+   - Switches application configuration to PostgreSQL and optionally rolls back if validation fails.
+4. **Runbook** covering manual validation, rollback, and monitoring steps post-cutover.
+
+## High-Level Timeline
+| Week | Milestone |
+| --- | --- |
+| 1 | Finalize Prisma schema compatibility review and document required adjustments. |
+| 2 | Implement PostgreSQL target preparation helper and add CI smoke tests against Postgres. |
+| 3 | Build fresh install automation and validate with clean deployments. |
+| 4 | Deliver production upgrade script, including automated backups and verification hooks. |
+| 5 | Draft and test rollback procedures, finalize documentation, and schedule pilot migrations. |
+
+## Open Questions
+- Should the automation manage database user creation or assume pre-provisioned credentials?
+- How will binary assets stored on disk be handled during migrations that require moving hosts?
+- Do we need blue/green Prisma clients for uninterrupted service during cutover?
+
+## Next Steps
+- Document environment variables required for PostgreSQL (e.g., `DATABASE_URL`, `SHADOW_DATABASE_URL`).
+- Prototype Prisma migration runs against a managed PostgreSQL service to confirm compatibility.
+- Draft detailed step-by-step instructions for both automation scripts to flesh out placeholder sections.

--- a/scripts/postgres-migration/fresh_install_postgres_setup.sh
+++ b/scripts/postgres-migration/fresh_install_postgres_setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Placeholder script for provisioning a new VisionSuit instance directly on PostgreSQL.
+# The final implementation will coordinate Prisma migrations and environment configuration
+# during a clean installation.
+
+POSTGRES_URL="${POSTGRES_URL:-}" 
+if [[ -z "${POSTGRES_URL}" ]]; then
+  echo "[fresh-install] POSTGRES_URL environment variable is required." >&2
+  exit 1
+fi
+
+cat <<'PLAN'
+[fresh-install] Planned workflow (not yet implemented):
+  1. Call ./scripts/postgres-migration/prepare_postgres_target.sh to validate the remote database.
+  2. Generate Prisma client artifacts configured for PostgreSQL.
+  3. Apply prisma migrate deploy against the PostgreSQL connection string.
+  4. Update backend/.env and frontend environment overrides to reference PostgreSQL URLs.
+  5. Run smoke tests to confirm API connectivity before enabling public access.
+PLAN

--- a/scripts/postgres-migration/prepare_postgres_target.sh
+++ b/scripts/postgres-migration/prepare_postgres_target.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Placeholder script for preparing a remote PostgreSQL database host.
+# This helper will eventually validate connectivity, provision databases,
+# and enforce TLS requirements before migrations run.
+
+if [[ $# -lt 1 ]]; then
+  cat <<USAGE
+Usage: $0 <postgres_connection_url>
+
+This placeholder currently only echoes the supplied PostgreSQL connection URL.
+Future revisions will perform the following checks automatically:
+  - Ensure the host is reachable and the PostgreSQL service responds.
+  - Create the target database and user when missing.
+  - Confirm required extensions (e.g., pg_trgm) are installed when Prisma needs them.
+  - Validate SSL/TLS enforcement to avoid plaintext credentials in transit.
+USAGE
+  exit 1
+fi
+
+POSTGRES_URL="$1"
+
+echo "[prepare-postgres] Placeholder validation for target: ${POSTGRES_URL}"
+echo "[prepare-postgres] TODO: Implement connectivity checks and remote provisioning."

--- a/scripts/postgres-migration/upgrade_sqlite_to_postgres.sh
+++ b/scripts/postgres-migration/upgrade_sqlite_to_postgres.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Placeholder script outlining the automated migration process from SQLite to PostgreSQL
+# for existing VisionSuit deployments. The scripted flow will orchestrate a maintenance
+# window, perform backups, migrate data, validate the result, and reopen the platform.
+
+POSTGRES_URL="${POSTGRES_URL:-}"
+SQLITE_PATH="${SQLITE_PATH:-backend/prisma/dev.db}"
+
+if [[ -z "${POSTGRES_URL}" ]]; then
+  echo "[upgrade] POSTGRES_URL environment variable is required." >&2
+  exit 1
+fi
+
+if [[ ! -f "${SQLITE_PATH}" ]]; then
+  echo "[upgrade] SQLite database not found at ${SQLITE_PATH}." >&2
+  exit 1
+fi
+
+cat <<PLAN
+[upgrade] Planned workflow (not yet implemented):
+  Step 1. Enable maintenance mode via maintenance.sh or the admin API to freeze writes.
+  Step 2. Create a timestamped backup copy of ${SQLITE_PATH} and archive it for rollback.
+  Step 3. Export SQLite data and import it into PostgreSQL at ${POSTGRES_URL}.
+          - Use Prisma migrate diff or pgloader to translate schemas.
+          - Preserve Prisma migration history to keep deploys aligned.
+  Step 4. Run automated verification:
+          - prisma db pull && prisma migrate status
+          - Targeted smoke tests that issue read/write checks against PostgreSQL.
+  Step 5. Update environment configuration to point DATABASE_URL at PostgreSQL.
+  Step 6. Restart backend services and confirm health probes pass.
+  Step 7. Disable maintenance mode and monitor logs for anomalies.
+  Step 8. Provide a rollback function that restores the SQLite file and reverts env settings
+          if validation fails.
+PLAN
+
+cat <<'TODO'
+[upgrade] TODO: Implement the following helpers during development:
+  - Automatic invocation of prepare_postgres_target.sh with credentials.
+  - Integrity check comparing row counts between SQLite and PostgreSQL.
+  - Structured logging for each migration phase to assist with audit trails.
+  - Optional dry-run flag that performs all checks without switching production traffic.
+TODO


### PR DESCRIPTION
## Summary
- add a PostgreSQL migration planning folder with a project plan and placeholder automation scripts
- document the new workspace in the README so operators can discover the upcoming migration effort
- record the planning change in the changelog for audit tracking

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dadfdc2df4833392d65cf50e737797