### PR TITLE
Fix preflight psql role check to use boolean exists

### DIFF
--- a/ChangeLog/changelog.md
+++ b/ChangeLog/changelog.md
@@ -1,3 +1,8 @@
+## 088 – [Normal Change] Boolean-aware PostgreSQL role check in preflight
+- **Type**: Normal Change
+- **Reason**: `psql` emitted `unrecognized value "1 = 0" for "\if expression"` during role provisioning, cluttering the preflight log even though the command continued.
+- **Change**: Switched the role lookup to `SELECT EXISTS` so `\if` receives the native boolean flag and inverted the branching to keep the alter/create behaviour intact without triggering warnings.
+
 ## 087 – [Emergency Change] Preflight auto-provisions PostgreSQL role
 - **Type**: Emergency Change
 - **Reason**: Migration rehearsals aborted with `password authentication failed` when the target role was missing or its password no longer matched the exported bundle, leaving the cutover blocked before any data moved.

--- a/scripts/postgres-migration/preflight.sh
+++ b/scripts/postgres-migration/preflight.sh
@@ -314,11 +314,11 @@ if ! "${SSH_CMD[@]}" \
 set -euo pipefail
 sudo -u "$SUPER" psql -v ON_ERROR_STOP=1 -p "$PORT" -d postgres -v role="$ROLE" -v pwd="$PASSWORD" <<'SQL'
 \set QUIET 1
-SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'role') THEN 1 ELSE 0 END AS role_exists \gset
-\if :role_exists = 0
-  SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'role', :'pwd') \gexec
-\else
+SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'role') AS role_exists \gset
+\if :role_exists
   SELECT format('ALTER ROLE %I WITH LOGIN PASSWORD %L', :'role', :'pwd') \gexec
+\else
+  SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'role', :'pwd') \gexec
 \endif
 \unset QUIET
 SQL


### PR DESCRIPTION
## Summary
- update the PostgreSQL role provisioning block in `preflight.sh` to rely on `SELECT EXISTS` and boolean-aware `\if` branching
- document the log cleanup in the changelog

## Testing
- `sudo -u postgres psql -v ON_ERROR_STOP=1 -p 5432 -d postgres -v role="visionsuit_preflight_test" -v pwd="example-secret" <<'SQL' ... SQL`


------
https://chatgpt.com/codex/tasks/task_e_68e00526376c833383a0705aa89a06d9