### PR TITLE
Automate SQLite to PostgreSQL upgrade rehearsal

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 074 – [Normal Change] PostgreSQL upgrade automation rehearsal
+- **Type**: Normal Change
+- **Reason**: Operators need a reliable, scriptable rehearsal for the SQLite-to-PostgreSQL cutover so they can validate infra prerequisites, capture backups, and verify data integrity before scheduling downtime.
+- **Change**: Implemented the `upgrade_sqlite_to_postgres.sh` workflow to stop services, capture timestamped SQLite backups, run `pgloader` imports, execute Prisma migrations, verify table row counts, and optionally run post-cutover health checks; documented the automation capabilities in the README.
+
 ## 073 – [Normal Change] PostgreSQL migration planning workspace
 - **Type**: Normal Change
 - **Reason**: Preparing for the upcoming move to PostgreSQL requires dedicated planning material and automation stubs so operators can evaluate the cutover approach before implementation begins.

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ For production deployments, review storage credentials, JWT secrets, GPU agent e
 
 - **PostgreSQL migration workspace** – Early planning artifacts and evolving automation for moving from SQLite to a remote PostgreSQL instance now live in `scripts/postgres-migration/`. The directory includes:
   - `PROJECT_PLAN.md` outlining goals, deliverables, and the development timeline for the migration effort.
-  - `prepare_postgres_target.sh`, which now validates connectivity, optionally creates the target database, enforces TLS policies, and installs required extensions before the cutover.
+  - `prepare_postgres_target.sh`, which validates connectivity, optionally creates the target database, enforces TLS policies, and installs required extensions before the cutover.
   - `fresh_install_postgres_setup.sh` and `upgrade_sqlite_to_postgres.sh`, which call the target preparation helper automatically (unless skipped via environment flags) before continuing with install or upgrade workflows.
-- The upgrade script sequence toggles maintenance mode, backs up the SQLite database, imports data into PostgreSQL, validates the cutover, and disables maintenance mode after health checks succeed. Upcoming revisions will focus on data integrity checks and richer audit logging once the migration flow is fully automated.
+- The upgrade automation now orchestrates the full rehearsal: it can stop services through `maintenance.sh`, take timestamped `.backup` and `.dump` snapshots of the SQLite file under `backups/postgres-migration/`, run `pgloader` to import data, execute Prisma `migrate deploy`/`generate`/`migrate status`, verify table row counts between SQLite and PostgreSQL, and optionally run a custom health check command before resuming traffic. Each phase is toggleable with `UPGRADE_*` environment variables so operators can dry-run the flow or reuse individual steps while testing their infrastructure.
 
 ## Moderation CLI Helpers
 

--- a/scripts/postgres-migration/upgrade_sqlite_to_postgres.sh
+++ b/scripts/postgres-migration/upgrade_sqlite_to_postgres.sh
@@ -1,24 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Placeholder script outlining the automated migration process from SQLite to PostgreSQL
-# for existing VisionSuit deployments. The scripted flow will orchestrate a maintenance
-# window, perform backups, migrate data, validate the result, and reopen the platform.
+# Automate the migration from SQLite to PostgreSQL for existing VisionSuit deployments.
+# The workflow stops application services, backs up the SQLite database, imports data
+# with pgloader, executes Prisma migrations, verifies table row counts, and then
+# restarts the stack. Each phase is controlled through environment variables so
+# operators can dry-run or reuse individual helpers when rehearsing cutovers.
 
 POSTGRES_URL="${POSTGRES_URL:-}"
 SQLITE_PATH="${SQLITE_PATH:-backend/prisma/dev.db}"
 
-if [[ -z "${POSTGRES_URL}" ]]; then
-  echo "[upgrade] POSTGRES_URL environment variable is required." >&2
-  exit 1
-fi
+log() {
+  printf '[upgrade] %s\n' "$1"
+}
 
