### PR TITLE
Fix PostgreSQL DO block quoting in postgress prepare script

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1637,3 +1637,8 @@
 - **Type**: Standard Change
 - **Reason**: Production cutovers from SQLite to PostgreSQL require an auditable, tightly controlled workflow so operators can avoid data loss during the transition.
 - **Changes**: Added dedicated automation for each migration phase (`postgress-prepare.sh`, `preflight.sh`, `migration.sh`, and `prisma-switch.sh`), rewrote the README and runbook to document the six-step production process, and ensured environment overrides plus service restarts are sourced from the generated `.env-migration` bundle.
+
+## 251 – [Fix] PostgreSQL prepare DO block quoting
+- **Type**: Normal Change
+- **Reason**: The `postgress-prepare.sh` helper substituted the shell process ID into `DO $$` blocks, causing PostgreSQL to reject the automation with `syntax error at or near "38371"`.
+- **Changes**: Switched the script’s here-documents to single-quote mode so `$` is preserved for PostgreSQL, keeping the DO blocks intact during role and database provisioning.

--- a/scripts/postgres-migration/postgress-prepare.sh
+++ b/scripts/postgres-migration/postgress-prepare.sh
@@ -201,7 +201,7 @@ else
   POSTGRES_SUPER="$(getent passwd | awk -F: '$1 ~ /postgres/ {print $1; exit}')"
 fi
 
-create_role_sql=$(cat <<SQL
+create_role_sql=$(cat <<'SQL'
 DO $$
 BEGIN
    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$DB_USER') THEN
@@ -214,7 +214,7 @@ SQL
 
 sudo -u "$POSTGRES_SUPER" psql -v ON_ERROR_STOP=1 -p "$DB_PORT" -c "$create_role_sql"
 
-create_db_sql=$(cat <<SQL
+create_db_sql=$(cat <<'SQL'
 DO $$
 BEGIN
    IF NOT EXISTS (SELECT FROM pg_database WHERE datname = '$DB_NAME') THEN


### PR DESCRIPTION
## Summary
- prevent shell expansion from corrupting the DO $$ blocks in postgress-prepare.sh by using single-quoted here-documents
- document the regression and its fix in ChangeLog entry 251

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc11d10ddc8333af4c0f48a6d60d65