### PR TITLE
Fix preflight SSH tunnel PID capture

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1657,3 +1657,8 @@
 - **Type**: Normal Change
 - **Reason**: The `postgress-prepare.sh` helper substituted the shell process ID into `DO $$` blocks, causing PostgreSQL to reject the automation with `syntax error at or near "38371"`.
 - **Changes**: Switched the script’s here-documents to single-quote mode so `$` is preserved for PostgreSQL, keeping the DO blocks intact during role and database provisioning.
+
+## 252 – [Fix] Preflight SSH tunnel PID capture
+- **Type**: Normal Change
+- **Reason**: The PostgreSQL migration preflight stopped before writing the `.env-migration` bundle because it referenced the background PID placeholder `$!` without actually launching the tunnel as a background job.
+- **Changes**: Started the SSH tunnel with an explicit background invocation so the script records the tunnel PID safely while preserving the cleanup trap and connection validation flow.

--- a/scripts/postgres-migration/preflight.sh
+++ b/scripts/postgres-migration/preflight.sh
@@ -194,7 +194,7 @@ PY
 fi
 
 SSH_CMD=(ssh -i "$SSH_KEY_PATH" -p "$SSH_PORT" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
-"${SSH_CMD[@]}" -fN -L "${TUNNEL_PORT}:${POSTGRES_INTERNAL_HOST}:${POSTGRES_PORT}" "${SSH_USER}@${SSH_HOST}"
+"${SSH_CMD[@]}" -N -L "${TUNNEL_PORT}:${POSTGRES_INTERNAL_HOST}:${POSTGRES_PORT}" "${SSH_USER}@${SSH_HOST}" &
 SSH_TUNNEL_PID=$!
 trap cleanup EXIT
 sleep 1


### PR DESCRIPTION
## Summary
- start the PostgreSQL migration preflight SSH tunnel in the background so the PID is captured for cleanup
- record the fix in the changelog for traceability

## Testing
- not run (not required for this change)


------
https://chatgpt.com/codex/tasks/task_e_68dfe178a9508333b6f5aa97c054140a