-if [[ ! -f "${SQLITE_PATH}" ]]; then
-  echo "[upgrade] SQLite database not found at ${SQLITE_PATH}." >&2
+abort() {
+  printf '[upgrade] %s\n' "$1" >&2
   exit 1
-fi
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+}
 
 parse_bool() {
   local value="${1:-}"
@@ -30,55 +29,240 @@ parse_bool() {
       return 1
       ;;
     *)
-      echo "[upgrade] Invalid boolean value: ${value}" >&2
-      exit 1
+      abort "Invalid boolean value: ${value}"
       ;;
   esac
 }
+
+require_command() {
+  local binary="$1"
+  if ! command -v "$binary" >/dev/null 2>&1; then
+    abort "Required command not found in PATH: ${binary}"
+  fi
+}
+
+if [[ -z "${POSTGRES_URL}" ]]; then
+  abort "POSTGRES_URL environment variable is required."
+fi
+
+if [[ ! -f "${SQLITE_PATH}" ]]; then
+  abort "SQLite database not found at ${SQLITE_PATH}."
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 UPGRADE_SKIP_TARGET_PREPARE="${UPGRADE_SKIP_TARGET_PREPARE:-false}"
 UPGRADE_REQUIRED_EXTENSIONS="${UPGRADE_REQUIRED_EXTENSIONS:-pg_trgm,uuid-ossp}"
 UPGRADE_REQUIRE_TLS="${UPGRADE_REQUIRE_TLS:-true}"
 UPGRADE_CREATE_DB="${UPGRADE_CREATE_DB:-false}"
+UPGRADE_DRY_RUN="${UPGRADE_DRY_RUN:-false}"
+UPGRADE_BACKUP_DIR="${UPGRADE_BACKUP_DIR:-${REPO_ROOT}/backups/postgres-migration}"
+UPGRADE_CREATE_SQLITE_DUMP="${UPGRADE_CREATE_SQLITE_DUMP:-true}"
+UPGRADE_STOP_SERVICES="${UPGRADE_STOP_SERVICES:-true}"
+UPGRADE_RESUME_SERVICES="${UPGRADE_RESUME_SERVICES:-true}"
+UPGRADE_PRISMA_PROJECT_DIR="${UPGRADE_PRISMA_PROJECT_DIR:-${REPO_ROOT}/backend}"
+UPGRADE_PRISMA_SCHEMA_PATH="${UPGRADE_PRISMA_SCHEMA_PATH:-}"
+UPGRADE_PRISMA_MIGRATE_DEPLOY="${UPGRADE_PRISMA_MIGRATE_DEPLOY:-true}"
+UPGRADE_PRISMA_GENERATE="${UPGRADE_PRISMA_GENERATE:-true}"
+UPGRADE_PRISMA_MIGRATE_STATUS="${UPGRADE_PRISMA_MIGRATE_STATUS:-true}"
+UPGRADE_VERIFY_ROW_COUNTS="${UPGRADE_VERIFY_ROW_COUNTS:-true}"
+UPGRADE_PGLOADER_BIN="${UPGRADE_PGLOADER_BIN:-pgloader}"
+UPGRADE_PGLOADER_EXTRA_ARGS="${UPGRADE_PGLOADER_EXTRA_ARGS:-}"
+UPGRADE_HEALTHCHECK_CMD="${UPGRADE_HEALTHCHECK_CMD:-}"
 
