### PR TITLE
Update PostgreSQL preparation guide for automation bundle

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 078 – [Normal Change] PostgreSQL preparation guide automation refresh
+- **Type**: Normal Change
+- **Reason**: The new automation bundle generates SSH credentials and configuration defaults, so the preparation playbook needed to show operators how to leverage the scripted flow instead of manually passing flags.
+- **Change**: Rewrote `docs/postgres-migration-preparation.md` to start with the automation-only run that mints the SSH key pair and config, documented copying the bundle to the remote host with `remote_prepare_helper.sh`, and clarified how the helper now persists the summary and configuration for future runs.
+
 ## 077 – [Normal Change] PostgreSQL migration automation bundle
 - **Type**: Normal Change
 - **Reason**: Operators asked for a nearly hands-free upgrade path so the remote helper, SSH credentials, and migration workflow stay in sync without manual parameter juggling.

--- a/docs/postgres-migration-preparation.md
+++ b/docs/postgres-migration-preparation.md
@@ -1,50 +1,64 @@
 # PostgreSQL Target Preparation Guide
 
-This guide walks operators through the preparation workflow for migrating VisionSuit from SQLite to a managed PostgreSQL host. Follow the steps below in order to guarantee that remote access, PostgreSQL roles, and compatibility checks are in place before running the migration orchestrators.
+This guide describes the automated preparation workflow for migrating VisionSuit from SQLite to a managed PostgreSQL host. The automation bundle now ships the dedicated SSH credentials and configuration that the remote helper consumes, so operators only need to copy a handful of files and execute the scripted steps below.
 
-## 1. Bootstrap the remote host
+## 1. Mint the automation bundle on the VisionSuit host
 
-Run `remote_prepare_helper.sh` on the PostgreSQL target (over SSH or after copying the script to the host):
+Run the upgrade orchestrator in automation-only mode to generate the SSH key pair and the configuration file consumed by the remote helper:
 
 ```bash
-sudo ./scripts/postgres-migration/remote_prepare_helper.sh \
-  --unix-user visionsuit \
-  --pg-role visionsuit \
-  --pg-createdb \
-  --pg-database visionsuit \
-  --ssh-pubkey "$(cat ~/.ssh/visionsuit.pub)"
+POSTGRES_URL="postgres://visionsuit_migrate@db.internal:5432/visionsuit?sslmode=require" \
+  SQLITE_PATH="backend/prisma/dev.db" \
+  UPGRADE_AUTOMATION_ONLY=true \
+  ./scripts/postgres-migration/upgrade_sqlite_to_postgres.sh
 ```
 
-The helper performs three critical tasks:
+The helper writes three assets under `scripts/postgres-migration/generated/`:
 
-1. **Provision SSH access** – It creates or updates the UNIX account, installs the provided public key for that user, and grants the same key root login rights. The script records the access details—including the exported public key—in `~/visionsuit_remote_access.txt` so automation on the VisionSuit server can reuse them without guesswork.
-2. **Capture the access summary** – Inspect the text file on the remote host to confirm the hostname, SSH fingerprint, and role provisioning status:
-   ```bash
-   sudo cat ~visionsuit/visionsuit_remote_access.txt
-   ```
-   Share the matching private key with the VisionSuit server so it can authenticate as the deployment user (and escalate to root) via SSH.
-3. **Create the PostgreSQL role** – The helper ensures the specified role exists with passwordless `LOGIN` privileges and optional `CREATEDB` rights. Configure `pg_hba.conf` to authorise the VisionSuit server’s host or SSH tunnel for the role.
+- `visionsuit_migration` and `visionsuit_migration.pub` – the private/public SSH key pair dedicated to remote automation.
+- `visionsuit_migration_config.env` – the parameter file that declares the remote UNIX user, sudo flag, PostgreSQL role, database grants, and the exported public key.
 
-## 2. Validate tooling and remote compatibility
+Regenerate the bundle any time you need to rotate credentials by re-running the command above. You can override usernames, roles, and filenames through the `UPGRADE_REMOTE_*` environment variables before invoking the helper.
 
