### PR TITLE
Automate PostgreSQL migration asset packaging

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 077 – [Normal Change] PostgreSQL migration automation bundle
+- **Type**: Normal Change
+- **Reason**: Operators asked for a nearly hands-free upgrade path so the remote helper, SSH credentials, and migration workflow stay in sync without manual parameter juggling.
+- **Change**: Taught `upgrade_sqlite_to_postgres.sh` to mint a dedicated SSH key pair and `visionsuit_migration_config.env`, added an `UPGRADE_AUTOMATION_ONLY` mode that exits after generating those assets, updated `remote_prepare_helper.sh` to auto-load the config and copy it to the deployment user, and refreshed the README with the streamlined rehearsal steps.
+
 ## 076 – [Normal Change] Remote preparation key export and guide
 - **Type**: Normal Change
 - **Reason**: Operators needed key-based root access, credential exports, and a dedicated playbook before VisionSuit could safely connect to the PostgreSQL target without managing database passwords.


### PR DESCRIPTION
## Summary
- generate a reusable SSH key pair and `visionsuit_migration_config.env` during the upgrade workflow, including an automation-only mode for producing the bundle on demand
- teach the remote preparation helper to auto-load the generated config, copy it to the deployment user, and document the stored automation assets
- document the streamlined rehearsal sequence in the README and log the change in the changelog

## Testing
- bash -n scripts/postgres-migration/remote_prepare_helper.sh
- bash -n scripts/postgres-migration/upgrade_sqlite_to_postgres.sh

------
https://chatgpt.com/codex/tasks/task_e_68daf42dc17c83339e6d5df12f8dbc30