-if ! parse_bool "$UPGRADE_SKIP_TARGET_PREPARE"; then
+set_bool() {
+  local var_name="$1"
+  local raw_value="$2"
+  if parse_bool "$raw_value"; then
+    printf -v "$var_name" '%s' true
+  else
+    printf -v "$var_name" '%s' false
+  fi
+}
+
+set_bool SKIP_TARGET_PREPARE "$UPGRADE_SKIP_TARGET_PREPARE"
+set_bool REQUIRE_TLS "$UPGRADE_REQUIRE_TLS"
+set_bool CREATE_DB "$UPGRADE_CREATE_DB"
+set_bool DRY_RUN "$UPGRADE_DRY_RUN"
+set_bool CREATE_SQLITE_DUMP "$UPGRADE_CREATE_SQLITE_DUMP"
+set_bool STOP_SERVICES "$UPGRADE_STOP_SERVICES"
+set_bool RESUME_SERVICES "$UPGRADE_RESUME_SERVICES"
+set_bool PRISMA_MIGRATE_DEPLOY "$UPGRADE_PRISMA_MIGRATE_DEPLOY"
+set_bool PRISMA_GENERATE "$UPGRADE_PRISMA_GENERATE"
+set_bool PRISMA_MIGRATE_STATUS "$UPGRADE_PRISMA_MIGRATE_STATUS"
+set_bool VERIFY_ROW_COUNTS "$UPGRADE_VERIFY_ROW_COUNTS"
+
+require_command sqlite3
+require_command psql
+if ! $DRY_RUN; then
+  require_command "$UPGRADE_PGLOADER_BIN"
+fi
+
+MAINTENANCE_ENGAGED=false
+MAINTENANCE_SCRIPT="${UPGRADE_MAINTENANCE_SCRIPT:-${REPO_ROOT}/maintenance.sh}"
+
+cleanup_actions() {
+  local status="$1"
+  if $MAINTENANCE_ENGAGED && $RESUME_SERVICES; then
+    log "Attempting to restart services via ${MAINTENANCE_SCRIPT}."
+    if [[ -x "$MAINTENANCE_SCRIPT" ]]; then
+      if ! "$MAINTENANCE_SCRIPT" start; then
+        printf '[upgrade] Failed to restart services; manual intervention required.\n' >&2
+      else
+        log "Services restarted."
+      fi
+    else
+      printf '[upgrade] Maintenance script %s is not executable; skipped automatic restart.\n' "$MAINTENANCE_SCRIPT" >&2
+    fi
+  fi
+  exit "$status"
+}
+
+trap 'cleanup_actions $?' EXIT
+
+if ! $SKIP_TARGET_PREPARE; then
   declare -a PREPARE_ARGS
-  if parse_bool "$UPGRADE_CREATE_DB"; then
+  if $CREATE_DB; then
     PREPARE_ARGS+=("--create-db")
   fi
   if [[ -n "${UPGRADE_REQUIRED_EXTENSIONS// }" ]]; then
     PREPARE_ARGS+=("--extensions" "$UPGRADE_REQUIRED_EXTENSIONS")
   fi
-  if parse_bool "$UPGRADE_REQUIRE_TLS"; then
+  if $REQUIRE_TLS; then
     PREPARE_ARGS+=("--require-tls")
   fi
-  echo "[upgrade] Running target validation before migration."
-  "${SCRIPT_DIR}/prepare_postgres_target.sh" "${PREPARE_ARGS[@]}" "$POSTGRES_URL"
+  log "Running target validation before migration."
+  if ! "$SCRIPT_DIR/prepare_postgres_target.sh" "${PREPARE_ARGS[@]}" "$POSTGRES_URL"; then
+    abort "PostgreSQL target preparation failed."
+  fi
 else
-  echo "[upgrade] Skipping target validation (UPGRADE_SKIP_TARGET_PREPARE=true)."
+  log "Skipping target validation (UPGRADE_SKIP_TARGET_PREPARE=true)."
 fi
 