-After the remote host is ready, run the local sanity validator from the repository root. Provide the Prisma project path, the SSH destination, and the remote PostgreSQL URL that the helper confirmed:
+## 2. Bootstrap the remote host with the helper
+
+Copy the remote helper and generated configuration to the PostgreSQL target and execute it with elevated privileges:
+
+```bash
+scp scripts/postgres-migration/remote_prepare_helper.sh \
+    scripts/postgres-migration/generated/visionsuit_migration_config.env \
+    admin@db.internal:/tmp/
+ssh admin@db.internal 'sudo bash /tmp/remote_prepare_helper.sh --config /tmp/visionsuit_migration_config.env'
+```
+
+When the configuration file sits next to the script you can omit `--config`; the helper automatically loads `visionsuit_migration_config.env` from the current directory. During execution it will:
+
+1. **Provision SSH access** – Create or update the UNIX deployment account, install the supplied public key for both the user and root, and grant optional sudo access based on the automation bundle.
+2. **Capture the access summary** – Write `~/visionsuit_remote_access.txt` that records the hostname, SSH fingerprint, and key material. Review the file and store the matching private key from the automation bundle on the VisionSuit server.
+3. **Create the PostgreSQL role** – Ensure the configured PostgreSQL role exists with passwordless `LOGIN` privileges, optional `CREATEDB`, and database grants when a name is provided.
+4. **Persist automation defaults** – Copy the used `visionsuit_migration_config.env` into the deployment user’s home directory so future runs reuse the same parameters without re-supplying flags.
+
+## 3. Validate local tooling and remote compatibility
+
+After the remote host is ready, run the local sanity validator from the repository root. Provide the Prisma project path, the SSH destination, the generated private key, and the PostgreSQL URL confirmed by the helper:
 
 ```bash
 ./scripts/postgres-migration/sanity_check.sh \
   --prisma-project ./backend \
-  --postgres-url "postgres://visionsuit@db.internal:5432/visionsuit?sslmode=require" \
-  --ssh-target visionsuit@db.internal \
+  --postgres-url "postgres://visionsuit_migrate@db.internal:5432/visionsuit?sslmode=require" \
+  --ssh-target visionsuit-migrator@db.internal \
+  --ssh-identity scripts/postgres-migration/generated/visionsuit_migration \
   --require-extensions pg_trgm,uuid-ossp
 ```
 
-The script verifies local Prisma dependencies, validates the remote PostgreSQL version, checks extension availability, and confirms connectivity over SSH.
+The script verifies local Prisma dependencies, validates the remote PostgreSQL version, checks extension availability, and confirms connectivity over SSH using the automation-generated credentials.
 
-## 3. Prepare the database and run rehearsals
+## 4. Prepare the database and run rehearsals
 
 With access validated, continue with the orchestration scripts:
 
 - `prepare_postgres_target.sh` – Creates the target database when missing, enforces TLS requirements, and installs required extensions.
 - `fresh_install_postgres_setup.sh` – Provisions a clean PostgreSQL environment and deploys the VisionSuit schema for new installs.
-- `upgrade_sqlite_to_postgres.sh` – Automates the SQLite-to-PostgreSQL rehearsal, including backups, `pgloader` imports, Prisma migrations, and data validation.
+- `upgrade_sqlite_to_postgres.sh` – Automates the SQLite-to-PostgreSQL rehearsal, including backups, `pgloader` imports, Prisma migrations, and data validation. It automatically reuses the automation bundle to refresh SSH keys or defaults when needed.
 
 Each orchestrator accepts environment toggles to skip phases or reuse existing resources. Review the script headers for the full list of options before running production migrations.


### PR DESCRIPTION
## Summary
- refresh the PostgreSQL preparation guide to highlight the automation-only bundle workflow
- explain how to copy the generated config to the remote host and what the helper now persists
- record the documentation refresh in the changelog

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daf874d4b08333be1736c3f841c1e2