-cat <<PLAN
-[upgrade] Planned workflow (not yet implemented):
-  Step 0. Confirm the PostgreSQL target is ready (this script now runs prepare_postgres_target.sh unless skipped).
-  Step 1. Enable maintenance mode via maintenance.sh or the admin API to freeze writes.
-  Step 2. Create a timestamped backup copy of ${SQLITE_PATH} and archive it for rollback.
-  Step 3. Export SQLite data and import it into PostgreSQL at ${POSTGRES_URL}.
-          - Use Prisma migrate diff or pgloader to translate schemas.
-          - Preserve Prisma migration history to keep deploys aligned.
-  Step 4. Run automated verification:
-          - prisma db pull && prisma migrate status
-          - Targeted smoke tests that issue read/write checks against PostgreSQL.
-  Step 5. Update environment configuration to point DATABASE_URL at PostgreSQL.
-  Step 6. Restart backend services and confirm health probes pass.
-  Step 7. Disable maintenance mode and monitor logs for anomalies.
-  Step 8. Provide a rollback function that restores the SQLite file and reverts env settings
-          if validation fails.
-PLAN
+timestamp="$(date -u +%Y%m%d-%H%M%S)"
+sqlite_absolute="$(python3 - <<'PY'
+import pathlib, sys
+print(pathlib.Path(sys.argv[1]).resolve())
+PY
+"$SQLITE_PATH")"
 
-cat <<'TODO'
-[upgrade] TODO: Implement the following helpers during development:
-  - Integrity check comparing row counts between SQLite and PostgreSQL.
-  - Structured logging for each migration phase to assist with audit trails.
-  - Optional dry-run flag that performs all checks without switching production traffic.
-TODO
+backup_base_name="$(basename "$sqlite_absolute").${timestamp}"
+backup_dir="$UPGRADE_BACKUP_DIR"
+backup_sqlite_path="$backup_dir/${backup_base_name}"
+backup_dump_path="${backup_sqlite_path}.sql"
+
+if ! $DRY_RUN; then
+  mkdir -p "$backup_dir"
+  log "Backing up SQLite database to ${backup_sqlite_path}."
+  sqlite3 "$sqlite_absolute" ".backup '$backup_sqlite_path'"
+  if $CREATE_SQLITE_DUMP; then
+    log "Creating SQLite dump at ${backup_dump_path}."
+    sqlite3 "$sqlite_absolute" .dump >"$backup_dump_path"
+  fi
+else
+  log "Dry run enabled – skipping backup generation."
+fi
+
+if $STOP_SERVICES && [[ -x "$MAINTENANCE_SCRIPT" ]]; then
+  log "Stopping services via ${MAINTENANCE_SCRIPT}."
+  if ! "$MAINTENANCE_SCRIPT" stop; then
+    abort "Failed to stop services using ${MAINTENANCE_SCRIPT}."
+  fi
+  MAINTENANCE_ENGAGED=true
+elif $STOP_SERVICES; then
+  log "Maintenance script ${MAINTENANCE_SCRIPT} not executable; skipping service stop."
+fi
+
+if ! $DRY_RUN; then
+  log "Importing SQLite data into PostgreSQL with ${UPGRADE_PGLOADER_BIN}."
+  sqlite_uri="$(python3 - <<'PY'
+import pathlib, sys, urllib.parse
+path = pathlib.Path(sys.argv[1]).resolve()
+print('sqlite:///' + urllib.parse.quote(str(path)))
+PY
+"$sqlite_absolute")"
+  mapfile -t PGLOADER_ARGS < <(python3 - <<'PY'
+import shlex, os
+extra = os.environ.get('UPGRADE_PGLOADER_EXTRA_ARGS', '')
+print('\n'.join(arg for arg in shlex.split(extra)))
+PY
+)
+  "$UPGRADE_PGLOADER_BIN" "${PGLOADER_ARGS[@]}" "$sqlite_uri" "$POSTGRES_URL"
+else
+  log "Dry run enabled – skipping pgloader import."
+fi
+
+prisma_schema_args=()
+if [[ -n "$UPGRADE_PRISMA_SCHEMA_PATH" ]]; then
+  prisma_schema_args=(--schema "$UPGRADE_PRISMA_SCHEMA_PATH")
+fi
+
+if ! $DRY_RUN && $PRISMA_MIGRATE_DEPLOY; then
+  log "Applying Prisma migrations against PostgreSQL."
+  DATABASE_URL="$POSTGRES_URL" npm --prefix "$UPGRADE_PRISMA_PROJECT_DIR" exec -- prisma migrate deploy "${prisma_schema_args[@]}"
+elif $PRISMA_MIGRATE_DEPLOY; then
+  log "Dry run enabled – skipping Prisma migrate deploy."
+fi
+
+if ! $DRY_RUN && $PRISMA_GENERATE; then
+  log "Regenerating Prisma client for PostgreSQL."
+  DATABASE_URL="$POSTGRES_URL" npm --prefix "$UPGRADE_PRISMA_PROJECT_DIR" exec -- prisma generate "${prisma_schema_args[@]}"
+elif $PRISMA_GENERATE; then
+  log "Dry run enabled – skipping Prisma generate."
+fi
+
+if ! $DRY_RUN && $PRISMA_MIGRATE_STATUS; then
+  log "Checking Prisma migration status on PostgreSQL."
+  DATABASE_URL="$POSTGRES_URL" npm --prefix "$UPGRADE_PRISMA_PROJECT_DIR" exec -- prisma migrate status "${prisma_schema_args[@]}"
+elif $PRISMA_MIGRATE_STATUS; then
+  log "Dry run enabled – skipping Prisma migrate status."
+fi
+
+integrity_failed=false
+if ! $DRY_RUN && $VERIFY_ROW_COUNTS; then
+  log "Verifying row counts between SQLite and PostgreSQL."
+  mapfile -t TABLES < <(sqlite3 "$sqlite_absolute" "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;")
+  for table in "${TABLES[@]}"; do
+    [[ -z "$table" ]] && continue
+    sqlite_count=$(sqlite3 "$sqlite_absolute" "SELECT COUNT(*) FROM \"$table\";" || echo "error")
+    if [[ "$sqlite_count" == "error" ]]; then
+      printf '[upgrade] Failed to count rows for table %s in SQLite.\n' "$table" >&2
+      integrity_failed=true
+      continue
+    fi
+    postgres_count=$(psql "$POSTGRES_URL" -X --tuples-only --no-align --set ON_ERROR_STOP=1 -c "SELECT COUNT(*) FROM \"$table\";" 2>/tmp/upgrade_postgres_count.err || echo "error")
+    if [[ "$postgres_count" == "error" ]]; then
+      printf '[upgrade] Failed to count rows for table %s in PostgreSQL.\n' "$table" >&2
+      cat /tmp/upgrade_postgres_count.err >&2 || true
+      integrity_failed=true
+      continue
+    fi
+    if [[ "$sqlite_count" != "$postgres_count" ]]; then
+      printf '[upgrade] Row count mismatch detected for %s (sqlite=%s, postgres=%s).\n' "$table" "$sqlite_count" "$postgres_count" >&2
+      integrity_failed=true
+    else
+      log "Verified ${table}: ${sqlite_count} rows."
+    fi
+  done
+  rm -f /tmp/upgrade_postgres_count.err
+elif $VERIFY_ROW_COUNTS; then
+  log "Dry run enabled – skipping row count verification."
+fi
+
+if $integrity_failed; then
+  abort "Row count verification failed. Review the logs before promoting PostgreSQL."
+fi
+
+if [[ -n "$UPGRADE_HEALTHCHECK_CMD" ]]; then
+  if ! $DRY_RUN; then
+    log "Running health check command: ${UPGRADE_HEALTHCHECK_CMD}"
+    if ! eval "$UPGRADE_HEALTHCHECK_CMD"; then
+      abort "Health check command failed."
+    fi
+  else
+    log "Dry run enabled – skipping health check command."
+  fi
+fi
+
+log "SQLite to PostgreSQL migration completed successfully."


### PR DESCRIPTION
## Summary
- expand `upgrade_sqlite_to_postgres.sh` into a full automation flow with backups, pgloader import, Prisma checks, row-count verification, and optional health checks
- document the new migration rehearsal capabilities and toggles in the README
- record the automation milestone in the changelog

## Testing
- bash -n scripts/postgres-migration/upgrade_sqlite_to_postgres.sh

------
https://chatgpt.com/codex/tasks/task_e_68dae816e098833387931984f97dac6f